### PR TITLE
ci: reclaim runner disk in ci.yml + regression-tests.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: 'true'
+      - name: Reclaim runner disk space
+        # MATLAB + toolboxes are ~5 GB; ubuntu-latest ships ~14 GB free, which the
+        # Setup MATLAB download can exhaust -> the runner crashes with "No space left
+        # on device" before any test runs. Free ~20-30 GB of preinstalled tooling we
+        # never use so the download is reliable (mirrors test-matrix.yml).
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android \
+                      /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
       # Sets up MATLAB on the GitHub Actions runner
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v3

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -37,6 +37,17 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Reclaim runner disk space
+        # Free ~20-30 GB of preinstalled tooling so the ~5 GB MATLAB toolbox download
+        # can't exhaust the runner disk ("No space left on device"). See test-matrix.yml.
+        run: |
+          echo "Disk before reclaim:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android \
+                      /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after reclaim:"; df -h /
+
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v3
         with:


### PR DESCRIPTION
Applies the disk-reclaim step (already in test-matrix.yml via #306) to the two remaining MATLAB workflows. Both run a single ubuntu-latest job that downloads ~5 GB of MATLAB + toolboxes; on a low-disk runner this exhausts the ~14 GB free space and crashes Setup MATLAB with No space left on device before any test runs. The step frees ~20-30 GB of unused preinstalled tooling (.NET, Android SDK, GHC, Swift, PowerShell, CodeQL, chromium/boost) and prunes Docker images. Pure CI reliability; no source changes. 🤖 Generated with Claude Code