### PR TITLE
ci(sweep): full per-instance matrix cloud sweep + VNN-COMP 2025 comparison tooling

### DIFF
--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -1,13 +1,12 @@
-name: VNN-COMP sweep (cloud)
+name: VNN-COMP sweep (cloud, matrix)
 
-# On-demand cloud sweep of the VNN-COMP 2025 benchmarks on a free GitHub-hosted
-# runner (public repo -> matlab-actions auto-licenses all toolboxes). Clones the
-# benchmark repo, runs run_all_benchmarks at a chosen per-instance timeout (with
-# optional epsilon-shrink + folder filter), and uploads the results CSV/MD.
-#
-# This is the cloud counterpart to the local sweep documented in VNNCOMP2025_STATUS.md.
-# Defaults to the official VNN-COMP 2025 benchmark repo (github.com/VNN-COMP/vnncomp2025_benchmarks,
-# branch main); point benchmarks_repo/ref at vnncomp2026_benchmarks for the 2026 set.
+# On-demand FULL cloud sweep of the VNN-COMP benchmarks: one parallel job PER
+# benchmark (so each gets its own ~6 h budget, like the competition), each running
+# ALL resolvable instances (run_which=all) of its benchmark via run_all_benchmarks.
+# An aggregate job combines the per-benchmark CSVs and (optionally) compares to the
+# official VNN-COMP 2025 results. Free GitHub-hosted runners (public repo ->
+# matlab-actions auto-licenses all toolboxes). Per-benchmark sparse-checkout keeps the
+# clone small. Defaults to the official 2025 benchmark repo.
 
 on:
   workflow_dispatch:
@@ -28,43 +27,86 @@ on:
         description: "Per-instance wall-clock timeout (s)"
         type: string
         default: "120"
-      eps_shrink:
-        description: "Optional epsilon shrink fraction in (0,1) for a tractability smoke test (blank = full epsilon)"
+      run_which:
+        description: "Instances per benchmark: 'all' (full set) or 'first' (one representative)"
         type: string
-        default: ""
-      folders:
-        description: "Optional comma-separated benchmark folder filter (blank = all)"
+        default: "all"
+      eps_shrink:
+        description: "Optional epsilon shrink in (0,1) for a tractability smoke test (blank = full epsilon)"
         type: string
         default: ""
       release:
         description: "MATLAB release"
         type: string
         default: "R2026a"
+      compare_2025:
+        description: "Aggregate: clone vnncomp2025_results and compare NNV vs 2025 + other tools"
+        type: boolean
+        default: true
 
 concurrency:
   group: vnncomp-sweep-${{ github.ref }}
   cancel-in-progress: false
 
 env:
-  # Opt JS actions into Node 24 ahead of GitHub's 2026-06-16 forced flip.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
     timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        folder:
+          - acasxu_2023
+          - cctsdb_yolo_2023
+          - cersyve
+          - cgan_2023
+          - cifar100_2024
+          - collins_aerospace_benchmark
+          - collins_rul_cnn_2022
+          - cora_2024
+          - dist_shift_2023
+          - linearizenn_2024
+          - lsnc_relu
+          - malbeware
+          - metaroom_2023
+          - ml4acopf_2024
+          - nn4sys
+          - relusplitter
+          - safenlp_2024
+          - sat_relu
+          - soundnessbench
+          - tinyimagenet_2024
+          - tllverifybench_2023
+          - traffic_signs_recognition_2023
+          - vggnet16_2022
+          - vit_2023
+          - yolo_2023
     steps:
       - name: Checkout NNV
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Clone VNN-COMP benchmarks (shallow)
+      - name: Reclaim runner disk space
         run: |
-          git clone --depth 1 --branch "${{ github.event.inputs.benchmarks_ref }}" \
+          echo "Disk before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/lib/android \
+                      /usr/share/swift /usr/local/share/powershell \
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/chromium /usr/local/share/boost || true
+          sudo docker image prune --all --force >/dev/null 2>&1 || true
+          echo "Disk after:"; df -h /
+
+      - name: Clone this benchmark only (sparse, shallow)
+        run: |
+          git clone --depth 1 --filter=blob:none --sparse \
+            --branch "${{ github.event.inputs.benchmarks_ref }}" \
             "${{ github.event.inputs.benchmarks_repo }}" vnncomp2025_benchmarks
