### PR TITLE
feat(pgd): needReshape-aware gradient falsification for image/permuted inputs

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -110,6 +110,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Reclaim runner disk space
+        # MATLAB + the 11 toolboxes need ~5.4 GB; ubuntu-latest ships only ~14 GB free, and the
+        # Setup MATLAB download can exhaust it -> the runner worker crashes with "No space left
+        # on device" before any test runs (intermittent; hit shards 6/8/9/11 on run 27359826401).
+        # Removing preinstalled tooling this job never uses frees ~20-30 GB and makes it reliable.
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android \
+                      /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
       - name: Setup MATLAB
         id: setup_matlab
         continue-on-error: true   # cache: true restores MATLAB from the GitHub Actions cache on
@@ -228,6 +240,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Reclaim runner disk space
+        # See the standard job: free ~20-30 GB so the MATLAB toolbox download can't exhaust
+        # the runner disk ("No space left on device").
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android \
+                      /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v3
         with:

--- a/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
@@ -37,6 +37,8 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
     n_steps    = getfielddef(opts, 'n_steps',    40);
     lr         = getfielddef(opts, 'lr',         0.1);
     use_fgsm   = getfielddef(opts, 'fgsm',       true);
+    max_time   = getfielddef(opts, 'max_time',   inf);   % seconds; bound so PGD never
+    t0 = tic;                                            % eats the per-instance budget
     if isfield(opts,'seed') && ~isempty(opts.seed), rng(opts.seed); end
 
     lb = double(lb(:)); ub = double(ub(:));
@@ -57,6 +59,7 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
 
     nH = numel(Hs);
     for r = 1:n_restarts
+        if toc(t0) > max_time, return; end    % time budget exhausted -> let reach run
         h = mod(r-1, nH) + 1;                 % steer toward one unsafe set per restart
         [G, g] = halfspace_Gg(Hs(h));
         xn = flat_to_net_arr(seeds{r}, inputSize, needReshape);   % optimize in net space

--- a/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
@@ -134,21 +134,23 @@ end
 function ns = net_input_shape(inputSize, needReshape)
     switch needReshape
         case 1, ns = [inputSize(2) inputSize(1) inputSize(3:end)];
-        case 3, ns = [inputSize(3) inputSize(2) inputSize(1)];
+        case 3, ns = [inputSize(3) inputSize(2) inputSize(1) inputSize(4:end)];
         otherwise                                  % 0 and 2 -> inputSize
             if isscalar(inputSize), ns = [inputSize 1]; else, ns = inputSize; end
     end
 end
 
 function arr = flat_to_net_arr(v, inputSize, needReshape)
+    % permute_pad keeps any dims beyond the swapped leading ones in place, so >3-D
+    % (e.g. Image3D) inputs do not error in permute() and <=3-D is unchanged.
     v = double(v(:));
     switch needReshape
         case 2
-            arr = permute(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1 3]);
+            arr = permute_pad(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1]);
         case 3
-            arr = permute(reshape(v, inputSize), [3 2 1]);
+            arr = permute_pad(reshape(v, inputSize), [3 2 1]);
         case 1
-            arr = permute(reshape(v, inputSize), [2 1 3]);
+            arr = permute_pad(reshape(v, inputSize), [2 1]);
         otherwise
             if isscalar(inputSize), arr = reshape(v, [inputSize 1]); else, arr = reshape(v, inputSize); end
     end
@@ -157,9 +159,18 @@ end
 function v = net_arr_to_flat(arr, inputSize, needReshape)
     arr = reshape(arr, net_input_shape(inputSize, needReshape));   % drop padded dims
     switch needReshape
-        case 2, arr = permute(arr, [2 1 3]);
-        case 3, arr = permute(arr, [3 2 1]);
-        case 1, arr = permute(arr, [2 1 3]);
+        case 2, arr = permute_pad(arr, [2 1]);
+        case 3, arr = permute_pad(arr, [3 2 1]);
+        case 1, arr = permute_pad(arr, [2 1]);
     end
     v = reshape(arr, [], 1);
+end
+
+function y = permute_pad(x, base)
+    % Permute x by `base` over its leading dims, leaving any higher dims in place.
+    % For more dims than numel(base), trailing dims map to identity (>3-D no longer
+    % throws); for <=numel(base) dims it reduces to plain permute(x, base).
+    nd = max(numel(base), ndims(x));
+    p  = [base, (numel(base) + 1):nd];
+    y  = permute(x, p);
 end

--- a/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
@@ -1,37 +1,38 @@
-function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, opts)
+function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, needReshape, opts)
 %PGD_FALSIFY  Gradient-based (FGSM warm-start + PGD) adversarial falsification.
