### PR TITLE
feat(vnncomp): wire onnxruntime SAT-witness guard into the runner (Pillar 2 -150 closer)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -113,8 +113,12 @@ if iscell(counterEx)
     % is AVAILABLE and definitively says the witness violates NOTHING, downgrade to
     % `unknown` rather than risk a -150. If onnxruntime is UNAVAILABLE (not installed, or
     % a replay error), TRUST validate_witness and keep `sat` -- never suppress a SAT we
-    % cannot disprove. Single-output spec only (prop{1}.Hg is the region the witness hit).
-    if ~isa(lb, "cell") && length(prop) == 1
+    % cannot disprove. Single-output-spec instances only (length(prop)==1) -- covers
+    % BOTH the non-cell and the cell-lb (multiple input sets, single output spec) SAT
+    % search paths above, which both falsify against prop{1}.Hg, the region the witness
+    % hit. (Multi-output-spec instances aren't gated: which spec the witness hit isn't
+    % tracked here; they still pass validate_witness.)
+    if length(prop) == 1
         try
             [orVio, orAvail] = validate_witness_onnx(onnx, counterEx{1}, prop{1}.Hg);
             if orAvail && ~orVio

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -104,6 +104,27 @@ cEX_time = toc(t);
 % Check if property was violated earlier
 if iscell(counterEx)
     status = 0;