-          echo "Benchmarks at: $(pwd)/vnncomp2025_benchmarks/${{ github.event.inputs.benchmarks_subdir }}"
-          ls -1 "vnncomp2025_benchmarks/${{ github.event.inputs.benchmarks_subdir }}" | head -40
+          cd vnncomp2025_benchmarks
+          git sparse-checkout set "${{ github.event.inputs.benchmarks_subdir }}/${{ matrix.folder }}"
+          echo "Files for ${{ matrix.folder }}:"; ls -1 "${{ github.event.inputs.benchmarks_subdir }}/${{ matrix.folder }}" | head
 
       - name: Setup MATLAB
         uses: matlab-actions/setup-matlab@v3
@@ -93,7 +135,7 @@ jobs:
           restore-keys: |
             nnv-tbxmanager-${{ runner.os }}-
 
-      - name: Run VNN-COMP sweep
+      - name: Run sweep for ${{ matrix.folder }} (all instances)
         uses: matlab-actions/run-command@v2
         timeout-minutes: 330
         with:
@@ -103,13 +145,8 @@ jobs:
             bench = fullfile(getenv('GITHUB_WORKSPACE'), 'vnncomp2025_benchmarks', '${{ github.event.inputs.benchmarks_subdir }}');
             to = str2double('${{ github.event.inputs.timeout_s }}'); if isnan(to), to = 120; end
             es = '${{ github.event.inputs.eps_shrink }}'; if ~isempty(es), setenv('NNV_EPS_SHRINK', es); end
-            ff = '${{ github.event.inputs.folders }}';
-            if isempty(strtrim(ff))
-                run_all_benchmarks(bench, to);
-            else
-                only = strtrim(split(string(ff), ','));
-                run_all_benchmarks(bench, to, cellstr(only));
-            end
+            rw = '${{ github.event.inputs.run_which }}'; if isempty(rw), rw = 'all'; end
+            run_all_benchmarks(bench, to, {'${{ matrix.folder }}'}, rw);
 
       - name: Save NNV tbxmanager cache (only a COMPLETE install, only on a miss)
         if: always() && steps.tbxcache.outputs.cache-hit != 'true' && hashFiles('code/nnv/tbxmanager/toolboxes/sedumi/**') != ''
@@ -118,10 +155,53 @@ jobs:
           path: code/nnv/tbxmanager
           key: nnv-tbxmanager-${{ runner.os }}-${{ hashFiles('code/nnv/install.m') }}
 
-      - name: Upload sweep results
+      - name: Upload ${{ matrix.folder }} results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vnncomp-sweep-results
-          path: code/nnv/examples/Submission/VNN_COMP2025/results_*.{csv,md}
+          name: sweep-${{ matrix.folder }}
+          path: code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
+          if-no-files-found: warn
+
+  aggregate:
+    needs: sweep
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: sweep-artifacts
+          pattern: sweep-*
+          merge-multiple: true
+      - name: Combine per-benchmark CSVs
+        run: |
+          out=results_all.csv
+          echo "subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message" > "$out"
+          find sweep-artifacts -name 'results_*.csv' -exec sh -c 'tail -n +2 "$1"' _ {} \; >> "$out"
+          echo "Combined $(($(wc -l < "$out") - 1)) instance rows."
+          python3 nnv/code/nnv/tools/vnncomp_compare/summarize_sweep.py "$out" > sweep_summary.md || \
+            python3 code/nnv/tools/vnncomp_compare/summarize_sweep.py "$out" > sweep_summary.md || \
+            echo "(summarizer not found on this checkout path)" > sweep_summary.md
+          cat sweep_summary.md
+      - name: Compare to VNN-COMP 2025 results + other tools
+        if: ${{ github.event.inputs.compare_2025 == 'true' }}
+        continue-on-error: true
+        run: |
+          git clone --depth 1 https://github.com/VNN-COMP/vnncomp2025_results.git vnncomp2025_results || \
+            git clone --depth 1 https://github.com/ChristopherBrix/vnncomp2025_results.git vnncomp2025_results || true
+          SCRIPT=code/nnv/tools/vnncomp_compare/compare_to_2025.py
+          [ -f "$SCRIPT" ] || SCRIPT=nnv/code/nnv/tools/vnncomp_compare/compare_to_2025.py
+          python3 "$SCRIPT" --new results_all.csv --results2025 vnncomp2025_results > comparison_2025.md 2>&1 || \
+            echo "comparison script failed (see log)" > comparison_2025.md
+          cat comparison_2025.md
+      - name: Upload aggregated results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: vnncomp-sweep-aggregate
+          path: |
+            results_all.csv
+            sweep_summary.md
+            comparison_2025.md
           if-no-files-found: warn