-%   Searches for an input x in the box [lb,ub] whose network output lands in one
-%   of the unsafe HalfSpaces in Hs -- i.e. a concrete COUNTEREXAMPLE / SAT witness
-%   -- using projected gradient descent on a violation-margin loss, with the
-%   gradient obtained by dlnetwork autodiff. This is the gradient-directed
-%   complement to NNV's existing random sampling (which found 3x fewer SAT than
-%   the field in VNN-COMP 2025); it is meant to be run FIRST, then fall back to
-%   random sampling if it fails. See VNNCOMP2026_STRATEGY.md (Pillar 1).
+%   Searches for an input in the box [lb,ub] whose network output lands in one of
+%   the unsafe HalfSpaces in Hs -- a concrete COUNTEREXAMPLE / SAT witness -- using
+%   projected gradient descent on a violation-margin loss, with the gradient from
+%   dlnetwork autodiff. Gradient-directed complement to NNV's random sampling
+%   (which found ~3x fewer SAT than the field in 2025); run FIRST, fall back to
+%   random. See VNNCOMP2026_STRATEGY.md (Pillar 1).
+%
+%   The optimization runs in the NETWORK-INPUT layout: the box and seeds are mapped
+%   flat-ONNX -> net-input with the SAME reshape+permute the runner uses
+%   (create_random_examples; selected by needReshape), so the forward pass is
+%   correct for image/permuted inputs; the returned witness is mapped back to flat
+%   ONNX order (matching lb/ub) so write_counterexample / validate_witness consume
+%   it directly.
 %
 %   SOUNDNESS: the returned point is a concrete evaluation, but the caller MUST
-%   still validate it with validate_witness() before emitting `sat` (the -150
-%   penalty makes a near-miss catastrophic).
+%   still validate it with validate_witness() before emitting `sat`.
 %
 %   Inputs:
-%     net         dlnetwork (required for autodiff). If not a dlnetwork, returns
-%                 found=false (the caller should fall back to random sampling).
-%     lb, ub      input lower/upper bounds, flattened column vectors.
-%     Hs          array of HalfSpace objects (the unsafe output region; a
-%                 counterexample y satisfies Hs(h).contains(y) for some h).
-%     inputSize   network input size used to reshape x (e.g. [1 784] or [32 32 3]).
-%     inputFormat 'default' or a dlarray dims label ("CB","SSCB","BC",...).
-%     opts        struct (all optional): n_restarts(20), n_steps(40), lr(0.1),
-%                 fgsm(true), seed([] = leave RNG alone).
+%     net          dlnetwork (required for autodiff). Non-dlnetwork -> found=false.
+%     lb, ub       input bounds, flat ONNX-order column vectors.
+%     Hs           array of HalfSpace (unsafe region; CE satisfies some Hs(h)).
+%     inputSize    network input size (e.g. [1 784] or [32 32 3]).
+%     inputFormat  'default' or a dlarray dims label ("CB","SSCB",...).
+%     needReshape  0 (flat/feature) | 1,2,3 (image permutes; mirrors the runner).
+%     opts         struct (optional): n_restarts(20), n_steps(40), lr(0.1),
+%                  fgsm(true), seed([]).
 %
-%   Outputs:
-%     cex   {x; y} cell (column input x and its output y) on success, else {}.
-%     found logical.
+%   Outputs: cex = {x; y} (flat x, output y) on success else {}; found logical.
 
     cex = {}; found = false;
-    if ~isa(net, 'dlnetwork')
-        return;   % no autodiff available -> caller uses random sampling
-    end
-    if nargin < 7 || isempty(opts), opts = struct(); end
+    if ~isa(net, 'dlnetwork'); return; end
+    if nargin < 7 || isempty(needReshape), needReshape = 0; end
+    if nargin < 8 || isempty(opts), opts = struct(); end
     n_restarts = getfielddef(opts, 'n_restarts', 20);
     n_steps    = getfielddef(opts, 'n_steps',    40);
     lr         = getfielddef(opts, 'lr',         0.1);
@@ -39,43 +40,43 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, opt
     if isfield(opts,'seed') && ~isempty(opts.seed), rng(opts.seed); end
 
     lb = double(lb(:)); ub = double(ub(:));
-    n  = numel(lb);
-    span = ub - lb;
-    fmt = resolve_format(inputFormat, inputSize);
+    nIn = numel(lb);
+    nsz = net_input_shape(inputSize, needReshape);   % net-input array shape (unpadded)
+    fmt = net_format(net, inputFormat, nsz);         % from the net's input layer
 
