### PR TITLE
onnxruntime SAT-witness guard (VNN-COMP Pillar 2: -150 defense)

### DIFF
--- a/VNNCOMP2026_PROGRESS.md
+++ b/VNNCOMP2026_PROGRESS.md
@@ -1,0 +1,89 @@
+# NNV — VNN-COMP 2026 participation: execution progress & direction
+
+*Living tracker of how the [scoring strategy](VNNCOMP2026_STRATEGY.md) is being executed. Status as of
+2026-06-11. Deadline: **tool submission June 30, 2026 AoE**; competition July 24–25, Lisbon. NNV is voted
+in. The 2025 baseline we're improving on: **6th/7, 697.3 pts** (see
+[VNNCOMP2025_RESULTS_ANALYSIS.md](VNNCOMP2025_RESULTS_ANALYSIS.md)).*
+
+## Direction in one paragraph
+
+The 2025 numbers say NNV's deficit is **executional, not theoretical** — CORA and nnenum use the same
+reachability family and outscore us. The three levers, in priority order from the data: **(1) find more SAT**
+(NNV got 354 vs ~1000 — weak random sampling), **(2) stop the −150 penalty leak** (19 invalid/missing
+witnesses), **(3) go faster** (worst startup; timeouts on big nets). The soundness gate is a *competitive
+advantage* under the −150 rule. So the plan is **fast-and-sound-or-`unknown`**: cheap gradient falsification
+first, then a cheap-to-precise abstraction ladder with refinement — never the exponential exact-star on large
+nets.
+
+## Pillar status
+
+| Pillar | Item | Status |
+|---|---|---|
+| **1 — Falsification (SAT)** | Gradient PGD/FGSM falsifier (feature inputs) | ✅ merged (#305) |
+| | needReshape-aware PGD (image/permuted inputs) | 🟢 #306 (auto-merging) |
+| | Format-from-layer fix + PGD time-budget (no budget starvation) | 🟢 #306 |
+| | Per-category falsification config (nRand, restarts/steps, ε) | ⬜ next |
+| | falsify ∥ reach race (parfeval), CW fallback for hard cases | ⬜ |
+| **2 — Validity (no −150)** | `validate_witness` re-evaluates every SAT before emitting | ✅ merged (#305) |
+| | needReshape-correct witness replay | 🟢 #306 |
+| | >3-D (Image3D) permute robustness in flat↔net mapping (Copilot) | 🟢 #306 (1e9717b5e) |
+| | **onnxruntime witness guard** (`validate_witness_onnx` + `onnx_replay_check.py`) | ✅ built + tested, awaiting runner wiring |
+| **3 — Imprecise + refine + speed** | fast-method ladder (zono→abs-dom, no exact-star for big nets) | ✅ (earlier) |
+| | adaptive `relaxFactor` per benchmark | ⬜ next |
+| | CEGAR ReLU/input splitting refinement (`NN_reach_refinement`) | ⬜ |
+| | bandit method selection + bounds caching | ⬜ |
+| | GPU bound propagation / PGD-on-GPU | ⬜ (stretch) |
+| **Submission** | `install/prepare/run_instance.sh` (R2026a) | ✅ merged (#305, VNN_COMP2026/) |
+| | TUM repeatability dry-run | ⬜ (needs the eval site) |
+| **VNN-LIB 2.0 (extended track)** | Python `vnnlib`-pip → `.mat` bridge | ⬜ (regular track needs none) |
+
+## Measured results
+
+- **Baseline (2025 official):** 1082 solved (354 SAT / 728 UNSAT), 6th/7, 697.3 pts.
+- **2025-set sweep, pre-PGD (fast-method only):** 120 s/instance, one representative instance per folder →
+  **1 sat**, 2 unsat, 14 unknown, rest error/timeout. See [VNNCOMP2025_STATUS.md](VNNCOMP2025_STATUS.md).
+- **2025-set sweep, WITH the PGD falsifier (2026-06-11, `results_20260611_103123`):** same 120 s/instance,
+  26 folders → **4 sat** (collins_rul, cora, safenlp, sat_relu), 2 unsat (malbeware, metaroom),
+  12 unknown, 5 error, 3 timeout. **SAT 1→4 (4×)** from gradient falsification — the headline Pillar-1
+  signal; unknowns 14→12. (Representative-instance sweep, not the full per-instance set — directional.)
+- **Errors worth a follow-up fix** (from the same sweep): `cgan_2023` and `soundnessbench` both fail with
+  `Unrecognized ... 'ONNXParams' for class '...ReshapeLayer1000'` — an importer gap in the ONNX Reshape
+  path; `collins_aerospace` "Unsupported Class of Layer"; `cctsdb_yolo` known-WIP.
+
+## Immediate next actions (deadline-ordered)
+
+1. **Land #306** (needReshape PGD + time-budget) → gradient falsification covers image benchmarks.
+2. **Per-category falsification + `relaxFactor` tuning** — raise `nRand`/PGD effort for the SAT-likely
+   classes; set `relaxFactor` high for the large CNNs (speed). Small, safe, testable.
+3. **Run the full cloud sweep** (`.github/workflows/vnncomp-sweep.yml`, official 2025 repo) at a realistic
+   timeout to get the true regular-track scorecard with the new falsifier.
+4. **Submission dry-run** on the TUM site to surface install/witness-format issues early.
+5. **`relaxFactor`/bandit + (stretch) CEGAR refinement** for the UNSAT closer; **vnnlib2 bridge** for the
+   4 extended-track 2.0 benchmarks if time allows.
+
+## Key hardening (Pillar 2): onnxruntime witness guard — BUILT + TESTED ✅
+
+`validate_witness` replays the candidate through **NNV's** forward (the same reshape/needReshape convention
+the falsifier used). That catches numerical near-misses, but a *systematic* witness-encoding error (the
+suspected source of several of the 19 −150 penalties — the runner's own "wrong counterexample writing?" note)
+would pass NNV's self-consistent replay yet fail the competition's check. The competition validates the SAT
+witness by replaying it through **onnxruntime on the original ONNX model**.
+
+**Done (this session):** the definitive guard now exists and is verified end-to-end:
+- `code/nnv/tools/onnx2nnv_python/onnx_replay_check.py` — replays a FLAT (ONNX-order) witness through the
+  ORIGINAL .onnx via onnxruntime and reports `VIOLATED`/`OK`/`ERROR` for the unsafe region `G·y ≤ g`.
+- `code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m` — MATLAB wrapper that calls it.
+  Verified on acasxu: violated→1, impossible-region→0, multi-HalfSpace any-violates→1.
+- Two bugs found + fixed while bringing it up: (a) the Windows case-insensitive FS collapsed the temp
+  `G.csv`/`g.csv` into one file (g clobbered G) — renamed to `Gmat.csv`/`gvec.csv`; (b) the Python loader
+  now reshapes G against the model's *known* output dim instead of trusting the CSV's parsed rank.
+
+**Remaining:** wire `validate_witness_onnx` into `run_vnncomp_instance.m`'s SAT path as the final gate before
+emitting `sat` (emit `unknown` if the ONNX replay doesn't violate). Deferred until #306 merges — #306 also
+edits `run_vnncomp_instance.m`, so wiring now would conflict. These three files sit on a separate branch off
+master (not in #306).
+
+## What NOT to spend time on
+
+Breadth/coverage — NNV already participated in 15/16 benchmarks in 2025; coverage is fine. The score comes
+from **SAT-finding, witness validity, and speed**, in that order.

--- a/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
@@ -1,0 +1,60 @@
+function ok = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
+%VALIDATE_WITNESS_ONNX  Definitive SAT-witness guard: replay through onnxruntime.
+%   Replays the FLAT (ONNX-order) witness through the ORIGINAL ONNX model via
+%   onnxruntime (tools/onnx2nnv_python/onnx_replay_check.py) and confirms the output
+%   lands in the unsafe region G*y <= g for some Hs(h). This is the competition's
+%   actual check, so unlike validate_witness (which replays through NNV's own
+%   forward) it also catches a SYSTEMATIC import/encoding mismatch -- the likely
+%   source of several of NNV's 19 incorrect/missing-CE (-150) penalties in 2025.
+%   Use it as the final gate before emitting `sat`; emit `unknown` if it returns false.
+%   See VNNCOMP2026_STRATEGY.md / VNNCOMP2026_PROGRESS.md (Pillar 2).
+%
+%   onnx_path : path to the ORIGINAL .onnx model.
+%   x_flat    : witness input, FLAT in ONNX order (the value written to the CE file).
+%   Hs        : array of HalfSpace (unsafe output region).
+%   out_tol   : output-constraint slack (default 1e-4).
+%
+%   ok : true only if onnxruntime confirms the witness violates some Hs(h).
+%   Returns false (safe) if Python/onnxruntime is unavailable or errors.
+
+    if nargin < 4 || isempty(out_tol), out_tol = 1e-4; end
+    ok = false;
+
+    script = fullfile(nnvroot(), 'code', 'nnv', 'tools', 'onnx2nnv_python', 'onnx_replay_check.py');
+    if ~isfile(script) || ~isfile(char(onnx_path))
+        return;
+    end
+
+    td = tempname; mkdir(td);
+    cleanup = onCleanup(@() rmdir(td, 's'));
+    xf = fullfile(td, 'x_in.csv');
+    writematrix(double(x_flat(:)), xf);
+
+    % NB: file names must be case-DISTINCT -- Windows' filesystem is case-insensitive,
+    % so "G.csv" and "g.csv" would be the same file and the second write clobbers the
+    % first (g would overwrite G), corrupting the unsafe-region matrix.
+    py = python_exe();
+    for h = 1:numel(Hs)
+        Gf = fullfile(td, 'Gmat.csv'); gf = fullfile(td, 'gvec.csv');
+        writematrix(double(Hs(h).G), Gf);
+        writematrix(double(Hs(h).g(:)), gf);
+        cmd = sprintf('%s "%s" "%s" "%s" "%s" "%s" --out-tol %g', ...
+            py, script, char(onnx_path), xf, Gf, gf, out_tol);
+        [st, out] = system(cmd);
+        if st == 0 && contains(out, 'VIOLATED')
+            ok = true; return;
+        end
+    end
+end
+
+function py = python_exe()
+    % Prefer an explicit interpreter if MATLAB knows one; else fall back to PATH.
+    py = 'python';
+    try
+        pe = pyenv;
+        if ~isempty(pe.Executable) && isfile(pe.Executable)
+            py = ['"' char(pe.Executable) '"'];
+        end
+    catch
+    end
+end

--- a/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
+++ b/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
@@ -24,9 +24,14 @@ function test_missing_onnx_returns_false(tc)
 end
 
 function test_empty_halfspace_array_returns_false(tc)
-    % No unsafe region -> nothing to violate -> false (and no crash).
-    bogus = fullfile(tempdir, 'definitely_not_a_real_model_xyz.onnx');
-    ok = validate_witness_onnx(bogus, [0; 0], HalfSpace.empty);
+    % A VALID (existing) model path but an EMPTY unsafe region: the Hs loop never
+    % iterates, so the wrapper returns false WITHOUT invoking Python. This exercises
+    % the empty-region path itself (the missing-file guard is covered by the test
+    % above). A stub file suffices -- no ONNX is parsed when there are zero HalfSpaces.
+    f = [tempname '.onnx'];
+    fid = fopen(f, 'w'); fwrite(fid, 'stub'); fclose(fid);
+    c = onCleanup(@() delete(f));  %#ok<NASGU>
+    ok = validate_witness_onnx(f, [1; 1], HalfSpace.empty);
     verifyFalse(tc, ok);
 end
 
@@ -57,9 +62,22 @@ end
 
 function assumeOnnxruntime(tc)
     % Skip (not fail) the replay tests when onnxruntime is not importable, so CI
-    % machines without it stay green -- the fallback contract is still exercised.
-    [st, ~] = system('python -c "import onnxruntime"');
+    % machines without it stay green. Resolve the interpreter the SAME way
+    % validate_witness_onnx's python_exe() does (prefer MATLAB's configured pyenv,
+    % else PATH 'python') so this gate matches the python the wrapper actually calls.
+    [st, ~] = system([resolve_python() ' -c "import onnxruntime"']);
     assumeEqual(tc, st, 0, 'python/onnxruntime unavailable -- skipping replay tests');
+end
+
+function py = resolve_python()
+    py = 'python';
+    try
+        pe = pyenv;
+        if ~isempty(pe.Executable) && isfile(pe.Executable)
+            py = ['"' char(pe.Executable) '"'];
+        end
+    catch
+    end
 end
 
 function [onnxPath, cleanup] = exportTinyLinearOnnx()

--- a/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
+++ b/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
@@ -1,0 +1,77 @@
+function tests = test_validate_witness_onnx
+%TEST_VALIDATE_WITNESS_ONNX  Tests for the onnxruntime SAT-witness guard.
+%   validate_witness_onnx replays a FLAT (ONNX-order) witness through the ORIGINAL
+%   .onnx via onnxruntime (the competition's own checker) and returns true ONLY when
+%   the output lands in the unsafe region G*y <= g. It is the definitive Pillar-2
+%   guard against the -150 "incorrect counterexample" penalty.
+%
+%   Two groups of tests:
+%     * fallback contract (always runs): returns false -- never errors -- when the
+%       model/Python is unavailable, so the runner safely degrades to `unknown`.
+%     * replay correctness (runs only if python+onnxruntime are importable): exports
+%       a tiny known-linear net to ONNX and checks violated->true / impossible->false.
+    tests = functiontests(localfunctions);
+end
+
+% ---------- fallback contract (environment-independent) ----------
+
+function test_missing_onnx_returns_false(tc)
+    % A non-existent model path must yield false (safe), not an error.
+    bogus = fullfile(tempdir, 'definitely_not_a_real_model_xyz.onnx');
+    if isfile(bogus), delete(bogus); end
+    ok = validate_witness_onnx(bogus, [0; 0], HalfSpace([1 0], 0));
+    verifyFalse(tc, ok);
+end
+
+function test_empty_halfspace_array_returns_false(tc)
+    % No unsafe region -> nothing to violate -> false (and no crash).
+    bogus = fullfile(tempdir, 'definitely_not_a_real_model_xyz.onnx');
+    ok = validate_witness_onnx(bogus, [0; 0], HalfSpace.empty);
+    verifyFalse(tc, ok);
+end
+
+% ---------- replay correctness (needs python + onnxruntime) ----------
+
+function test_violated_true_and_impossible_false(tc)
+    assumeOnnxruntime(tc);
+    [onnx, cleanup] = exportTinyLinearOnnx();  %#ok<ASGLU> keep cleanup alive
+    % Net is y = 1*x1 + 2*x2 (single output). For x=[1;1], y=3.
+    x = [1; 1];
+    % Unsafe set {y : y <= 10} -> 3 <= 10 -> VIOLATED -> true.
+    ok_v = validate_witness_onnx(onnx, x, HalfSpace(1, 10));
+    verifyTrue(tc, ok_v, 'witness y=3 should violate {y <= 10}');
+    % Unsafe set {y : y <= -10} -> impossible for y=3 -> OK -> false.
+    ok_i = validate_witness_onnx(onnx, x, HalfSpace(1, -10));
+    verifyFalse(tc, ok_i, 'witness y=3 must NOT be accepted for {y <= -10}');
+end
+
+function test_multi_halfspace_any_violates(tc)
+    assumeOnnxruntime(tc);
+    [onnx, cleanup] = exportTinyLinearOnnx();  %#ok<ASGLU>
+    x = [1; 1];   % y = 3
+    Hs = [HalfSpace(1, -10), HalfSpace(1, 10)];  % 1st impossible, 2nd holds
+    verifyTrue(tc, validate_witness_onnx(onnx, x, Hs), 'any-violates should accept');
+end
+
+% ---------- helpers ----------
+
+function assumeOnnxruntime(tc)
+    % Skip (not fail) the replay tests when onnxruntime is not importable, so CI
+    % machines without it stay green -- the fallback contract is still exercised.
+    [st, ~] = system('python -c "import onnxruntime"');
+    assumeEqual(tc, st, 0, 'python/onnxruntime unavailable -- skipping replay tests');
+end
+
+function [onnxPath, cleanup] = exportTinyLinearOnnx()
+    % A minimal known-linear net: featureInput(2) -> fc(1) with y = [1 2]*x.
+    % Preset the weights ON THE LAYER before building the dlnetwork -- dlnetwork
+    % preserves already-initialized learnables, so y is deterministic.
+    fc = fullyConnectedLayer(1, 'Name', 'fc');
+    fc.Weights = single([1 2]);   % y = 1*x1 + 2*x2
+    fc.Bias    = single(0);
+    layers = [featureInputLayer(2, 'Name', 'in'); fc];
+    net = dlnetwork(layers);
+    onnxPath = [tempname '.onnx'];
+    exportONNXNetwork(net, onnxPath);
+    cleanup = onCleanup(@() delete(onnxPath));
+end

--- a/code/nnv/tools/onnx2nnv_python/onnx_replay_check.py
+++ b/code/nnv/tools/onnx2nnv_python/onnx_replay_check.py
@@ -1,0 +1,87 @@
+"""onnx_replay_check.py -- validate a SAT counterexample against the ORIGINAL ONNX
+model via onnxruntime (the competition's actual checker), not NNV's forward.
+
+VNN-COMP scores incorrect/non-replayable verdicts at -150; a witness that NNV's
+self-consistent replay accepts could still fail the competition if NNV's import
+permutes the input differently than the ONNX model expects. This replays the flat
+witness through onnxruntime and checks whether the output lands in the unsafe
+region G*y <= g, so the runner can refuse to emit `sat` for a non-replayable witness.
+
+Usage:
+  python onnx_replay_check.py <model.onnx> <x.csv> <G.csv> <g.csv> [--out-tol 1e-4]
+
+  x.csv : the counterexample input, FLAT in ONNX order (one value per line or CSV).
+  G.csv : the unsafe-region matrix G (rows = constraints, cols = output dim).
+  g.csv : the unsafe-region vector g (one value per line).
+
+Prints one of:
+  VIOLATED max_margin=<m>   -> witness is a TRUE counterexample (all G*y - g <= tol)
+  OK       max_margin=<m>   -> witness does NOT violate (do not emit sat)
+  ERROR    <message>        -> could not validate (treat as not-sat)
+Exit code: 0 VIOLATED, 1 OK, 2 ERROR.
+"""
+
+import sys
+import argparse
+import numpy as np
+
+
+def _load_vec(path):
+    return np.loadtxt(path, delimiter=',').astype(np.float64).ravel()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('onnx')
+    p.add_argument('x_csv')
+    p.add_argument('G_csv')
+    p.add_argument('g_csv')
+    p.add_argument('--out-tol', type=float, default=1e-4)
+    args = p.parse_args()
+
+    try:
+        import onnxruntime as ort
+    except Exception as e:  # pragma: no cover
+        print(f"ERROR onnxruntime import failed: {e}")
+        return 2
+
+    try:
+        # Load everything FLAT (ravel) so the result is robust to how the CSV writer
+        # laid the values out (one-per-line vs comma-separated, scalar vs vector).
+        # G is reshaped to (nrows, outdim) below, once the model's output dim is known.
+        x = _load_vec(args.x_csv).astype(np.float32)
+        G_flat = _load_vec(args.G_csv)
+        g = _load_vec(args.g_csv)
+
+        sess = ort.InferenceSession(args.onnx, providers=['CPUExecutionProvider'])
+        inp = sess.get_inputs()[0]
+        shape = [d if isinstance(d, int) and d > 0 else 1 for d in inp.shape]
+        try:
+            xr = x.reshape(shape)
+        except ValueError:
+            # element count differs from the declared shape (e.g. a symbolic/batch
+            # dim): flatten to a single batch row of the known data size.
+            xr = x.reshape([1, x.size])
+
+        y = np.asarray(sess.run(None, {inp.name: xr})[0]).ravel().astype(np.float64)
+        outdim = y.size
+        if G_flat.size % outdim != 0 or G_flat.size // outdim != g.size:
+            print(f"ERROR G has {G_flat.size} entries, incompatible with "
+                  f"{g.size} constraints x {outdim} outputs")
+            return 2
+        G = G_flat.reshape(g.size, outdim)
+
+        margins = G.dot(y) - g
+        mmax = float(np.max(margins))
+        if np.all(margins <= args.out_tol):
+            print(f"VIOLATED max_margin={mmax:.6e}")
+            return 0
+        print(f"OK max_margin={mmax:.6e}")
+        return 1
+    except Exception as e:
+        print(f"ERROR {e}")
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds the definitive guard against the VNN-COMP **-150 penalty** for an incorrect/non-replayable counterexample (NNV leaked 19 such points in 2025). It validates a SAT witness the way the competition does — by replaying it through **onnxruntime on the original ONNX model** — instead of only re-checking it through NNV's own forward (which a *systematic* import/encoding mismatch would pass).

## Files

- `code/nnv/tools/onnx2nnv_python/onnx_replay_check.py` — replays a FLAT (ONNX-order) witness through the original `.onnx` via onnxruntime; reports `VIOLATED`/`OK`/`ERROR` for the unsafe region `G·y ≤ g` (exit 0/1/2).
- `code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m` — MATLAB wrapper. Returns true only when onnxruntime confirms a violation; returns false (safe) if Python/onnxruntime is unavailable or errors, so the runner degrades to `unknown` rather than emitting a false `sat`.
- `code/nnv/tests/vnncomp25/test_validate_witness_onnx.m` — 4 tests: two always-on fallback-contract tests (missing model / empty `Hs` → false, no error) and two replay tests (export a tiny known-linear net → ONNX, check violated→true / impossible→false) that **skip** when onnxruntime is not importable.

## Two bugs fixed during bring-up

1. Windows' case-insensitive filesystem collapsed the temp `G.csv`/`g.csv` into one file (`g` clobbered `G`), corrupting the unsafe-region matrix → renamed `Gmat.csv`/`gvec.csv`.
2. The Python loader now reshapes `G` against the model's **known output dim** instead of trusting `np.loadtxt`'s parsed rank.

## Scope / sequencing

Self-contained — does **not** touch the runner. Wiring `validate_witness_onnx` into `run_vnncomp_instance.m`'s SAT path is deferred until #306 (which also edits that runner) merges, to avoid a conflict. `VNNCOMP2026_PROGRESS.md` tracks status.

Verified locally on R2026a: 4/4 tests pass (onnxruntime 1.23.1 present); guard returns violated→1, impossible→0, multi-HalfSpace any-violates→1 on acasxu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
