### PR TITLE
fix(vnncomp): build ImageStar by input-layer type, not shape (recover acasxu reach)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -19,13 +19,23 @@ if isempty(inputSize)
     inputSize = net.Layers(1, 1).InputSize;
 end
 
-% Decide the reach input-set type from the NET's input layer (not the input SHAPE):
-% ImageInputLayer/Image3DInputLayer -> ImageStar; flat feature / NN-manifest -> Star.
-% Fixes acasxu (imported as a [1 5 1] ImageInputLayer): the shape heuristic built a
-% Star and every acasxu reach errored ("Input is not an ImageStar").
-useImageStar = isa(net, 'dlnetwork') && ~isempty(net.Layers) && ...
-    (isa(net.Layers(1), 'nnet.cnn.layer.ImageInputLayer') || ...
-     isa(net.Layers(1), 'nnet.cnn.layer.Image3DInputLayer'));
+% Decide the reach input-set type from the NET's input-layer TYPE (not the input
+% SHAPE) whenever the net exposes Layers -- dlnetwork AND SeriesNetwork/DAGNetwork:
+% ImageInputLayer/Image3DInputLayer -> ImageStar; FeatureInputLayer -> Star. Leave
+% [] (unknown) otherwise (e.g. NNV NN manifest nets, sequence inputs) so
+% create_input_set falls back to its shape heuristic. Fixes acasxu (a [1 5 1]
+% ImageInputLayer): the shape heuristic built a Star and every acasxu reach errored
+% ("Input is not an ImageStar"). Using [] for the unknown case (not false) avoids
+% forcing a Star on a non-dlnetwork image net (which would reintroduce that bug).
+useImageStar = [];
+if isprop(net, 'Layers') && ~isempty(net.Layers)
+    L1 = net.Layers(1);
+    if isa(L1, 'nnet.cnn.layer.ImageInputLayer') || isa(L1, 'nnet.cnn.layer.Image3DInputLayer')
+        useImageStar = true;
+    elseif isa(L1, 'nnet.cnn.layer.FeatureInputLayer') || isa(L1, 'nnet.onnx.layer.FeatureInputLayer')
+        useImageStar = false;
+    end
+end
 
 % Load property to verify
 property = load_vnnlib(vnnlib);

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -19,6 +19,14 @@ if isempty(inputSize)
     inputSize = net.Layers(1, 1).InputSize;
 end
 
+% Decide the reach input-set type from the NET's input layer (not the input SHAPE):
+% ImageInputLayer/Image3DInputLayer -> ImageStar; flat feature / NN-manifest -> Star.
+% Fixes acasxu (imported as a [1 5 1] ImageInputLayer): the shape heuristic built a
+% Star and every acasxu reach errored ("Input is not an ImageStar").
+useImageStar = isa(net, 'dlnetwork') && ~isempty(net.Layers) && ...
+    (isa(net.Layers(1), 'nnet.cnn.layer.ImageInputLayer') || ...
+     isa(net.Layers(1), 'nnet.cnn.layer.Image3DInputLayer'));
+
 % Load property to verify
 property = load_vnnlib(vnnlib);
 lb = property.lb; % input lower bounds
@@ -113,7 +121,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
                 
                 reachOptions = reachOptionsList{1};
     
-                IS = create_input_set(lb, ub, inputSize, needReshape);
+                IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar);
 
                 % Compute reachability. Reach may FAIL LOUD by design (layers
                 % refuse to return unsound sets); an error is mapped to
@@ -172,7 +180,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                     reachOptions = reachOptPar{1};
 
-                    IS = create_input_set(lb_spc, ub_spc, inputSize, needReshape);
+                    IS = create_input_set(lb_spc, ub_spc, inputSize, needReshape, useImageStar);
 
                     % Compute reachability
                     if ~strcmp(reachOptions.reachMethod, "cp-star")
@@ -246,7 +254,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                     reachOptions = reachOptPar{1};
 
-                    IS = create_input_set(lb_spc, ub_spc, inputSize, needReshape);
+                    IS = create_input_set(lb_spc, ub_spc, inputSize, needReshape, useImageStar);
 
                     % Compute reachability
                     if ~strcmp(reachOptions.reachMethod, "cp-star")
@@ -338,14 +346,21 @@ end
 
 %% Helper functions
 
-function IS = create_input_set(lb, ub, inputSize, needReshape)
+function IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar)
 
-    % If the network has a flat feature input (scalar inputSize, or
-    % singleton-with-channels), build a Star instead of an ImageStar.
-    % Some downstream NNV layer reach() implementations read Set.dim,
-    % which Star has but ImageStar does not.
-    is_feature_input = isscalar(inputSize) || ...
-        (numel(inputSize) <= 3 && nnz(inputSize > 1) <= 1);
+    % Choose the set type from the NET's input-layer TYPE when the caller knows it
+    % (useImageStar), not from the input SHAPE. A net imported as an ImageInputLayer
+    % (e.g. acasxu, inputSize [1 5 1]) needs an ImageStar even though its spatial dims
+    % are singleton; the old shape-only heuristic built a Star and EVERY acasxu reach
+    % errored ("Input is not an ImageStar"), losing all robust/UNSAT acasxu verdicts.
+    % Star is still used for flat feature / NN-manifest inputs, because some downstream
+    % NNV layer reach() implementations read Set.dim, which Star has but ImageStar lacks.
+    if nargin >= 5 && ~isempty(useImageStar)
+        is_feature_input = ~useImageStar;
+    else
+        is_feature_input = isscalar(inputSize) || ...
+            (numel(inputSize) <= 3 && nnz(inputSize > 1) <= 1);
+    end
     if is_feature_input
         IS = Star(double(lb(:)), double(ub(:)));
         return;


### PR DESCRIPTION
## Problem

`create_input_set` chose Star vs ImageStar from the input **shape**: any net whose `inputSize` had ≤1 non-singleton spatial dim got a `Star`. **acasxu** is imported as an `ImageInputLayer` with `inputSize [1 5 1]` (singleton spatial dims), so it got a `Star` — but its NNV reach expects an `ImageStar`, so **every acasxu reach errored** with `Input is not an ImageStar -> unknown`, losing all robust/UNSAT acasxu verdicts. (acasxu reach worked in 2025; the shape heuristic was a regression.)

## Fix

Decide from the **net's input-layer type** instead of the shape:
- `ImageInputLayer` / `Image3DInputLayer` → `ImageStar`
- flat feature (`FeatureInputLayer`) / NN-manifest → `Star` (kept — some downstream layer `reach()` read `Set.dim`, which `ImageStar` lacks)

Computed once after the net loads (`useImageStar`) and threaded to all three `create_input_set` call sites. `create_input_set` falls back to the old shape heuristic when the flag is absent (backward compatible).

## Validation (R2026a, local MCP)
- acasxu: `layer1 = ImageInputLayer` → `useImageStar=1` → ImageStar; approx-star reach now **runs** (was erroring).
- cora: `layer1 = FeatureInputLayer` → `useImageStar=0` → Star (unchanged — preserves the `Set.dim` case).
- Static-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