-    % Build restart seeds: box corners first (cheap, often violate), then random.
+    % Box in the network-input layout (element-wise, since flat->net is a permutation).
+    LBn = flat_to_net_arr(lb, inputSize, needReshape);
+    UBn = flat_to_net_arr(ub, inputSize, needReshape);
+    SPn = UBn - LBn;
+
+    % Restart seeds (flat): corners, midpoint, then random.
     seeds = cell(1, n_restarts);
     seeds{1} = lb; if n_restarts >= 2, seeds{2} = ub; end
     if n_restarts >= 3, seeds{3} = (lb+ub)/2; end
-    for r = 4:n_restarts
-        seeds{r} = lb + span.*rand(n,1);
-    end
+    for r = 4:n_restarts, seeds{r} = lb + (ub-lb).*rand(nIn,1); end
 
-    % Targets: each HalfSpace's (G,g). A counterexample lands in ANY of them; we
-    % minimize one target's worst margin per restart, but check ALL after.
     nH = numel(Hs);
     for r = 1:n_restarts
-        h = mod(r-1, nH) + 1;          % cycle which unsafe set we steer toward
+        h = mod(r-1, nH) + 1;                 % steer toward one unsafe set per restart
         [G, g] = halfspace_Gg(Hs(h));
-        x = seeds{r};
+        xn = flat_to_net_arr(seeds{r}, inputSize, needReshape);   % optimize in net space
         for it = 1:n_steps
-            dlx = to_dlarray(x, inputSize, fmt);
+            dlx = to_dlarray(xn, fmt);
             [~, grad] = dlfeval(@loss_and_grad, net, dlx, G, g);
-            grad = double(extractdata(grad));
-            grad = grad(:);
+            gnArr = reshape(double(extractdata(grad)), nsz);      % drop padded batch dim
             if use_fgsm && it == 1
-                upd = sign(grad);                    % FGSM warm-start step
+                upd = sign(gnArr);                                % FGSM warm-start
             else
-                gn = norm(grad); if gn < 1e-12, gn = 1; end
-                upd = grad / gn;                     % normalized PGD step
+                gn = norm(gnArr(:)); if gn < 1e-12, gn = 1; end
+                upd = gnArr / gn;                                 % normalized PGD step
             end
-            x = x - lr .* span .* upd;               % descend the violation margin
-            x = min(max(x, lb), ub);                 % project back into the box
-            % Check ALL unsafe sets for a concrete hit.
-            y = forward_eval(net, x, inputSize, fmt);
+            xn = xn - lr .* SPn .* upd;                           % descend the margin
+            xn = min(max(xn, LBn), UBn);                          % project into the box
+            y = extractdata(predict(net, to_dlarray(xn, fmt)));
             for hh = 1:nH
                 if Hs(hh).contains(double(y(:)))
-                    cex = {x; double(y(:))}; found = true; return;
+                    cex = {net_arr_to_flat(xn, inputSize, needReshape); double(y(:))};
+                    found = true; return;
                 end
             end
         end
@@ -88,47 +89,74 @@ function v = getfielddef(s, f, d)
     if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
 end
 
-function fmt = resolve_format(inputFormat, inputSize)
-    if nargin >= 1 && ~isempty(inputFormat) && ~strcmp(inputFormat, "default")
-        fmt = char(inputFormat);   % trust the caller's dims label as-is; do NOT
-        return;                    % append 'B' (that corrupts labels like 'BC'/'BCT')
+function fmt = net_format(net, inputFormat, nsz)
+    if ~isempty(inputFormat) && ~strcmp(inputFormat, "default")
+        fmt = char(inputFormat); return;     % trust the caller's label as-is
     end
-    % default: flat feature input -> CB; image (3D) -> SSCB.
-    if isscalar(inputSize) || (numel(inputSize) <= 3 && nnz(inputSize > 1) <= 1)
-        fmt = 'CB';
-    else
+    L = net.Layers(1);                       % infer from the actual input layer
+    if isa(L, 'nnet.cnn.layer.ImageInputLayer')
         fmt = 'SSCB';
-    end
-end
-
-function dlx = to_dlarray(x, inputSize, fmt)
-    if isscalar(inputSize)
-        xr = reshape(x, [inputSize, 1]);
+    elseif isa(L, 'nnet.cnn.layer.Image3DInputLayer')
+        fmt = 'SSSCB';
+    elseif isa(L, 'nnet.cnn.layer.FeatureInputLayer') || isa(L, 'nnet.onnx.layer.FeatureInputLayer')
+        fmt = 'CB';
+    elseif numel(nsz) >= 3
+        fmt = 'SSCB';
     else
-        xr = reshape(x, inputSize);
+        fmt = 'CB';
     end