--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -135,7 +135,7 @@ jobs:
           restore-keys: |
             nnv-tbxmanager-${{ runner.os }}-
 
-      - name: Run sweep for ${{ matrix.folder }} (all instances)
+      - name: Run sweep for ${{ matrix.folder }} (run_which=${{ github.event.inputs.run_which }})
         uses: matlab-actions/run-command@v2
         timeout-minutes: 330
         with:

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -163,6 +163,7 @@ for i = 1:n
             ternary(~isempty(err), [': ' err(1:min(120,end))], ''));
         row = {sub, cat, pr.onnx_rel, pr.vnnlib_rel, status, status_str, time_s, err};
         results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
+        if exist(out_file, 'file'), delete(out_file); end   % avoid leaving 1000s of temp .txt
     end
 end
 
@@ -256,7 +257,7 @@ for i = 1:n
     s = matlab.lang.makeValidName(char(results{i,6}));
     if isfield(counts, s), counts.(s) = counts.(s)+1; else, counts.other = counts.other+1; end
 end
-fprintf(fid, '## Tally (one representative instance per benchmark folder)\n\n');
+fprintf(fid, '## Tally (per recorded instance)\n\n');
 fprintf(fid, '| outcome | count |\n|---|---|\n');
 flds = fieldnames(counts);
 for i = 1:numel(flds)

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -40,6 +40,14 @@ if nargin >= 3 && ~isempty(varargin{3})
 else
     only_folders = {};
 end
+% Optional 4th arg: 'first' (one representative instance per folder, default) or
+% 'all' (every resolvable instance in instances.csv -- the full competition set,
+% needed for a true per-instance comparison to the VNN-COMP 2025 results).
+if nargin >= 4 && ~isempty(varargin{4})
+    run_which = lower(char(string(varargin{4})));
+else
+    run_which = 'first';
+end
 
 if ~isfolder(bench_root)
     error('Benchmark root not found: %s', bench_root);
@@ -95,7 +103,7 @@ md_path  = fullfile(script_dir, sprintf('results_%s.md', ts));
 fid = fopen(csv_path, 'w');
 fprintf(fid, 'subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message\n');
 
-results = cell(n, 8);
+results = cell(0, 8);   % grows per instance (all-instances mode -> count unknown up front)
 
 % --- Use Processes pool with 1 worker for clean timeouts and real error msgs ---
 existing_pool = gcp('nocreate');
@@ -112,54 +120,50 @@ for i = 1:n
     end
     fprintf('\n[%2d/%d] %s -> dispatcher category "%s"\n', i, n, sub, cat);
 
-    % Pick first instance from instances.csv
     inst_csv = fullfile(bench_root, sub, 'instances.csv');
     if ~isfile(inst_csv)
-        results(i,:) = {sub, cat, '', '', -2, 'no_instances_csv', 0, ''};
+        row = {sub, cat, '', '', -2, 'no_instances_csv', 0, ''};
+        results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
         fprintf('  -> no instances.csv\n');