+
+    % Pillar-2 final gate: replay the SAT witness through onnxruntime on the ORIGINAL
+    % ONNX model (the competition's own checker) before committing to `sat`. A witness
+    % that NNV's self-consistent validate_witness accepts could still fail the
+    % competition if NNV's import permutes the input differently than the ONNX expects
+    % (the suspected source of several of the 19 -150 penalties in 2025). If onnxruntime
+    % is AVAILABLE and definitively says the witness violates NOTHING, downgrade to
+    % `unknown` rather than risk a -150. If onnxruntime is UNAVAILABLE (not installed, or
+    % a replay error), TRUST validate_witness and keep `sat` -- never suppress a SAT we
+    % cannot disprove. Single-output spec only (prop{1}.Hg is the region the witness hit).
+    if ~isa(lb, "cell") && length(prop) == 1
+        try
+            [orVio, orAvail] = validate_witness_onnx(onnx, counterEx{1}, prop{1}.Hg);
+            if orAvail && ~orVio
+                fprintf('onnxruntime replay rejected the SAT witness -> unknown\n');
+                status = 2; counterEx = nan;
+            end
+        catch
+            % onnx guard could not run -> trust validate_witness, keep sat
+        end
+    end
 end
 
 vT = tic;

--- a/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
@@ -6,7 +6,9 @@ function [ok, available] = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
 %   actual check, so unlike validate_witness (which replays through NNV's own
 %   forward) it also catches a SYSTEMATIC import/encoding mismatch -- the likely
 %   source of several of NNV's 19 incorrect/missing-CE (-150) penalties in 2025.
-%   Use it as the final gate before emitting `sat`; emit `unknown` if it returns false.
+%   Use it as the final gate before emitting `sat`: downgrade to `unknown` ONLY when
+%   `~ok && available` (onnxruntime ran and definitively found no violation); if
+%   `~available` (onnxruntime unavailable / replay error), trust validate_witness.
 %   See VNNCOMP2026_STRATEGY.md / VNNCOMP2026_PROGRESS.md (Pillar 2).
 %
 %   onnx_path : path to the ORIGINAL .onnx model.
@@ -15,12 +17,12 @@ function [ok, available] = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
 %   out_tol   : output-constraint slack (default 1e-4).
 %
 %   ok        : true only if onnxruntime confirms the witness violates some Hs(h).
-%   available : true only if onnxruntime actually RAN and returned a clean verdict
-%               (VIOLATED/OK) for EVERY Hs. So `ok=false & available=true` means
-%               onnxruntime definitively says the witness violates NOTHING (the caller
-%               may downgrade `sat`->`unknown`). `available=false` means we could not
-%               check (Python/onnxruntime/model missing, or a replay ERROR) -> the
-%               caller must TRUST validate_witness and NOT suppress the sat.
+%   available : true means the `ok` result is DEFINITIVE -- either a VIOLATED was found
+%               (early return, ok=true), or EVERY Hs returned a clean OK (ok=false). So
+%               `~ok && available` means onnxruntime definitively says the witness
+%               violates NOTHING (the caller downgrades `sat`->`unknown`). available=false
+%               means we could not check (Python/onnxruntime/model missing, or a replay
+%               ERROR) -> the caller must TRUST validate_witness and NOT suppress the sat.
 
     if nargin < 4 || isempty(out_tol), out_tol = 1e-4; end
     ok = false; available = false;

--- a/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/validate_witness_onnx.m
@@ -1,4 +1,4 @@
-function ok = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
+function [ok, available] = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
 %VALIDATE_WITNESS_ONNX  Definitive SAT-witness guard: replay through onnxruntime.
 %   Replays the FLAT (ONNX-order) witness through the ORIGINAL ONNX model via
 %   onnxruntime (tools/onnx2nnv_python/onnx_replay_check.py) and confirms the output
@@ -14,11 +14,16 @@ function ok = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
 %   Hs        : array of HalfSpace (unsafe output region).
 %   out_tol   : output-constraint slack (default 1e-4).
 %
-%   ok : true only if onnxruntime confirms the witness violates some Hs(h).
-%   Returns false (safe) if Python/onnxruntime is unavailable or errors.
+%   ok        : true only if onnxruntime confirms the witness violates some Hs(h).
+%   available : true only if onnxruntime actually RAN and returned a clean verdict
+%               (VIOLATED/OK) for EVERY Hs. So `ok=false & available=true` means
+%               onnxruntime definitively says the witness violates NOTHING (the caller
+%               may downgrade `sat`->`unknown`). `available=false` means we could not
+%               check (Python/onnxruntime/model missing, or a replay ERROR) -> the
+%               caller must TRUST validate_witness and NOT suppress the sat.
 
     if nargin < 4 || isempty(out_tol), out_tol = 1e-4; end
-    ok = false;
+    ok = false; available = false;
 
     script = fullfile(nnvroot(), 'code', 'nnv', 'tools', 'onnx2nnv_python', 'onnx_replay_check.py');
     if ~isfile(script) || ~isfile(char(onnx_path))
@@ -34,17 +39,21 @@ function ok = validate_witness_onnx(onnx_path, x_flat, Hs, out_tol)
     % so "G.csv" and "g.csv" would be the same file and the second write clobbers the
     % first (g would overwrite G), corrupting the unsafe-region matrix.
     py = python_exe();
-    for h = 1:numel(Hs)
+    all_clean = ~isempty(Hs);       % a "definitively non-violating" verdict needs >=1
+    for h = 1:numel(Hs)             % Hs that onnxruntime cleanly checked
         Gf = fullfile(td, 'Gmat.csv'); gf = fullfile(td, 'gvec.csv');
         writematrix(double(Hs(h).G), Gf);
         writematrix(double(Hs(h).g(:)), gf);
         cmd = sprintf('%s "%s" "%s" "%s" "%s" "%s" --out-tol %g', ...
             py, script, char(onnx_path), xf, Gf, gf, out_tol);
-        [st, out] = system(cmd);
-        if st == 0 && contains(out, 'VIOLATED')
-            ok = true; return;
+        [st, out] = system(cmd); %#ok<ASGLU>
+        if contains(out, 'VIOLATED')        % onnxruntime confirms a real counterexample
+            ok = true; available = true; return;
+        elseif ~contains(out, 'OK ')        % ERROR / python-missing -> cannot trust this
+            all_clean = false;              % Hs (a clean non-violation prints "OK ...")
         end
     end
+    available = all_clean;          % every Hs returned a clean OK -> confirmed non-CE
 end
 
 function py = python_exe()

--- a/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
+++ b/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
@@ -19,8 +19,9 @@ function test_missing_onnx_returns_false(tc)
     % A non-existent model path must yield false (safe), not an error.
     bogus = fullfile(tempdir, 'definitely_not_a_real_model_xyz.onnx');
     if isfile(bogus), delete(bogus); end
-    ok = validate_witness_onnx(bogus, [0; 0], HalfSpace([1 0], 0));
+    [ok, available] = validate_witness_onnx(bogus, [0; 0], HalfSpace([1 0], 0));
     verifyFalse(tc, ok);
+    verifyFalse(tc, available, 'missing model -> unavailable, so the runner trusts validate_witness (keeps sat)');
 end
 
 function test_empty_halfspace_array_returns_false(tc)
@@ -42,12 +43,16 @@ function test_violated_true_and_impossible_false(tc)
     [onnx, cleanup] = exportTinyLinearOnnx();  %#ok<ASGLU> keep cleanup alive
     % Net is y = 1*x1 + 2*x2 (single output). For x=[1;1], y=3.
     x = [1; 1];
-    % Unsafe set {y : y <= 10} -> 3 <= 10 -> VIOLATED -> true.
-    ok_v = validate_witness_onnx(onnx, x, HalfSpace(1, 10));
+    % Unsafe set {y : y <= 10} -> 3 <= 10 -> VIOLATED -> ok=true, available=true.
+    [ok_v, av_v] = validate_witness_onnx(onnx, x, HalfSpace(1, 10));
     verifyTrue(tc, ok_v, 'witness y=3 should violate {y <= 10}');
-    % Unsafe set {y : y <= -10} -> impossible for y=3 -> OK -> false.
-    ok_i = validate_witness_onnx(onnx, x, HalfSpace(1, -10));
+    verifyTrue(tc, av_v, 'a clean VIOLATED verdict is available');
+    % Unsafe set {y : y <= -10} -> impossible for y=3 -> OK -> ok=false, available=TRUE.
+    % available=true + ok=false is the DOWNGRADE case: onnxruntime definitively says the
+    % witness violates nothing, so the runner emits `unknown` instead of a wrong `sat`.
+    [ok_i, av_i] = validate_witness_onnx(onnx, x, HalfSpace(1, -10));
     verifyFalse(tc, ok_i, 'witness y=3 must NOT be accepted for {y <= -10}');
+    verifyTrue(tc, av_i, 'a clean OK (non-violation) verdict is available -> caller downgrades');
 end
 
 function test_multi_halfspace_any_violates(tc)


### PR DESCRIPTION
## What

Wires the onnxruntime SAT-witness guard (built in #307 as a standalone tool) into `run_vnncomp_instance`'s SAT path — **the −150 closer** (Pillar 2). Before emitting `sat`, the witness is replayed through **onnxruntime on the original ONNX** (the competition's own checker); a `sat` is downgraded to `unknown` only when onnxruntime *definitively* says the witness violates nothing — catching a systematic import/encoding mismatch that NNV's self-consistent `validate_witness` cannot.

## Safe by construction (3-state)

`validate_witness_onnx` now returns `[ok, available]`:
- `available = true` only if onnxruntime **ran** and returned a clean verdict (VIOLATED/OK) for **every** Hs.
- The runner downgrades **only when `available && ~ok`**.
- If onnxruntime is unavailable (not installed / replay error → `available = false`), it **trusts `validate_witness` and keeps `sat`** — so it never suppresses a SAT it cannot disprove.

Single-output spec only (the common case). Cost: ~1.5s onnxruntime replay **per SAT verdict** (SAT-only, not per instance).

## Validation
- **lsnc_relu stays SAT** — its cross-validated witness replays as VIOLATED, so the gate keeps it.
- 3-state guard: `violated=[ok=1,avail=1]`, `nonviol=[ok=0,avail=1]` (downgrade case), `missing=[ok=0,avail=0]` (trust validate_witness).
- 4/4 `test_validate_witness_onnx` pass (now asserting `available`); static-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