-    % Pad trailing singleton dims so the array rank matches the format label rank
-    % (e.g. an [H W C] image with an 'SSCB' label needs a trailing batch dim).
-    if ndims(xr) < numel(fmt)
-        xr = reshape(xr, [size(xr), ones(1, numel(fmt) - ndims(xr))]);
-    end
-    dlx = dlarray(single(xr), fmt);
 end
 
-function y = forward_eval(net, x, inputSize, fmt)
-    dlx = to_dlarray(x, inputSize, fmt);
-    y = extractdata(predict(net, dlx));
+function dlx = to_dlarray(arr, fmt)
+    % Pad trailing singleton dims so the array rank matches the format label rank.
+    if ndims(arr) < numel(fmt)
+        arr = reshape(arr, [size(arr), ones(1, numel(fmt) - ndims(arr))]);
+    end
+    dlx = dlarray(single(arr), fmt);
 end
 
 function [loss, grad] = loss_and_grad(net, dlx, G, g)
-    y = predict(net, dlx);
-    y = y(:);
-    margins = G * y - g(:);          % unsafe set is {y : G*y <= g}; want all <= 0
-    loss = max(margins);             % minimize the worst-violated constraint
+    y = predict(net, dlx); y = y(:);
+    margins = G * y - g(:);          % unsafe set {y : G*y <= g}; drive all <= 0
+    loss = max(margins);
     grad = dlgradient(loss, dlx);
 end
 
 function [G, g] = halfspace_Gg(H)
-    % NNV HalfSpace stores the constraint as G*x <= g.
-    G = H.G; g = H.g;
+    G = H.G; g = H.g;               % NNV HalfSpace: G*x <= g
+end
+
+% ---- flat-ONNX <-> network-input layout (mirrors run_vnncomp_instance) ----
+
+function ns = net_input_shape(inputSize, needReshape)
+    switch needReshape
+        case 1, ns = [inputSize(2) inputSize(1) inputSize(3:end)];
+        case 3, ns = [inputSize(3) inputSize(2) inputSize(1)];
+        otherwise                                  % 0 and 2 -> inputSize
+            if isscalar(inputSize), ns = [inputSize 1]; else, ns = inputSize; end
+    end
+end
+
+function arr = flat_to_net_arr(v, inputSize, needReshape)
+    v = double(v(:));
+    switch needReshape
+        case 2
+            arr = permute(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1 3]);
+        case 3
+            arr = permute(reshape(v, inputSize), [3 2 1]);
+        case 1
+            arr = permute(reshape(v, inputSize), [2 1 3]);
+        otherwise
+            if isscalar(inputSize), arr = reshape(v, [inputSize 1]); else, arr = reshape(v, inputSize); end
+    end
+end
+
+function v = net_arr_to_flat(arr, inputSize, needReshape)
+    arr = reshape(arr, net_input_shape(inputSize, needReshape));   % drop padded dims
+    switch needReshape
+        case 2, arr = permute(arr, [2 1 3]);
+        case 3, arr = permute(arr, [3 2 1]);
+        case 1, arr = permute(arr, [2 1 3]);
+    end
+    v = reshape(arr, [], 1);
 end

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -998,16 +998,16 @@ end
 % Falsification function (random simulation looking for counterexamples)
 function counterEx = falsify_single(net, lb, ub, inputSize, nRand, Hs, needReshape, inputFormat)
     counterEx = nan;
-    % Gradient-directed falsification FIRST for flat feature inputs (needReshape==0),
-    % where the input vector maps directly to the network input (no permute risk).
-    % PGD/FGSM finds counterexamples far more reliably than random sampling (NNV
-    % found 354 SAT vs ~1000 for the field in 2025). Gated to dlnetwork + needReshape==0,
+    % Gradient-directed falsification FIRST (FGSM warm-start + PGD). pgd_falsify maps
+    % the flat input to the network-input layout with the SAME reshape+permute the
+    % runner uses (needReshape), so it works for image/permuted inputs too. NNV found
+    % 354 SAT vs ~1000 for the field in 2025; this targets that gap. Gated to dlnetwork,
     % wrapped in try/catch, and VALIDATED before acceptance, so it can only ADD a sound
     % SAT or fall through to the existing random sampling. [VNNCOMP2026_STRATEGY Pillar 1/2]
-    if needReshape == 0 && isa(net, 'dlnetwork')
+    if isa(net, 'dlnetwork')
         try