-        write_row(fid, results(i,:));
         continue;
     end
-    pair = pick_first_instance(inst_csv, bench_root, sub);
-    if isempty(pair)
-        results(i,:) = {sub, cat, '', '', -2, 'no_resolvable_instance', 0, ''};
+    pairs = pick_instances(inst_csv, bench_root, sub, run_which);
+    if isempty(pairs)
+        row = {sub, cat, '', '', -2, 'no_resolvable_instance', 0, ''};
+        results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
         fprintf('  -> no resolvable instance in CSV\n');
-        write_row(fid, results(i,:));
         continue;
     end
-    onnx_rel   = pair.onnx_rel;
-    vnnlib_rel = pair.vnnlib_rel;
-    onnx       = pair.onnx;
-    vnnlib     = pair.vnnlib;
-    fprintf('  onnx:   %s\n  vnnlib: %s\n', onnx, vnnlib);
-
-    out_file = [tempname '.txt'];
-    t0 = tic;
-    f = parfeval(pool, @run_vnncomp_instance, 2, cat, onnx, vnnlib, out_file);
-    ok = wait(f, 'finished', timeout_s);
-    if ok
-        if isempty(f.Error)
-            try
-                [status, ~] = fetchOutputs(f);
-                status_str = status_to_str(status);
-                err = '';
-            catch ME
-                status = -1; status_str = 'error'; err = ME.message;
+    fprintf('  %d instance(s) [%s]\n', numel(pairs), run_which);
+    for k = 1:numel(pairs)
+        pr = pairs{k};
+        out_file = [tempname '.txt'];
+        t0 = tic;
+        f = parfeval(pool, @run_vnncomp_instance, 2, cat, pr.onnx, pr.vnnlib, out_file);
+        ok = wait(f, 'finished', timeout_s);
+        if ok
+            if isempty(f.Error)
+                try
+                    [status, ~] = fetchOutputs(f);
+                    status_str = status_to_str(status);
+                    err = '';
+                catch ME
+                    status = -1; status_str = 'error'; err = ME.message;
+                end
+            else
+                status = -1; status_str = 'error'; err = f.Error.message;
             end
         else
-            status = -1; status_str = 'error'; err = f.Error.message;
+            cancel(f);
+            status = -1; status_str = 'timeout';
+            err = sprintf('exceeded %d s', timeout_s);
         end
-    else
-        cancel(f);
-        status = -1; status_str = 'timeout';
-        err = sprintf('exceeded %d s', timeout_s);
+        time_s = toc(t0);
+        fprintf('  [%d/%d] %s -> %s (%.1f s)%s\n', k, numel(pairs), pr.onnx_rel, status_str, time_s, ...
+            ternary(~isempty(err), [': ' err(1:min(120,end))], ''));
+        row = {sub, cat, pr.onnx_rel, pr.vnnlib_rel, status, status_str, time_s, err};
+        results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
     end
-    time_s = toc(t0);
-    fprintf('  -> %s (%.1f s)%s\n', status_str, time_s, ...
-        ternary(~isempty(err), [': ' err(1:min(160,end))], ''));
-
-    results(i,:) = {sub, cat, onnx_rel, vnnlib_rel, status, status_str, time_s, err};
-    write_row(fid, results(i,:));
 end
 
 fclose(fid);
@@ -174,24 +178,23 @@ end
 
 %% --- Helpers ---
 
-function pair = pick_first_instance(inst_csv, bench_root, sub)
-% Read instances.csv (3 cols: onnx_rel, vnnlib_rel, timeout_s),
-% find the first row whose ONNX and VNNLIB resolve (decompressing .gz on
-% demand). Returns struct with onnx_rel, vnnlib_rel, onnx, vnnlib.
-pair = [];
+function pairs = pick_instances(inst_csv, bench_root, sub, run_which)
+% Read instances.csv (3 cols: onnx_rel, vnnlib_rel, timeout_s) and return a cell
+% array of resolvable {onnx_rel, vnnlib_rel, onnx, vnnlib} structs (decompressing
+% .gz on demand). run_which='first' returns the first resolvable instance; 'all'
+% returns EVERY resolvable instance (the full competition set for that benchmark).
+pairs = {};
 T = readtable(inst_csv, 'Delimiter', ',', 'ReadVariableNames', false, ...
     'TextType', 'string', 'Format', '%s%s%s');
 for r = 1:height(T)
     onnx_rel   = strrep(strtrim(char(T{r,1})), './', '');
     vnnlib_rel = strrep(strtrim(char(T{r,2})), './', '');
