### PR TITLE
fix(vnnlib): conjoin post-(or) constraints into each disjunct (SOUNDNESS, prevents false SAT / -150)

### DIFF
--- a/code/nnv/engine/utils/load_vnnlib.m
+++ b/code/nnv/engine/utils/load_vnnlib.m
@@ -120,8 +120,19 @@ function property = load_vnnlib(propertyFile)
                     last_ast = property.prop{n2};
                     if length(last_ast) > 1 % means previous ast was an "or"
                         property.prop{n2+1} = ast;
-                    elseif contains(propertyFile, "quadrotor2d_state") % quick fix for lsnc_relu
-                        last_ast.Hg = [last_ast.Hg; ast.Hg];
+                    elseif numel(last_ast.Hg) > 1
+                        % The running unsafe region is an OR (Hg is an array of disjunct
+                        % HalfSpaces). A standalone assertion that follows the (or ...) is
+                        % a CONJUNCT and must be AND-ed into EVERY disjunct (append its
+                        % rows to each), so the unsafe region stays (d1 AND c) OR
+                        % (d2 AND c) OR ...  The old `% quick fix for quadrotor2d_state`
+                        % instead APPENDED it as a new OR term ([Hg; ast.Hg]), dropping
+                        % the conjunction -> witnesses that satisfy a disjunct but violate
+                        % the conjunct were accepted as SAT (false counterexamples, -150).
+                        for di = 1:numel(last_ast.Hg)
+                            last_ast.Hg(di).G = [last_ast.Hg(di).G; ast.Hg.G];
+                            last_ast.Hg(di).g = [last_ast.Hg(di).g; ast.Hg.g];
+                        end
                         property.prop{n2} = last_ast;
                     else
                         last_ast.Hg.G = [last_ast.Hg.G; ast.Hg.G];

--- a/code/nnv/tests/utils/test_load_vnnlib.m
+++ b/code/nnv/tests/utils/test_load_vnnlib.m
@@ -128,3 +128,30 @@ for i = 1:min(3, length(props))
     assert(length(property.lb) == 5, sprintf('Property %d should have 5 inputs', i));
 end
 
+%% Test: a constraint after an (or ...) is CONJOINED into each disjunct
+% Regression for the load_vnnlib bug where a standalone assertion that follows an
+% (or ...) was APPENDED as a new OR disjunct instead of AND-ed into every disjunct.
+% That dropped the conjunction, so a witness satisfying one disjunct but violating the
+% conjunct was wrongly accepted as SAT (a false counterexample -> -150). Real-world
+% case: lsnc_relu / quadrotor2d_state, where the unsafe region is (OR of Y conditions)
+% AND (Y_1 in a narrow box).
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (or (and (>= Y_0 1.0)) (and (<= Y_1 -1.0))))\n');
+fprintf(fid, '(assert (<= Y_0 5.0))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 2, 'two OR disjuncts should yield two HalfSpaces');
+assert(size(Hg(1).G, 1) == 2, 'disjunct 1 must conjoin the trailing Y_0<=5 constraint (2 rows)');
+assert(size(Hg(2).G, 1) == 2, 'disjunct 2 must conjoin the trailing Y_0<=5 constraint (2 rows)');
+assert(any(Hg(1).G(:, 1) ~= 0), 'the Y_0 conjunct must be present in disjunct 1');
+assert(any(Hg(2).G(:, 1) ~= 0), 'the Y_0 conjunct must be present in disjunct 2');
+
+%% Summary
+disp('test_load_vnnlib: all sections passed');
+


### PR DESCRIPTION
## Critical soundness fix

`load_vnnlib` mis-parsed `(assert (or A B ...)) (assert C) ...`: the standalone constraint after the `(or ...)` was **appended as a new OR disjunct** (a hard-coded `% quick fix for quadrotor2d_state`) instead of **AND-ed into every disjunct**. So the unsafe region became `(A OR B OR ... OR C)` instead of `(A OR B OR ...) AND C`.

**Impact (found by comparing our sweep to the VNN-COMP 2025 results):** NNV's now-effective gradient falsification reliably finds witnesses satisfying a disjunct but **violating the conjunct**; `validate_witness` and the onnxruntime guard both use this same mis-parsed region, so nothing catches it → NNV emits a **false `sat`**. On lsnc_relu that was ~69/81 instances that alpha-beta-CROWN proves UNSAT → ≈ **−10,000 points**.

**Fix:** when the running unsafe region is an OR (Hg array of disjuncts), append a new conjunctive assertion's rows to **every** disjunct. General (any `(or ...) AND <constraints>`).

**Verified:** lsnc_relu `quadrotor2d_state_0` false-SAT → unknown (sound); each disjunct now carries the Y_1 box; +1 regression test, 10/10 `test_load_vnnlib` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)