-            [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, struct('seed', 0));
-            if found && validate_witness(net, cex{1}, lb, ub, Hs, inputSize, inputFormat)
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, needReshape, struct('seed', 0));
+            if found && validate_witness(net, cex{1}, lb, ub, Hs, inputSize, inputFormat, needReshape)
                 counterEx = cex; return;
             end
         catch

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -1006,7 +1006,7 @@ function counterEx = falsify_single(net, lb, ub, inputSize, nRand, Hs, needResha
     % SAT or fall through to the existing random sampling. [VNNCOMP2026_STRATEGY Pillar 1/2]
     if isa(net, 'dlnetwork')
         try
-            [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, needReshape, struct('seed', 0));
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, needReshape, struct('seed', 0, 'max_time', 5));
             if found && validate_witness(net, cex{1}, lb, ub, Hs, inputSize, inputFormat, needReshape)
                 counterEx = cex; return;
             end

--- a/code/nnv/examples/Submission/VNN_COMP2025/validate_witness.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/validate_witness.m
@@ -1,86 +1,98 @@
-function ok = validate_witness(net, x, lb, ub, Hs, inputSize, inputFormat, in_tol, out_tol)
+function ok = validate_witness(net, x, lb, ub, Hs, inputSize, inputFormat, needReshape, in_tol, out_tol)
 %VALIDATE_WITNESS  Confirm a SAT counterexample is REAL before emitting `sat`.
-%   VNN-COMP scores an incorrect/non-replayable verdict at -150 (16x the +10 for
-%   a correct one), and NNV leaked 19 such "incorrect/missing-CE" points in 2025.
-%   This re-evaluates a candidate counterexample on the network and confirms it
-%   genuinely (1) respects the input box and (2) lands in the unsafe output
-%   region, so the caller never writes `sat` for a numerical near-miss. If it
-%   fails, the caller must emit `unknown` instead. See VNNCOMP2026_STRATEGY.md
-%   (Pillar 2).
+%   VNN-COMP scores an incorrect/non-replayable verdict at -150 (16x the +10 for a
+%   correct one); NNV leaked 19 such "incorrect/missing-CE" points in 2025. This
+%   re-evaluates a candidate on the network -- mapping the FLAT witness to the
+%   network-input layout with the SAME reshape+permute the runner uses (needReshape)
+%   -- and confirms it (1) respects the input box and (2) lands in the unsafe output
+%   region. If it fails, the caller must emit `unknown`, never `sat`. Strategy Pillar 2.
 %
 %   Inputs:
-%     net          dlnetwork OR an NNV NN (the same object falsification used).
-%     x            candidate input, FLAT column vector (same order as lb/ub).
+%     net          dlnetwork OR an NNV NN.
+%     x            candidate input, FLAT ONNX-order column vector (lb/ub order).
 %     lb, ub       input box bounds (flat vectors).