-    onnx_p   = fullfile(bench_root, sub, onnx_rel);
-    vnnlib_p = fullfile(bench_root, sub, vnnlib_rel);
-    onnx_p   = ensure_decompressed(onnx_p);
-    vnnlib_p = ensure_decompressed(vnnlib_p);
+    onnx_p   = ensure_decompressed(fullfile(bench_root, sub, onnx_rel));
+    vnnlib_p = ensure_decompressed(fullfile(bench_root, sub, vnnlib_rel));
     if ~isempty(onnx_p) && ~isempty(vnnlib_p)
-        pair = struct('onnx_rel', onnx_rel, 'vnnlib_rel', vnnlib_rel, ...
-            'onnx', onnx_p, 'vnnlib', vnnlib_p);
-        return;
+        pairs{end+1} = struct('onnx_rel', onnx_rel, 'vnnlib_rel', vnnlib_rel, ...
+            'onnx', onnx_p, 'vnnlib', vnnlib_p); %#ok<AGROW>
+        if strcmp(run_which, 'first'), return; end
     end
 end
 end

--- a/code/nnv/tools/vnncomp_compare/compare_to_2025.py
+++ b/code/nnv/tools/vnncomp_compare/compare_to_2025.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""compare_to_2025.py -- compare NNV's fresh sweep to the official VNN-COMP 2025
-results (NNV's own 2025 line + the other tools), per benchmark.
+"""compare_to_2025.py -- put NNV's fresh sweep next to the official VNN-COMP 2025
+results for context.
 
-The VNN-COMP results repo layout has varied year to year, so this script DISCOVERS the
-structure (any *.csv it can find) rather than hard-coding it, identifies NNV's 2025
-per-instance verdicts and the other tools' verdicts heuristically, and reports:
-  1. NNV NEW (this sweep) solved/sat/unsat per benchmark,
-  2. NNV 2025 (from the results repo) for the same benchmarks,
-  3. the other tools' solved totals per benchmark (so we see the field),
-and flags any NNV-NEW `sat`/`unsat` that DISAGREES with the 2025 consensus (a possible
-incorrect verdict -- the -150 risk). It prints what format it found so the heuristics
-are easy to refine.
+CURRENT behaviour (the VNN-COMP results repo layout has varied year to year, so this is
+deliberately conservative):
+  1. Prints NNV NEW (this sweep) solved/sat/unsat per benchmark + totals, against the
+     published 2025 NNV baseline (1082 solved / 697.3 pts).
+  2. DISCOVERS the 2025 results repo structure (walks it for *.csv, identifies the likely
+     NNV file, and prints a sample) so the exact column format is visible.
+
+NOT yet implemented (the format above must be confirmed first): per-instance parsing of
+the 2025 verdicts, per-tool totals, and flagging NNV-NEW sat/unsat that disagree with the
+2025 consensus (the -150 risk). The discovery output makes wiring those a small, targeted
+follow-up; the NNV NEW scorecard is exact and self-contained.
 
 Usage:
   python3 compare_to_2025.py --new results_all.csv --results2025 <dir>
@@ -64,12 +66,18 @@ def discover_csvs(root):
 
 
 def sniff(path, max_rows=3):
+    # Read up to max_rows lines; a short file (fewer lines) must still return what it has
+    # -- don't let StopIteration (or any read error) swallow the whole sample.
+    rows = []
     try:
         with open(path, newline='', errors='replace') as f:
-            rows = [next(f).rstrip('\n') for _ in range(max_rows)]
-        return rows
-    except Exception:
-        return []
+            for line in f:
+                rows.append(line.rstrip('\n'))
+                if len(rows) >= max_rows:
+                    break
+    except OSError:
+        pass
+    return rows
 
 
 def main():
@@ -116,9 +124,9 @@ def main():
     else:
         print("\nNo file path contained 'nnv'; 2025 per-tool results may be columns in a combined CSV.")
         print("```\n" + "\n".join(sniff(csvs[0])) + "\n```")
-    print("\n> Per-instance agreement-checking against the 2025 consensus is wired to the discovered "
-          "format above; refine `compare_to_2025.py`'s parser once the exact columns are confirmed. "
-          "The NNV NEW scorecard is exact and self-contained.")
+    print("\n> NEXT: per-instance parsing of the 2025 verdicts and agreement-checking against the "
+          "consensus are NOT yet implemented -- add them to `compare_to_2025.py` using the format "
+          "shown above (a small, targeted follow-up). The NNV NEW scorecard is exact and self-contained.")
     return 0
 
 

--- a/code/nnv/tools/vnncomp_compare/compare_to_2025.py
+++ b/code/nnv/tools/vnncomp_compare/compare_to_2025.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""compare_to_2025.py -- compare NNV's fresh sweep to the official VNN-COMP 2025
+results (NNV's own 2025 line + the other tools), per benchmark.
+
+The VNN-COMP results repo layout has varied year to year, so this script DISCOVERS the
+structure (any *.csv it can find) rather than hard-coding it, identifies NNV's 2025
+per-instance verdicts and the other tools' verdicts heuristically, and reports:
+  1. NNV NEW (this sweep) solved/sat/unsat per benchmark,
+  2. NNV 2025 (from the results repo) for the same benchmarks,
+  3. the other tools' solved totals per benchmark (so we see the field),
+and flags any NNV-NEW `sat`/`unsat` that DISAGREES with the 2025 consensus (a possible
+incorrect verdict -- the -150 risk). It prints what format it found so the heuristics
+are easy to refine.
+
+Usage:
+  python3 compare_to_2025.py --new results_all.csv --results2025 <dir>
+"""
+import argparse
+import csv
+import os
+import sys
+from collections import defaultdict, Counter
+
+VERDICTS = {'sat', 'unsat', 'unknown', 'timeout', 'error', 'holds', 'violated',
+            'sat ', 'unsat ', 'true', 'false'}
+NORM = {'holds': 'unsat', 'violated': 'sat', 'true': 'unsat', 'false': 'sat'}
+
+
+def norm_verdict(v):
+    v = (v or '').strip().lower()
+    return NORM.get(v, v)
+
+
+def base(name):
+    """basename without dir / extension / .gz, for matching instances across formats."""
+    n = os.path.basename(str(name).strip())
+    for ext in ('.gz', '.onnx', '.vnnlib', '.csv'):
+        if n.endswith(ext):
+            n = n[: -len(ext)]
+    return n
+
+
+def load_new(path):
+    """NNV's fresh sweep -> {benchmark: Counter(verdicts)} and per-instance verdict map."""
+    by_bench = defaultdict(Counter)
+    inst = {}
+    with open(path, newline='') as f:
+        for r in csv.DictReader(f):
+            b = (r.get('subfolder') or r.get('category') or '?').strip()
+            v = norm_verdict(r.get('status_str'))
+            by_bench[b][v] += 1
+            key = (b, base(r.get('onnx')), base(r.get('vnnlib')))
+            inst[key] = v
+    return by_bench, inst
+
+
+def discover_csvs(root):
+    out = []
+    for dp, _, fns in os.walk(root):
+        for fn in fns:
+            if fn.lower().endswith('.csv'):
+                out.append(os.path.join(dp, fn))
+    return out
+
+
+def sniff(path, max_rows=3):
+    try:
+        with open(path, newline='', errors='replace') as f:
+            rows = [next(f).rstrip('\n') for _ in range(max_rows)]
+        return rows
+    except Exception:
+        return []
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--new', required=True)
+    ap.add_argument('--results2025', required=True)
+    args = ap.parse_args()
+
+    new_by_bench, _ = load_new(args.new)
+    print("# NNV sweep vs VNN-COMP 2025\n")
+    print("## NNV NEW (this sweep)\n")
+    print("| benchmark | n | sat | unsat | solved | unknown | timeout | error |")
+    print("|---|--:|--:|--:|--:|--:|--:|--:|")
+    tot = Counter()
+    for b in sorted(new_by_bench):
+        c = new_by_bench[b]
+        err = sum(v for k, v in c.items() if k in ('error', 'missing', 'decompress_failed',
+                                                   'no_instances_csv', 'no_resolvable_instance'))
+        solved = c.get('sat', 0) + c.get('unsat', 0)
+        for k in ('sat', 'unsat', 'unknown', 'timeout'):
+            tot[k] += c.get(k, 0)
+        tot['solved'] += solved
+        print(f"| {b} | {sum(c.values())} | {c.get('sat',0)} | {c.get('unsat',0)} | {solved} | "
+              f"{c.get('unknown',0)} | {c.get('timeout',0)} | {err} |")
+    print(f"\n**NNV NEW totals:** solved {tot['solved']} (sat {tot['sat']} / unsat {tot['unsat']}), "
+          f"unknown {tot['unknown']}, timeout {tot['timeout']}.")
+    print("Baseline (2025 official): NNV solved 1082 (354 sat / 728 unsat), 6th/7, 697.3 pts.\n")
+
+    # --- discover the 2025 results structure ---
+    csvs = discover_csvs(args.results2025)
+    print(f"## 2025 results repo: discovered {len(csvs)} CSV file(s)\n")
+    if not csvs:
+        print("No CSVs found -- the repo layout may differ; inspect "
+              f"`{args.results2025}` and extend this script. NNV NEW scorecard above stands alone.")
+        return 0
+    # Show a sample so the format is obvious and the heuristics refinable.
+    nnv_csvs = [p for p in csvs if 'nnv' in p.lower()]
+    print("Sample files (first 12):")
+    for p in csvs[:12]:
+        print(f"- `{os.path.relpath(p, args.results2025)}`")
+    if nnv_csvs:
+        print(f"\nLikely NNV 2025 file(s): {[os.path.relpath(p, args.results2025) for p in nnv_csvs[:5]]}")
+        print("```\n" + "\n".join(sniff(nnv_csvs[0])) + "\n```")
+    else:
+        print("\nNo file path contained 'nnv'; 2025 per-tool results may be columns in a combined CSV.")
+        print("```\n" + "\n".join(sniff(csvs[0])) + "\n```")
+    print("\n> Per-instance agreement-checking against the 2025 consensus is wired to the discovered "
+          "format above; refine `compare_to_2025.py`'s parser once the exact columns are confirmed. "
+          "The NNV NEW scorecard is exact and self-contained.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/code/nnv/tools/vnncomp_compare/summarize_sweep.py
+++ b/code/nnv/tools/vnncomp_compare/summarize_sweep.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""summarize_sweep.py -- turn a run_all_benchmarks results CSV into a VNN-COMP-style
+scorecard (per-category and overall solved counts + a rough score estimate).
+
+Input CSV columns (from run_all_benchmarks.m):
+    subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message
+
+VNN-COMP scoring (per the rules): a correct sat/unsat = +10, an INCORRECT verdict =
+-150, and timeout/unknown/error = 0. We do NOT have ground truth here, so this reports
+SOLVED counts (sat+unsat) and an OPTIMISTIC score (assumes every emitted sat/unsat is
+correct -- the real score needs the official checker / 2025 ground truth, which
+compare_to_2025.py cross-checks). Use this for a quick directional read.
+
+Usage:  python3 summarize_sweep.py results_all.csv [> summary.md]
+"""
+import csv
+import sys
+from collections import defaultdict, Counter
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: summarize_sweep.py <results.csv>", file=sys.stderr)
+        return 2
+    path = sys.argv[1]
+    rows = []
+    with open(path, newline='') as f:
+        for r in csv.DictReader(f):
+            rows.append(r)
+
+    by_cat = defaultdict(Counter)
+    overall = Counter()
+    times = []
+    for r in rows:
+        st = (r.get('status_str') or '').strip()
+        cat = (r.get('subfolder') or r.get('category') or '?').strip()
+        by_cat[cat][st] += 1
+        overall[st] += 1
+        try:
+            times.append(float(r.get('time_s') or 0))
+        except ValueError:
+            pass
+
+    n = len(rows)
+    sat = overall.get('sat', 0)
+    unsat = overall.get('unsat', 0)
+    solved = sat + unsat
+    unknown = overall.get('unknown', 0)
+    timeout = overall.get('timeout', 0)
+    error = sum(v for k, v in overall.items() if k in ('error', 'missing', 'decompress_failed',
+                                                       'no_instances_csv', 'no_resolvable_instance'))
+
+    print("# NNV VNN-COMP sweep scorecard\n")
+    print(f"- **Instances:** {n}")
+    print(f"- **Solved:** {solved}  (sat {sat} / unsat {unsat})")
+    print(f"- **Unknown:** {unknown}  |  **Timeout:** {timeout}  |  **Error/missing:** {error}")
+    if times:
+        print(f"- **Time/instance:** mean {sum(times)/len(times):.1f}s, max {max(times):.1f}s, total {sum(times)/60:.1f} min")
+    print(f"- **Optimistic score** (all emitted verdicts assumed correct; +10 each): **{10*solved}** "
+          f"(real score needs the official checker -- see comparison)\n")
+
+    print("## Per-benchmark\n")
+    print("| benchmark | n | sat | unsat | unknown | timeout | error |")
+    print("|---|--:|--:|--:|--:|--:|--:|")
+    for cat in sorted(by_cat):
+        c = by_cat[cat]
+        err = sum(v for k, v in c.items() if k in ('error', 'missing', 'decompress_failed',
+                                                   'no_instances_csv', 'no_resolvable_instance'))
+        print(f"| {cat} | {sum(c.values())} | {c.get('sat',0)} | {c.get('unsat',0)} | "
+              f"{c.get('unknown',0)} | {c.get('timeout',0)} | {err} |")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/code/nnv/tools/vnncomp_compare/summarize_sweep.py
+++ b/code/nnv/tools/vnncomp_compare/summarize_sweep.py
@@ -8,8 +8,8 @@ Input CSV columns (from run_all_benchmarks.m):
 VNN-COMP scoring (per the rules): a correct sat/unsat = +10, an INCORRECT verdict =
 -150, and timeout/unknown/error = 0. We do NOT have ground truth here, so this reports
 SOLVED counts (sat+unsat) and an OPTIMISTIC score (assumes every emitted sat/unsat is
-correct -- the real score needs the official checker / 2025 ground truth, which
-compare_to_2025.py cross-checks). Use this for a quick directional read.
+correct -- the real score needs the official checker / 2025 ground truth; compare_to_2025.py
+reports this NNV scorecard against the 2025 results for context). Quick directional read.
 
 Usage:  python3 summarize_sweep.py results_all.csv [> summary.md]
 """
@@ -37,7 +37,9 @@ def main():
         by_cat[cat][st] += 1
         overall[st] += 1
         try:
-            times.append(float(r.get('time_s') or 0))
+            t = float(r.get('time_s') or 0)
+            if t > 0:                      # skip 0-time rows (missing/no-instance) -> no skew
+                times.append(t)
         except ValueError:
             pass
 


### PR DESCRIPTION
Matrix cloud sweep (one job per benchmark, all instances via run_all_benchmarks run_which=all, sparse checkout + disk-reclaim) with an aggregate job that combines per-benchmark CSVs (summarize_sweep.py scorecard) and compares to vnncomp2025_results (compare_to_2025.py). Validated locally: lsnc_relu all 80 instances -> 80/80 SAT. 🤖 Generated with Claude Code