### PR TITLE
feat(vnncomp): gradient PGD on the NN-manifest path (numerical gradient)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
@@ -67,6 +67,13 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
         h = mod(r-1, nH) + 1;                 % steer toward one unsafe set per restart
         [G, g] = halfspace_Gg(Hs(h));
         xn = flat_to_net_arr(seeds{r}, inputSize, needReshape);   % optimize in net space
+        y = forward_eval(net, xn, fmt, is_nn);     % the seed itself may already be a CE
+        for hh = 1:nH                              % (e.g. the ub corner / a random seed);
+            if Hs(hh).contains(y)                  % catch it BEFORE a noisy FGSM/SPSA first
+                cex = {net_arr_to_flat(xn, inputSize, needReshape); y};  % step moves away
+                found = true; return;
+            end
+        end
         for it = 1:n_steps
             if is_nn
                 gnArr = nn_margin_grad(net, xn, G, g, SPn, use_spsa);   % numerical grad

--- a/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/pgd_falsify.m
@@ -18,7 +18,8 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
 %   still validate it with validate_witness() before emitting `sat`.
 %
 %   Inputs:
-%     net          dlnetwork (required for autodiff). Non-dlnetwork -> found=false.
+%     net          dlnetwork (autodiff PGD) OR an NNV NN (numerical-gradient PGD, for
+%                  the Python-importer manifest path). Any other type -> found=false.
 %     lb, ub       input bounds, flat ONNX-order column vectors.
 %     Hs           array of HalfSpace (unsafe region; CE satisfies some Hs(h)).
 %     inputSize    network input size (e.g. [1 784] or [32 32 3]).
@@ -30,7 +31,8 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
 %   Outputs: cex = {x; y} (flat x, output y) on success else {}; found logical.
 
     cex = {}; found = false;
-    if ~isa(net, 'dlnetwork'); return; end
+    is_nn = isa(net, 'NN');                  % NNV NN (manifest path): no autodiff, so
+    if ~(isa(net, 'dlnetwork') || is_nn); return; end  % use numerical-gradient PGD below
     if nargin < 7 || isempty(needReshape), needReshape = 0; end
     if nargin < 8 || isempty(opts), opts = struct(); end
     n_restarts = getfielddef(opts, 'n_restarts', 20);
@@ -44,7 +46,9 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
     lb = double(lb(:)); ub = double(ub(:));
     nIn = numel(lb);
     nsz = net_input_shape(inputSize, needReshape);   % net-input array shape (unpadded)
-    fmt = net_format(net, inputFormat, nsz);         % from the net's input layer
+    if is_nn, fmt = ''; else, fmt = net_format(net, inputFormat, nsz); end  % NN: no dlarray
+    use_spsa = nIn > 60;   % finite-diff costs nIn evals/step; SPSA costs 2 -> use SPSA
+                           % for high-dim image manifest nets, finite-diff for small ones
 
     % Box in the network-input layout (element-wise, since flat->net is a permutation).
     LBn = flat_to_net_arr(lb, inputSize, needReshape);
@@ -64,9 +68,13 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
         [G, g] = halfspace_Gg(Hs(h));
         xn = flat_to_net_arr(seeds{r}, inputSize, needReshape);   % optimize in net space
         for it = 1:n_steps
-            dlx = to_dlarray(xn, fmt);
-            [~, grad] = dlfeval(@loss_and_grad, net, dlx, G, g);
-            gnArr = reshape(double(extractdata(grad)), nsz);      % drop padded batch dim
+            if is_nn
+                gnArr = nn_margin_grad(net, xn, G, g, SPn, use_spsa);   % numerical grad
+            else
+                dlx = to_dlarray(xn, fmt);
+                [~, grad] = dlfeval(@loss_and_grad, net, dlx, G, g);
+                gnArr = reshape(double(extractdata(grad)), nsz);      % drop padded batch dim
+            end
             if use_fgsm && it == 1
                 upd = sign(gnArr);                                % FGSM warm-start
             else