-%     Hs           array of HalfSpace (unsafe region); a real CE satisfies some h.
-%     inputSize    network input size for reshaping x.
-%     inputFormat  'default' or a dlarray dims label (for dlnetwork forward).
-%     in_tol       input-constraint slack (default 1e-6; rules require ~zero tol).
-%     out_tol      output-constraint slack (default 1e-4 absolute).
+%     Hs           array of HalfSpace (unsafe region).
+%     inputSize    network input size.
+%     inputFormat  'default' or a dlarray dims label.
+%     needReshape  0 | 1,2,3 (mirrors the runner's flat<->net layout).
+%     in_tol       input-constraint slack (default 1e-6).
+%     out_tol      output-constraint slack (default 1e-4).
 %
-%   Output: ok (logical) -- true only if the witness is a validated counterexample.
+%   Output: ok -- true only for a validated counterexample.
 
-    if nargin < 8 || isempty(in_tol),  in_tol  = 1e-6; end
-    if nargin < 9 || isempty(out_tol), out_tol = 1e-4; end
+    if nargin < 8  || isempty(needReshape), needReshape = 0;    end
+    if nargin < 9  || isempty(in_tol),      in_tol  = 1e-6;     end
+    if nargin < 10 || isempty(out_tol),     out_tol = 1e-4;     end
     ok = false;
 
     x  = double(x(:));
     lb = double(lb(:)); ub = double(ub(:));
 
-    % (1) Input must lie within the specified box (near-zero tolerance).
+    % (1) Input must lie within the box (near-zero tolerance per the rules).
     if numel(x) ~= numel(lb) || any(x < lb - in_tol) || any(x > ub + in_tol)
         return;
     end
 
-    % (2) Re-evaluate the network on the witness.
+    % (2) Re-evaluate the network on the witness (in the network-input layout).
     try
-        y = eval_net(net, x, inputSize, inputFormat);
+        y = eval_net(net, x, inputSize, inputFormat, needReshape);
     catch
-        return;   % cannot validate -> treat as invalid (caller -> unknown)
+        return;   % cannot validate -> invalid (caller -> unknown)
     end
     y = double(y(:));
-    if isempty(y) || any(~isfinite(y))
-        return;
-    end
+    if isempty(y) || any(~isfinite(y)), return; end
 
     % (3) Confirm the output lands in some unsafe HalfSpace (G*y <= g).
     for h = 1:numel(Hs)
         m = Hs(h).G * y - Hs(h).g(:);
-        if all(m <= out_tol)
-            ok = true; return;
-        end
+        if all(m <= out_tol), ok = true; return; end
     end
 end
 
 % ---- helpers ----
 
-function y = eval_net(net, x, inputSize, inputFormat)
-    if isa(net, 'NN')                 % NNV native net (Python-importer manifest)
-        y = net.evaluate(x);
+function y = eval_net(net, x, inputSize, inputFormat, needReshape)
+    arr = flat_to_net_arr(x, inputSize, needReshape);   % flat ONNX -> net-input layout
+    if isa(net, 'NN')                                   % NNV native net (manifest path)
+        y = net.evaluate(arr);
         return;
     end
-    % dlnetwork: reshape + label + predict.
-    if isscalar(inputSize)
-        xr = reshape(x, [inputSize, 1]);
-    else
-        xr = reshape(x, inputSize);
+    fmt = net_format(net, inputFormat, size(arr));
+    if ndims(arr) < numel(fmt)
+        arr = reshape(arr, [size(arr), ones(1, numel(fmt) - ndims(arr))]);
     end
-    fmt = resolve_format(inputFormat, inputSize);
-    % Pad trailing singleton dims so the array rank matches the format label rank.
-    if ndims(xr) < numel(fmt)
-        xr = reshape(xr, [size(xr), ones(1, numel(fmt) - ndims(xr))]);
-    end
-    y = extractdata(predict(net, dlarray(single(xr), fmt)));
+    y = extractdata(predict(net, dlarray(single(arr), fmt)));
 end
 
-function fmt = resolve_format(inputFormat, inputSize)
-    if nargin >= 1 && ~isempty(inputFormat) && ~strcmp(inputFormat, "default")
-        fmt = char(inputFormat);   % trust the caller's dims label as-is (no 'B' append)
-        return;
+function fmt = net_format(net, inputFormat, nsz)
+    if ~isempty(inputFormat) && ~strcmp(inputFormat, "default")
+        fmt = char(inputFormat); return;     % trust the caller's label as-is
     end
-    if isscalar(inputSize) || (numel(inputSize) <= 3 && nnz(inputSize > 1) <= 1)
-        fmt = 'CB';
-    else
+    L = net.Layers(1);                       % infer from the actual input layer
+    if isa(L, 'nnet.cnn.layer.ImageInputLayer')
         fmt = 'SSCB';
+    elseif isa(L, 'nnet.cnn.layer.Image3DInputLayer')
+        fmt = 'SSSCB';
+    elseif isa(L, 'nnet.cnn.layer.FeatureInputLayer') || isa(L, 'nnet.onnx.layer.FeatureInputLayer')
+        fmt = 'CB';
+    elseif numel(nsz) >= 3
+        fmt = 'SSCB';
+    else
+        fmt = 'CB';
+    end
+end
+
+function arr = flat_to_net_arr(v, inputSize, needReshape)
+    % flat ONNX-order vector -> network-input array (mirrors create_random_examples).
+    v = double(v(:));
+    switch needReshape
+        case 2
+            arr = permute(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1 3]);
+        case 3
+            arr = permute(reshape(v, inputSize), [3 2 1]);
+        case 1
+            arr = permute(reshape(v, inputSize), [2 1 3]);
+        otherwise
+            if isscalar(inputSize), arr = reshape(v, [inputSize 1]); else, arr = reshape(v, inputSize); end
     end
 end

--- a/code/nnv/examples/Submission/VNN_COMP2025/validate_witness.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/validate_witness.m
@@ -84,15 +84,27 @@ end
 
 function arr = flat_to_net_arr(v, inputSize, needReshape)
     % flat ONNX-order vector -> network-input array (mirrors create_random_examples).
+    % permute_pad extends the leading-dim swap with identity on any higher dims, so
+    % >3-D inputs (e.g. Image3D) do not error in permute() (matches <=3-D exactly).
     v = double(v(:));
     switch needReshape
         case 2
-            arr = permute(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1 3]);
+            arr = permute_pad(reshape(v, [inputSize(2) inputSize(1) inputSize(3:end)]), [2 1]);
         case 3
-            arr = permute(reshape(v, inputSize), [3 2 1]);
+            arr = permute_pad(reshape(v, inputSize), [3 2 1]);
         case 1
-            arr = permute(reshape(v, inputSize), [2 1 3]);
+            arr = permute_pad(reshape(v, inputSize), [2 1]);
         otherwise
             if isscalar(inputSize), arr = reshape(v, [inputSize 1]); else, arr = reshape(v, inputSize); end
     end
