### PR TITLE
docs: VNN-COMP 2026 readiness + 2025 competitive analysis + scoring strategy

### DIFF
--- a/VNNCOMP2025_RESULTS_ANALYSIS.md
+++ b/VNNCOMP2025_RESULTS_ANALYSIS.md
@@ -1,0 +1,56 @@
+# VNN-COMP 2025 results — competitive analysis for NNV (where we lose, where to gain)
+
+*Hard numbers from the official results repo (github.com/VNN-COMP/vnncomp2025_results,
+SCORING-SMALL-TOL/latex), 2026-06-11. This is the empirical basis for
+[`VNNCOMP2026_STRATEGY.md`](VNNCOMP2026_STRATEGY.md). The narrative report is arXiv:2512.19007.*
+
+## Final 2025 leaderboard (overall score) — NNV was 6th of 7
+
+| # | Tool | Score | Method (short) |
+|---|------|------:|----|
+| 1 | α-β-CROWN | **1600.0** | GPU linear-bound propagation (CROWN) + branch-and-bound (β-CROWN / GCP-CROWN) |
+| 2 | NeuralSAT | 1360.1 | GPU; DPLL(T) / abstraction + clause learning |
+| 3 | PyRAT | 1218.5 | abstract interpretation (zonotope/polytope), CPU |
+| 4 | **CORA** | 954.6 | **MATLAB** zonotope/polynomial-zonotope reachability |
+| 5 | nnenum | 740.8 | star/zonotope, CPU, ReLU case-splitting |
+| 6 | **NNV** | **697.3** | **MATLAB** star/ImageStar/zono/abs-dom reachability |
+| 7 | SobolBox | 529.0 | sampling/Sobol |
+
+**The gap is not "we're MATLAB/CPU."** CORA (954.6) and nnenum (740.8) use the *same* family of
+reachability tech as NNV and beat it. The gap is **SAT-finding, penalty leakage, and speed** — all fixable.
+
+## Diagnostic tables (the why)
+
+| Metric | α-β-CROWN | NeuralSAT | PyRAT | CORA | nnenum | **NNV** | SobolBox |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Benchmarks participated | 16 | 16 | 15 | 14 | 11 | **15** | 9 |
+| Instances verified (total) | 2575 | 2425 | 2090 | 1854 | 1596 | **1082** | 1057 |
+| **SAT found** | 1082 | 1055 | 1018 | 946 | 786 | **354** | 317 |
+| UNSAT proved | 1493 | 1370 | 1072 | 908 | 810 | **728** | 740 |
+| **Incorrect / missing-CE** | 0 | 17 | 2 | 20 | 0 | **19** | 437 |
+| Startup overhead (s) | 6.0 | 5.9 | 6.0 | 10.9 | 0.9 | **14.2** | 2.7 |
+
+## The four NNV-specific takeaways (ranked by score impact)
+
+1. **🔴 SAT-finding is the #1 weakness — 354 vs ~1000.** NNV finds **3× fewer counterexamples** than the
+   leaders. Its runner does only ~100–500 *random* samples (`falsify_single`/`create_random_examples`),
+   while the field uses **gradient/PGD adversarial attacks**. SAT cases are CHEAP points (no reachability
+   needed) — closing even half this gap is a large, low-cost score gain. **→ add a PGD/gradient
+   falsifier** (autodiff through the `dlnetwork` toward the unsafe `HalfSpace`), multi-start, run it FIRST.
+2. **🔴 Penalty leakage — 19 incorrect / missing-CE.** NNV "incorrect" is almost certainly **invalid or
+   missing counterexample witnesses** (claimed SAT but the written witness didn't replay/validate), not
+   wrong reachability — matching the runner's own note ("penalties last year… wrong counterexample
+   writing?"). Each costs heavily. **→ validate every SAT witness by replaying it through the network
+   (onnxruntime/`evaluate`) before emitting `sat`; fix the needReshape/flatten-order witness encoding** —
+   never emit `sat` without a confirmed counterexample.
+3. **🔴 Slowest startup (14.2 s).** `startup_nnv` + path/`javaaddpath`/dependency-check overhead is the
+   worst in the field; on short-timeout instances this is pure lost budget. **→ a lean
+   `prepare_instance.sh`/`run_instance.sh` path that does the heavy setup ONCE (install phase), caches a
+   warmed MATLAB/NNV state, and trims per-instance startup.**
+4. **🟠 UNSAT (proving) is closest to the pack (728) but still trails 2×.** Reachability proving is NNV's
+   relative strength; the leaders win via **GPU bounds + branch-and-bound refinement** (prove the easy part
+   with cheap bounds, split only where needed) rather than one expensive pass. **→ cheap-to-precise
+   abstraction ladder + input/ReLU splitting refinement; explore GPU bound propagation.**
+
+**Coverage (15/16 benchmarks) is already competitive — do NOT over-invest in breadth; invest in SAT-finding,
+witness validity, and speed.**

--- a/VNNCOMP2026_READINESS.md
+++ b/VNNCOMP2026_READINESS.md
@@ -1,0 +1,91 @@
+# NNV — VNN-COMP 2026 Readiness Plan
+
+*Forward plan for NNV's VNN-COMP 2026 entry. Sourced from a deep `gh`/web sweep of the VNN-COMP 2026
+governance repo, the 2026 benchmarks repo, and the VNN-LIB 2.0 spec (2026-06-11). Companion to the 2025
+status in [`VNNCOMP2025_STATUS.md`](VNNCOMP2025_STATUS.md).*
+
+## TL;DR — and the hard deadline
+
+- **VNN-COMP 2026** is July 24–25, 2026 in Lisbon (SAIV @ FLoC). **🔴 Tool submission closes June 30, 2026
+  AoE** — a hard deadline. NNV is among the voted-in tools.
+- **The regular track (24 benchmarks) is ALL VNN-LIB 1.0** → reachable with NNV's **existing**
+  `load_vnnlib.m` parser. **No VNN-LIB 2.0 parser is strictly required to score the regular track.**
+- **VNN-LIB 2.0** is the big new capability: **4 extended-track benchmarks are 2.0-only**
+  (`adaptive_cruise_control_non_linear_2026`, `isomorphic_acasxu_2026`, `monotonic_acasxu_2026`,
+  `smart_turn_multimodal_2026`). 2.0 adds `declare-network` (multi-net), `declare-hidden` (intermediate-
+  tensor constraints), multi-input/output, `X[i,j]` tensor indexing, a type system, `equal-to`/
+  `isomorphic-to`, nested `and`/`or` (DNF query trees), a `(vnnlib-version 2.0)` header, and `.vnnlib.gz`
+  compression. Spec: arXiv:2605.07451 (released 2025-12-15); Python `vnnlib` pip v1.0.2 parses it.
+- **Scoring** (issue #2 / rules.md): correct = +10, **incorrect = −150** (so an unsound verdict is
+  catastrophic — NNV's sound-by-refusal posture is exactly right), timeout/error/unknown = 0. SAT needs a
+  witness (line 2: `((VAR val) …)`) replayable through onnxruntime within 1e-3 rel / 1e-4 abs.
+
+## Benchmark delta vs 2025
+
+- **Regular track (24, VNN-LIB 1.0):** the 2025 set NNV already handles, plus refreshed/new ones —
+  `acasxu_2023`, `cersyve`, `cgan2026`, **`challenging_certified_training_2026` (NEW)**, `cifar100_2024`,
+  `collins_rul_cnn_2022`, `cora_2024`, `dist_shift_2023`, `linearizenn_2024`, `lsnc_relu`, `malbeware`,
+  `metaroom_2023`, `ml4acopf_2024`, `nn4sys`, **`relusplitter_2026`**, `safenlp_2024`, `sat_relu`,
+  **`soundnessbench_2026`**, `tinyimagenet_2024`, `tllverifybench_2023`, `traffic_signs_recognition_2023`,
+  `vggnet16_2022`, `vit_2023`, `yolo_2023`. Bot re-pushed ONNX/csv June 4–10, so **re-validate all against
+  the latest repo**.
+- **Extended track (6):** `cctsdb_yolo_2023` + `collins_aerospace_benchmark` (1.0; NNV already fail-louds
+  these soundly), and the **4 VNN-LIB-2.0-only** new ones above.
+- **6 new for 2026:** `adaptive_cruise_control_non_linear_2026` (2.0), `cersyve` (control: cartpole/double-
+  integrator/lane-keep/pendulum/pointmass), `challenging_certified_training_2026`, `isomorphic_acasxu_2026`
+  (2.0, network-equivalence), `monotonic_acasxu_2026` (2.0), `smart_turn_multimodal_2026` (2.0, vision+control).
+- Known repo issues to watch (vnncomp2026_benchmarks): #5 1.0 files in 2.0 folders, #4 wrong ONNX paths in
+  `monotonic_acasxu` instances.csv, #2 cgan_2026 version ambiguity.
+
+## VNN-LIB 2.0 — what `load_vnnlib.m` needs (for the extended track)
+
+NNV's `load_vnnlib.m` is an S-expression parser (keeps working for all 1.0). To add 2.0:
+1. **Version dispatch:** read `(vnnlib-version 1.0|2.0)` header; branch parsing. Add **`.vnnlib.gz`
+   decompression** (gunzip on load) — 2026 ships specs gzipped.
+2. **`declare-input/output/hidden` + types + shapes:** parse named, typed (`float32`…), shaped tensors;
+   replace the implicit single `X`/`Y` with named multi-input/output maps.
+3. **Tensor indexing `X[i,j,k]`** (vs 1.0 `X_i_j_k`): map multi-dim subscripts to NNV's linear/predicate
+   indices.
+4. **`declare-hidden`:** constrain an intermediate ONNX **node** output by name — needs NNV to expose
+   named intermediate reach sets (non-trivial; biggest lift, used by the attention/encoder 2.0 benchmarks).
+5. **Nested `and`/`or` (DNF query trees):** build full disjunctive `HalfSpace` sets (1.0 had limited
+   disjunction).
+6. **`declare-network` / `equal-to` / `isomorphic-to`:** multi-network queries (teacher-student,
+   ACAS-equivalence). For the isomorphic/monotonic ACAS benchmarks, parse + represent two networks.
+- **Shortcut:** the Python `vnnlib` pip package (v1.0.2) already parses 2.0 — consider a thin Python→`.mat`
+  bridge (like the existing `onnx2nnv_python` importer) that emits a 1.0-style bounds/spec `.mat` NNV can
+  consume, rather than reimplementing the full 2.0 grammar in MATLAB by June 30.
+
+## Tool submission (rules.md)
+
+- Three bash scripts: **`install_tool.sh`** (once: deps/licenses), **`prepare_instance.sh`** (version,
+  benchmark, onnx, vnnlib; ≤10 min; no analysis), **`run_instance.sh`** (…+ results path + timeout s;
+  writes a single word: `sat`/`unsat`/`unknown`/`timeout`/`error`, + SAT witness). Submit via the TUM
+  repeatability site; start unofficial dry-runs NOW to surface install/ONNX errors early.
+- **Platform (pick one):** recommend **`m5.16xlarge` CPU** (64 vCPU, 256 GB) — NNV is CPU/LP/star-based and
+  the large ViT/VGG/TinyImageNet nets need RAM the GPU box (61 GB) lacks.
+
+## Prioritized NNV action list (deadline-driven)
+
+1. **🔴 NOW — submission harness + dry run.** Write `install/prepare/run_instance.sh` around the existing
+   `run_vnncomp_instance` path; verify the SAT **witness format** + the dual CE tolerance (1e-3/1e-4);
+   start unofficial dry-runs on the TUM site. (Biggest schedule risk is install/format, not verification.)
+2. **🔴 Regular-track refresh (24, VNN-LIB 1.0).** Re-validate the 13 already-wired benchmarks against the
+   June ONNX/csv refresh, and finish loaders for `cgan2026`, `relusplitter_2026`,
+   `challenging_certified_training_2026`, `cersyve`, `soundnessbench_2026`. Carry over the 2025 wins
+   (fast-method/no-exact-star for the compute-bound nets; manifest path for import-gap nets).
+2b. **🟠 Run the full cloud sweep** (`.github/workflows/vnncomp-sweep.yml`, now defaulting to the official
+   repo) at a realistic timeout to get the real regular-track scorecard before June 30.
+3. **🟡 VNN-LIB 2.0 support (extended track).** Add `.vnnlib.gz` + version dispatch + named typed
+   multi-IO + tensor indexing to `load_vnnlib.m` — OR a Python `vnnlib`→`.mat` bridge (faster path). Defer
+   `declare-hidden` (intermediate constraints) and multi-network (`isomorphic/monotonic acasxu`) unless
+   time allows; these are the deepest lifts.
+4. **🟢 −150 penalty discipline.** The catastrophic-incorrect rule makes NNV's "never certify
+   not-robust/unsafe from an over-approximation" gate a competitive *advantage* — keep every reach
+   sound-or-refuse, and make sure SAT comes only from validated falsification witnesses.
+
+## What's unchanged / reusable from the 2025 work
+
+The fast-method runner (no exact-star for compute-bound cats), the manifest (Python-importer) path for
+import-gap nets, the soundness gate ([42]), and the cloud sweep workflow all carry directly into 2026 — the
+regular track is largely the 2025 pipeline re-pointed at `vnncomp2026_benchmarks`.

--- a/VNNCOMP2026_READINESS.md
+++ b/VNNCOMP2026_READINESS.md
@@ -15,7 +15,7 @@ status in [`VNNCOMP2025_STATUS.md`](VNNCOMP2025_STATUS.md).*
   `smart_turn_multimodal_2026`). 2.0 adds `declare-network` (multi-net), `declare-hidden` (intermediate-
   tensor constraints), multi-input/output, `X[i,j]` tensor indexing, a type system, `equal-to`/
   `isomorphic-to`, nested `and`/`or` (DNF query trees), a `(vnnlib-version 2.0)` header, and `.vnnlib.gz`
-  compression. Spec: arXiv:2605.07451 (released 2025-12-15); Python `vnnlib` pip v1.0.2 parses it.
+  compression. Spec: vnnlib.org + arXiv:2605.07451; Python `vnnlib` pip v1.0.2 parses 2.0 (incl. `.vnnlib.gz`).
 - **Scoring** (issue #2 / rules.md): correct = +10, **incorrect = −150** (so an unsound verdict is
   catastrophic — NNV's sound-by-refusal posture is exactly right), timeout/error/unknown = 0. SAT needs a
   witness (line 2: `((VAR val) …)`) replayable through onnxruntime within 1e-3 rel / 1e-4 abs.
@@ -35,7 +35,7 @@ status in [`VNNCOMP2025_STATUS.md`](VNNCOMP2025_STATUS.md).*
   integrator/lane-keep/pendulum/pointmass), `challenging_certified_training_2026`, `isomorphic_acasxu_2026`
   (2.0, network-equivalence), `monotonic_acasxu_2026` (2.0), `smart_turn_multimodal_2026` (2.0, vision+control).
 - Known repo issues to watch (vnncomp2026_benchmarks): #5 1.0 files in 2.0 folders, #4 wrong ONNX paths in
-  `monotonic_acasxu` instances.csv, #2 cgan_2026 version ambiguity.
+  `monotonic_acasxu` instances.csv, #2 `cgan2026` version ambiguity (repo folder may appear as `cgan_2026`).
 
 ## VNN-LIB 2.0 — what `load_vnnlib.m` needs (for the extended track)
 

--- a/VNNCOMP2026_STRATEGY.md
+++ b/VNNCOMP2026_STRATEGY.md
@@ -59,7 +59,7 @@ NNV's `falsify_single` does only ~100–500 *random* samples, no gradients. Add 
 - **Per-benchmark-class tuning** (`NNV_NRAND_FALSIFY` + PGD steps): small FC (ACAS/safenlp) — few samples,
   fast PGD; large images (cifar100/tinyimagenet/vgg) — many samples, more PGD steps.
 - **Run falsification FIRST and in parallel with reach**, not just as a 0.5 s pre-pass.
-- *Expected:* the literature + the 354-vs-1000 gap suggest PGD roughly 2–3×'s SAT yield — the biggest single
+- *Expected:* the literature + the 354-vs-1000 gap suggest PGD roughly 2–3× the SAT yield — the biggest single
   point gain available, at modest effort.
 
 ## Pillar 2 — Validity & soundness (drive the 19 penalties → 0)

--- a/VNNCOMP2026_STRATEGY.md
+++ b/VNNCOMP2026_STRATEGY.md
@@ -1,0 +1,142 @@
+# NNV — VNN-COMP 2026 Scoring-Maximization Strategy
+
+*How NNV moves up from 6th/7 (697.3 pts, 2025). Grounded in the hard 2025 scoreboard
+([`VNNCOMP2025_RESULTS_ANALYSIS.md`](VNNCOMP2025_RESULTS_ANALYSIS.md)), the 2026 rules, the 2025 report
+(arXiv:2512.19007), and deep research on the winning tools' methods. Companion:
+[`VNNCOMP2026_READINESS.md`](VNNCOMP2026_READINESS.md) (benchmarks/vnnlib2/deadline). **Deadline: tool
+submission June 30, 2026 AoE.***
+
+## The score math → what actually moves the needle
+
+Per benchmark: **correct sat/unsat = +10, INCORRECT = −150, timeout/error/unknown = 0**, no time bonus.
+Benchmark score = % of the max tool's score on that benchmark; overall = sum of per-benchmark %s; ties → total
+runtime. So the levers, in order of leverage **for NNV given the 2025 data**:
+
+1. **Find more SAT** — NNV got **354 SAT vs ~1000** for the leaders. SAT instances are *cheap points* (no
+   reachability needed), and NNV's falsifier is the weakest in the field (random sampling only). **This is
+   the single highest-ROI fix.**
+2. **Stop leaking −150** — NNV had **19 incorrect/missing-CE** (invalid SAT witnesses). At a 16× penalty, a
+   handful of these erase dozens of correct answers. **Validate every witness before emitting `sat`.**
+3. **Be faster** — NNV had the **worst startup (14.2 s)** and times out on big nets; more instances solved
+   within timeout = higher %, and runtime is the tiebreak.
+4. **Prove more UNSAT** — NNV's 728 is its relative strength but still ~2× behind; close it with
+   cheap-bounds + refinement (not one expensive exact-star pass).
+
+**NNV's soundness gate is a competitive ASSET** — the −150 rule punishes the aggressive; "never certify
+not-robust/unsafe from an over-approximation, return `unknown` instead" is exactly the right posture.
+
+## The portfolio pipeline (per instance)
+
+Replace the current "falsify-100-random → reach-method-list" with a **time-budgeted, falsify-first,
+cheap-to-precise** pipeline, run with **falsification and reachability racing in parallel** (`parfeval`),
+first sound verdict wins, the loser is killed:
+
+```
+budget T (per-instance timeout)
+├─ FALSIFY worker  (target: SAT fast)         ┐ race; first {sat|unsat} wins,
+│   FGSM warm-start → PGD (multi-start) →      │ kill the other. Always VALIDATE
+│   CW fallback → random.  VALIDATE witness.    │ a SAT witness before emitting.
+├─ PROVE worker    (target: UNSAT fast)        ┘
+│   interval/zono → abs-dom → approx-star,  with
+│   ABSTRACTION-REFINEMENT (split top-k unstable
+│   neurons) instead of jumping to exact-star.
+└─ at T−ε: emit `unknown` (0 pts) — NEVER a partial/unsound verdict.
+```
+
+Never run `exact-star` on large nets (it's the exponential trap that caused 2025 timeouts; the 2025 fix
+already leads the compute-bound categories with `approx-zono`/`abs-dom`).
+
+## Pillar 1 — Falsification (the #1 score lever: close 354 → ~900 SAT)
+
+NNV's `falsify_single` does only ~100–500 *random* samples, no gradients. Add a real adversarial attack:
+- **Loss = distance to the unsafe region:** for unsafe `U = {y : Hg·y ≤ g}`, minimize
+  `max(0, margin-to-violation)` over `x ∈ [lb,ub]` via MATLAB autodiff (`dlarray`/`dlfeval`/`dlgradient`)
+  through the `dlnetwork`.
+- **FGSM warm-start → PGD refine:** 1-step FGSM on ~20 seeds → keep the top violating candidates → 50-step
+  PGD (Adam, projected to `[lb,ub]`). **Multi-start in `parfor`** (each worker its own net copy).
+- **Adaptive ε** by domain (images ≈ 0.1–0.5; flat features ≈ 0.01–0.1 of the range).
+- **CW attack** only as a last resort on hard, highly-constrained instances (nn4sys, sat_relu).
+- **Per-benchmark-class tuning** (`NNV_NRAND_FALSIFY` + PGD steps): small FC (ACAS/safenlp) — few samples,
+  fast PGD; large images (cifar100/tinyimagenet/vgg) — many samples, more PGD steps.
+- **Run falsification FIRST and in parallel with reach**, not just as a 0.5 s pre-pass.
+- *Expected:* the literature + the 354-vs-1000 gap suggest PGD roughly 2–3×'s SAT yield — the biggest single
+  point gain available, at modest effort.
+
+## Pillar 2 — Validity & soundness (drive the 19 penalties → 0)
+
+- **`validate_witness.m`:** before writing `sat`, **re-evaluate the candidate `x` through the network and
+  confirm the property is violated with a 1e-6 input-constraint margin** (issue #2 requires zero-tolerance
+  on input constraints; output replay tolerated to 1e-3 rel / 1e-4 abs). If it fails → emit **`unknown`,
+  never `sat`.**
+- **Fix witness encoding:** the `needReshape`/flatten ordering must match the ONNX input order (the runner
+  already has `needReshape==3` handling — extend + test it for every benchmark; the 2025 penalties were
+  "wrong CE writing").
+- Keep the **`[42]` exact-star gate** (no not-robust from an over-approximation) — it's why NNV's incorrect
+  count comes only from witnesses, not reachability.
+
+## Pillar 3 — Imprecise-but-sufficient + refinement + GPU (close UNSAT, get fast)
+
+- **CEGAR-style abstraction-refinement (`NN_reach_refinement.m`):** start with a cheap over-approx
+  (interval/zono/abs-dom); if undecided at a time threshold, **split the top-k unstable ReLU neurons** (rank
+  by activation range straddling 0), spawn the `2^k` phase-fixed sub-Stars in `parfor`, combine by
+  disjunction (SAT if any child SAT, UNSAT if all children UNSAT). This is the middle ground NNV lacks
+  between loose-zono and exponential exact-star.
+- **Adaptive `relaxFactor`** per benchmark: 0.8–0.9 for large nets (ViT/VGG/YOLO), 0.0–0.2 for small (ACAS).
+- **GPU bound propagation (high-impact, optional):** MATLAB `dlnetwork`/`dlarray` run on GPU. Use it for
+  **PGD (Pillar 1) and CROWN-style linear bounds** on large CNNs — this is exactly where α-β-CROWN wins.
+  Gate behind `NNV_USE_GPU`; CPU fallback. (Note: the p3 box has only 61 GB RAM — see Platform.)
+- **GCP-CROWN-style cutting planes:** NNV's Star already supports extra constraints (`C·a ≤ d`); append
+  tightening cuts from ReLU stability after a loose pass.
+- **Bounds caching:** ACAS-Xu runs the *same net* over many input sets — cache per-layer interval bounds
+  across a benchmark's instances.
+- **Bandit method selection:** record `(benchmark, method, status, time)` during the pre-June-30 cloud
+  sweep; reorder `reachOptionsList` per benchmark to put the historically-winning method first.
+
+## Speed & parallelism (NNV was the slowest to start)
+
+- **Keep `prepare_instance.sh` minimal** (it is); do heavy setup ONCE in `install_tool.sh`. Trim
+  `startup_nnv` per-instance cost; consider a pre-warmed MATLAB/NNV state.
+- **Use the 64 cores:** `parfor` over (a) multiple vnnlib specs (already partial), (b) falsification
+  multi-start, (c) refinement sub-problems. Avoid nested parpools (the known hang).
+- **Single-thread MATLAB where parpool isn't helping** (drop JIT/pool overhead on tiny instances).
+
+## Platform & submission harness
+
+- **Platform: `m5.16xlarge` CPU (64 vCPU, 256 GB)** as primary — NNV is CPU/LP/star-based and the large
+  ViT/VGG/TinyImageNet nets need the RAM the GPU box (61 GB) lacks. **Re-evaluate GPU (`p3.2xlarge`) only if
+  the PGD-on-GPU falsifier + CROWN bounds prove decisive** and fit in 61 GB.
+- **Scripts:** `install_tool.sh` (deps/toolboxes/licenses + warm-up), `prepare_instance.sh` (≤10 min, no
+  analysis), `run_instance.sh` (single-word result + validated SAT witness). **Start unofficial dry-runs on
+  the TUM repeatability site NOW** to surface install/format errors early.
+
+## VNN-LIB 2.0 (extended track) — use the Python packages (your call)
+
+Per your direction, **bridge via the existing Python `vnnlib`/`vnnlib2` packages** rather than reimplement
+the 2.0 grammar in MATLAB by June 30: extend the vendored `onnx2nnv_python` pattern with a
+`vnnlib2nnv.py` that parses (pip `vnnlib` v1.0.2 handles 2.0 + `.vnnlib.gz`) and emits a 1.0-style
+bounds/spec `.mat` NNV already consumes. Defer the deep `declare-hidden` (intermediate-tensor) and
+multi-network (`isomorphic/monotonic_acasxu`) cases unless time allows — the **regular track (24, all VNN-LIB
+1.0) needs no 2.0 parser at all** and is where most of the score is.
+
+## Sequenced engineering plan (effort vs the June 30 deadline)
+
+**🔴 Tier 0 — quick, highest-ROI (do first):**
+1. **PGD/FGSM falsifier + multi-start `parfor`** (Pillar 1) — the 354→~900 SAT gap. *Biggest point gain.*
+2. **`validate_witness.m`** + witness-encoding fixes (Pillar 2) — kill the 19 −150 leaks.
+3. **Submission scripts + TUM dry-run** — surface install/format issues now.
+4. **Full cloud sweep** (`vnncomp-sweep.yml`, official repo) at realistic timeout → the real regular-track
+   scorecard + the bandit/method data.
+
+**🟠 Tier 1 — medium:**
+5. Per-instance **falsify∥reach race** (`parfeval`) + timeout-to-`unknown` guard.
+6. Auto-tuned `relaxFactor` + bandit method ordering + bounds caching.
+7. Startup-overhead reduction; broader `parfor` parallelism.
+
+**🟡 Tier 2 — deeper (time-permitting):**
+8. **Abstraction-refinement loop** (`NN_reach_refinement.m`, multi-neuron split) — the UNSAT closer.
+9. **GPU** bound propagation + PGD on GPU.
+10. **VNN-LIB 2.0 Python bridge** for the 4 extended-track 2.0 benchmarks.
+
+**Bottom line:** the data says the win condition is **falsification + witness validity + speed**, not new
+verification theory. Tier 0 alone (better SAT-finding and zero penalty leakage) should move NNV materially
+up the table; the soundness gate keeps the −150 column at zero, which is where the aggressive tools bleed.


### PR DESCRIPTION
Forward-planning docs for NNV's VNN-COMP 2026 entry (tool deadline **June 30, 2026**). Docs only.

- **VNNCOMP2026_READINESS.md** — 2026 landscape: 24 regular-track (all VNN-LIB 1.0, existing parser), 6 extended (4 VNN-LIB-2.0-only), vnnlib2 delta + Python-bridge plan, submission contract.
- **VNNCOMP2025_RESULTS_ANALYSIS.md** — hard scoreboard (NNV 6th/7, 697.3). Ranked gaps: SAT-finding (354 vs ~1000), 19 −150 penalty leaks, worst startup (14.2s).
- **VNNCOMP2026_STRATEGY.md** — scoring-max plan: falsify‖reach portfolio, PGD falsifier (Pillar 1), witness validation (Pillar 2), refinement/GPU/relaxFactor/caching (Pillar 3), m5 CPU platform, vnnlib2 Python bridge, tiered Tier-0 quick wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)