@@ -75,10 +83,10 @@ function [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, nee
             end
             xn = xn - lr .* SPn .* upd;                           % descend the margin
             xn = min(max(xn, LBn), UBn);                          % project into the box
-            y = extractdata(predict(net, to_dlarray(xn, fmt)));
+            y = forward_eval(net, xn, fmt, is_nn);
             for hh = 1:nH
-                if Hs(hh).contains(double(y(:)))
-                    cex = {net_arr_to_flat(xn, inputSize, needReshape); double(y(:))};
+                if Hs(hh).contains(y)
+                    cex = {net_arr_to_flat(xn, inputSize, needReshape); y};
                     found = true; return;
                 end
             end
@@ -127,6 +135,47 @@ end
 
 function [G, g] = halfspace_Gg(H)
     G = H.G; g = H.g;               % NNV HalfSpace: G*x <= g
+end
+
+% ---- NNV NN (manifest-path) forward + numerical gradient (no autodiff) ----
+
+function y = forward_eval(net, xn, fmt, is_nn)
+    if is_nn
+        y = net.evaluate(xn);                              % NNV NN forward
+    else
+        y = extractdata(predict(net, to_dlarray(xn, fmt)));
+    end
+    y = double(y(:));
+end
+
+function gnArr = nn_margin_grad(net, xn, G, g, SPn, use_spsa)
+    % Numerical gradient of the violation margin max(G*evaluate(xn) - g) w.r.t. the
+    % net-input array xn, for NNV NN nets (which have no autodiff). Two estimators:
+    %  - finite difference (nIn forward evals): exact-ish, used for small inputs.
+    %  - SPSA (2 forward evals): a single random +-1 direction, used for high-dim
+    %    image nets so cost stays O(1) per step instead of O(nIn).
+    % Perturbation sizes scale with the per-dim box width SPn (fixed dims, SPn=0, get
+    % a tiny floor; their gradient is never applied since the update multiplies by SPn).
+    if use_spsa
+        delta = sign(rand(size(xn)) - 0.5); delta(delta == 0) = 1;
+        c = max(1e-5, 1e-2 .* SPn);
+        mp = nn_margin(net, xn + c .* delta, G, g);
+        mm = nn_margin(net, xn - c .* delta, G, g);
+        gnArr = ((mp - mm) / 2) .* (delta ./ c);
+    else
+        m0 = nn_margin(net, xn, G, g);
+        gnArr = zeros(size(xn));
+        hstep = max(1e-6, 1e-3 .* SPn);
+        for d = 1:numel(xn)
+            xp = xn; xp(d) = xn(d) + hstep(d);
+            gnArr(d) = (nn_margin(net, xp, G, g) - m0) / hstep(d);
+        end
+    end
+end
+
+function m = nn_margin(net, xn, G, g)
+    y = double(reshape(net.evaluate(xn), [], 1));
+    m = max(G * y - g(:));          % unsafe set {y : G*y <= g}; minimize the worst margin
 end
 
 % ---- flat-ONNX <-> network-input layout (mirrors run_vnncomp_instance) ----

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -1067,10 +1067,13 @@ function counterEx = falsify_single(net, lb, ub, inputSize, nRand, Hs, needResha
     % Gradient-directed falsification FIRST (FGSM warm-start + PGD). pgd_falsify maps
     % the flat input to the network-input layout with the SAME reshape+permute the
     % runner uses (needReshape), so it works for image/permuted inputs too. NNV found
-    % 354 SAT vs ~1000 for the field in 2025; this targets that gap. Gated to dlnetwork,
-    % wrapped in try/catch, and VALIDATED before acceptance, so it can only ADD a sound
-    % SAT or fall through to the existing random sampling. [VNNCOMP2026_STRATEGY Pillar 1/2]
-    if isa(net, 'dlnetwork')
+    % 354 SAT vs ~1000 for the field in 2025; this targets that gap. dlnetwork nets use
+    % autodiff; NNV NN nets (the Python-importer manifest path, e.g. traffic_signs --
+    % all-SAT in 2025 -- and lsnc_relu) use a numerical gradient inside pgd_falsify, so
+    % they too get gradient falsification instead of random sampling alone. Wrapped in
+    % try/catch and VALIDATED before acceptance, so it can only ADD a sound SAT or fall
+    % through to the existing random sampling. [VNNCOMP2026_STRATEGY Pillar 1/2]
+    if isa(net, 'dlnetwork') || isa(net, 'NN')
         try
             [cex, found] = pgd_falsify(net, lb, ub, Hs, inputSize, inputFormat, needReshape, opts);
             if found && validate_witness(net, cex{1}, lb, ub, Hs, inputSize, inputFormat, needReshape)

--- a/code/nnv/tests/vnncomp25/test_pgd_falsify.m
+++ b/code/nnv/tests/vnncomp25/test_pgd_falsify.m
@@ -21,6 +21,11 @@ classdef test_pgd_falsify < matlab.unittest.TestCase
                        fullyConnectedLayer(1, 'Name', 'fc', 'Weights', [1 10], 'Bias', 0) ];
             net = dlnetwork(layers);
         end
+        function net = sum64_net()                   % y = sum(x), 64 inputs (>60 -> SPSA)
+            layers = [ featureInputLayer(64, 'Name', 'in')
+                       fullyConnectedLayer(1, 'Name', 'fc', 'Weights', ones(1,64), 'Bias', 0) ];
+            net = dlnetwork(layers);
+        end
     end
 
     methods (Test)
@@ -81,6 +86,39 @@ classdef test_pgd_falsify < matlab.unittest.TestCase
             Hs = HalfSpace(-1, -1.5);
             [~, found] = pgd_falsify("not a dlnetwork", [0;0], [1;1], Hs, 2, 'CB', 0, struct());
             testCase.verifyFalse(found);
+        end
+
+        % ---- NN-manifest path: numerical-gradient PGD (no autodiff) ----
+
+        function test_pgd_nn_finds_ce(testCase)
+            % matlab2nnv -> NNV NN (the manifest path's net type); pgd_falsify must use
+            % the finite-difference numerical gradient (nIn=2 <= 60) to find the CE.
+            net = matlab2nnv(test_pgd_falsify.linsum_net());   % y = x1 + x2 as an NNV NN
+            lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -1.5);  % unsafe y >= 1.5
+            opts = struct('seed', 0, 'n_restarts', 12, 'n_steps', 30, 'lr', 0.2);
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, 2, 'default', 0, opts);
+            testCase.verifyTrue(found, 'numerical PGD should find a CE for y>=1.5 on an NN net');
+            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, 2, 'default', 0), ...
+                'NN-found witness must validate');
+        end
+
+        function test_pgd_nn_no_ce(testCase)
+            net = matlab2nnv(test_pgd_falsify.linsum_net());
+            lb = [0;0]; ub = [1;1]; Hs = HalfSpace(-1, -100);  % unsafe y >= 100: impossible
+            opts = struct('seed', 0, 'n_restarts', 8, 'n_steps', 30);
+            [~, found] = pgd_falsify(net, lb, ub, Hs, 2, 'default', 0, opts);
+            testCase.verifyFalse(found, 'no CE exists for y>=100 on [0,1]^2');
+        end
+
+        function test_pgd_nn_spsa_highdim(testCase)
+            % >60 inputs triggers the SPSA estimator (2 evals/step). y = sum(x); unsafe
+            % y >= 50 on [0,1]^64 is satisfiable (x=1 -> y=64), so SPSA must climb to it.
+            net = matlab2nnv(test_pgd_falsify.sum64_net());
+            lb = zeros(64,1); ub = ones(64,1); Hs = HalfSpace(-1, -50);
+            opts = struct('seed', 0, 'n_restarts', 6, 'n_steps', 60, 'lr', 0.3);
+            [cex, found] = pgd_falsify(net, lb, ub, Hs, 64, 'default', 0, opts);
+            testCase.verifyTrue(found, 'SPSA numerical PGD should find a CE for sum(x)>=50 on [0,1]^64');
+            testCase.verifyTrue(validate_witness(net, cex{1}, lb, ub, Hs, 64, 'default', 0));
         end
 
     end


### PR DESCRIPTION
## What

`pgd_falsify` was dlnetwork-only (autodiff), so the Python-importer **manifest** nets (lsnc_relu, traffic_signs) got **no gradient falsification** — only random sampling. This adds a numerical-gradient branch for NNV `NN` nets:
- **finite difference** (`nIn` forward evals) for small inputs;
- **SPSA** (2 forward evals/step) for high-dim image nets (`nIn > 60`), so per-step cost stays O(1) instead of O(`nIn`).

Both reuse the existing needReshape-aware flat↔net mapping. Soundness unchanged — every candidate still passes `validate_witness` before acceptance. `falsify_single` now runs `pgd_falsify` for `isa(net,'NN')` too.

## Measured
- **lsnc_relu** (ReLU manifest net): **unknown → SAT in 1.06s** — gradient PGD found a validated counterexample that random sampling alone missed. The headline win.
- **traffic_signs** is a **binarized (Sign)** model: Sign has ~zero gradient almost everywhere, so gradient falsification (any kind) is ineffective there; it correctly falls through to the existing random sampling (no help, but no regression).

## Tests
`test_pgd_falsify`: +3 NN-branch tests (finite-diff find/no-CE + SPSA high-dim). **9/9 pass**; the dlnetwork path is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