+end
+
+function y = permute_pad(x, base)
+    % Permute x by `base` over its leading dims, leaving any higher dims in place.
+    % For an array with more dims than numel(base), the trailing dims map to identity
+    % (so a 4-D Image3D input no longer throws); for <=numel(base) dims it reduces to
+    % plain permute(x, base) -- identical to the original hard-coded vectors.
+    nd = max(numel(base), ndims(x));
+    p  = [base, (numel(base) + 1):nd];
+    y  = permute(x, p);
 end

--- a/code/nnv/tests/vnncomp25/test_pgd_falsify.m
+++ b/code/nnv/tests/vnncomp25/test_pgd_falsify.m
@@ -1,75 +1,85 @@
 classdef test_pgd_falsify < matlab.unittest.TestCase
     % Tests for the gradient-based falsifier (pgd_falsify) and the SAT-witness
-    % validator (validate_witness) -- VNN-COMP 2026 strategy Pillars 1 & 2.
-    %
-    % Net under test: y = x1 + x2 (a 2->1 linear dlnetwork) on the box [0,1]^2.
-    % Unsafe region: y >= 1.5, encoded as the HalfSpace {y : -y <= -1.5}. A
-    % counterexample exists (e.g. x=[1;1] -> y=2), so PGD must find one, the
-    % validator must confirm it, and must REJECT non-violating / out-of-box points.
+    % validator (validate_witness) -- VNN-COMP 2026 strategy Pillars 1 & 2 -- across
+    % feature, non-permuted image, and PERMUTED image (needReshape) inputs.
 
     methods (Static)
-        function net = linsum_net()
+        function net = linsum_net()                  % y = x1 + x2 (feature, 2->1)
             layers = [ featureInputLayer(2, 'Name', 'in')
                        fullyConnectedLayer(1, 'Name', 'fc', 'Weights', [1 1], 'Bias', 0) ];
             net = dlnetwork(layers);
         end
-        function net = img_sum_net()
-            % 1x1x2 "image" -> y = sum of the 2 channels (exercises the SSCB /
-            % multi-dim format + rank-padding path).
+        function net = img_sum_net()                 % 1x1x2 image -> y = c1 + c2
             layers = [ imageInputLayer([1 1 2], 'Name', 'in', 'Normalization', 'none')
                        fullyConnectedLayer(1, 'Name', 'fc', 'Weights', [1 1], 'Bias', 0) ];
+            net = dlnetwork(layers);
+        end
+        function net = img_pos_net()                 % 1x2x1 image -> y = p1 + 10*p2
+            % input layer is the MATLAB (post-permute) size [1 2 1]; the ONNX
+            % (pre-permute) size is [2 1 1] with needReshape=1.
+            layers = [ imageInputLayer([1 2 1], 'Name', 'in', 'Normalization', 'none')
+                       fullyConnectedLayer(1, 'Name', 'fc', 'Weights', [1 10], 'Bias', 0) ];
             net = dlnetwork(layers);
         end
     end
 
     methods (Test)
 
-        function test_pgd_image_format_sscb(testCase)
-            % multi-dim input (inputSize=[1 1 2], format 'SSCB'): the format/reshape
-            % path must produce a valid forward pass, find the CE, and validate it.
+        function test_pgd_feature(testCase)
+            net = test_pgd_falsify.linsum_net();
+            lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -1.5);   % unsafe y >= 1.5
+            opts = struct('seed', 0, 'n_restarts', 12, 'n_steps', 30, 'lr', 0.2);
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, 2, 'CB', 0, opts);
+            testCase.verifyTrue(found, 'PGD should find a CE for y>=1.5 on [0,1]^2');
+            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, 2, 'CB', 0), ...
+                'PGD-found witness must validate');
+        end
+
+        function test_pgd_image_no_permute(testCase)
             net = test_pgd_falsify.img_sum_net();
             lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -1.5);
             opts = struct('seed', 0, 'n_restarts', 12, 'n_steps', 30, 'lr', 0.2);
-            [cex, found] = pgd_falsify(net, lb, ub, Hs, [1 1 2], 'SSCB', opts);
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, [1 1 2], 'SSCB', 0, opts);
             testCase.verifyTrue(found, 'PGD should find a CE on the 1x1x2 image net');
-            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, [1 1 2], 'SSCB'), ...
-                'image-format witness must validate');
+            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, [1 1 2], 'SSCB', 0), ...
+                'image witness must validate');
         end
 
-        function test_pgd_finds_counterexample(testCase)
-            net = test_pgd_falsify.linsum_net();
-            lb = [0;0]; ub = [1;1];
-            Hs = HalfSpace(-1, -1.5);                 % {y : y >= 1.5}
-            opts = struct('seed', 0, 'n_restarts', 12, 'n_steps', 30, 'lr', 0.2);
-            [cex, found] = pgd_falsify(net, lb, ub, Hs, 2, 'CB', opts);
-            testCase.verifyTrue(found, 'PGD should find a counterexample for y>=1.5 on [0,1]^2');
-            testCase.verifyEqual(numel(cex), 2, 'cex = {x; y}');
-            % the returned point is a genuine violation
-            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, 2, 'CB'), ...
-                'PGD-found witness must validate');
+        function test_pgd_image_needreshape1(testCase)
+            % Permuted image (needReshape=1): the flat ONNX input must be reshaped to
+            % the ONNX size [2 1 1] then permuted [2 1 3] to the MATLAB net input
+            % [1 2 1]. Position-sensitive weights ([1 10]) make the permute MATTER, so
+            % a wrong mapping would either error or fail the INDEPENDENT oracle below.
+            net = test_pgd_falsify.img_pos_net();
+            lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -6);     % unsafe y >= 6
+            opts = struct('seed', 0, 'n_restarts', 16, 'n_steps', 40, 'lr', 0.25);
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, [2 1 1], 'default', 1, opts);
+            testCase.verifyTrue(found, 'PGD should find a CE on the needReshape=1 image net');
+            w = cex{1};
+            % INDEPENDENT oracle: with the CORRECT permute the net computes y = w1 + 10*w2.
+            testCase.verifyGreaterThanOrEqual(w(1) + 10*w(2), 6 - 1e-3, ...
+                'witness must satisfy the true (correct-permute) spec y = w1 + 10*w2 >= 6');
+            testCase.verifyTrue(validate_witness(net, w, lb, ub, Hs, [2 1 1], 'default', 1), ...
+                'needReshape=1 witness must validate (round-trip consistent)');
         end
 
         function test_validate_rejects_non_violating(testCase)
             net = test_pgd_falsify.linsum_net();
             lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -1.5);
-            % x=[0;0] -> y=0, NOT in {y>=1.5}
-            testCase.verifyFalse(validate_witness(net, [0;0], lb, ub, Hs, 2, 'CB'), ...
+            testCase.verifyFalse(validate_witness(net, [0;0], lb, ub, Hs, 2, 'CB', 0), ...
                 'a non-violating point must be rejected (else -150 risk)');
         end
 
         function test_validate_rejects_out_of_box(testCase)
             net = test_pgd_falsify.linsum_net();
             lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -1.5);
-            % x=[2;2] violates the OUTPUT spec (y=4>=1.5) but is OUTSIDE the input box
-            testCase.verifyFalse(validate_witness(net, [2;2], lb, ub, Hs, 2, 'CB'), ...
+            testCase.verifyFalse(validate_witness(net, [2;2], lb, ub, Hs, 2, 'CB', 0), ...
                 'an out-of-box witness must be rejected');
         end
 
         function test_pgd_no_op_on_non_dlnetwork(testCase)
-            % On a non-dlnetwork (e.g. an NNV NN), pgd must gracefully return
-            % found=false so the caller falls back to random sampling.
             Hs = HalfSpace(-1, -1.5);
-            [~, found] = pgd_falsify("not a dlnetwork", [0;0], [1;1], Hs, 2, 'CB', struct());
+            [~, found] = pgd_falsify("not a dlnetwork", [0;0], [1;1], Hs, 2, 'CB', 0, struct());
             testCase.verifyFalse(found);
         end
 


### PR DESCRIPTION
Extends the Tier-0 PGD/FGSM falsifier into the **image benchmarks' permuted-input path** (cifar100, traffic, metaroom, yolo, vggnet, tinyimagenet, collins — a large share of NNV's benchmarks), continuing strategy Pillar 1 (close the 354→~1000 SAT gap).

- **pgd_falsify** optimizes in the **network-input layout** — box + seeds mapped flat-ONNX→net-input with the **same reshape+permute the runner uses** (needReshape 0/1/2/3), witness mapped back to flat ONNX order.
- **Format inferred from the net's input layer** (ImageInputLayer→SSCB, FeatureInputLayer→CB), not a size heuristic that mis-classified small image inputSizes like `[2 1 1]` as `CB` (caught by the new test).
- **validate_witness** applies the same mapping for the replay.
- **Runner gate widened** from `needReshape==0` to all dlnetwork inputs (still try/catch + validated → can only add a sound SAT or fall through to random).
- **6/6 tests pass** (feature + non-permuted image + a needReshape=1 PERMUTED image test with an independent oracle `y = w1 + 10·w2` that catches permute bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)