### PR TITLE
Fix unsound Star.HadamardProduct with a McCormick relaxation

### DIFF
--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -381,9 +381,26 @@ classdef Star
         end
         
         function S = HadamardProduct(obj, X)
+            % HadamardProduct - sound over-approximation of the elementwise
+            % product of two stars, z = x .* y for x in obj, y in X.
+            %
             % @X: another star with same dimension
-            % @S: new star
-            
+            % @S: new star, guaranteed to contain {x .* y : x in obj, y in X}
+            %
+            % For each output neuron z(i) = x(i)*y(i) with x(i) in [lx, ux]
+            % and y(i) in [ly, uy], one new predicate variable z(i) is
+            % introduced, bounded by the four McCormick inequalities
+            %
+            %   z >= lx*y + ly*x - lx*ly      z <= ux*y + ly*x - ux*ly
+            %   z >= ux*y + uy*x - ux*uy      z <= lx*y + uy*x - lx*uy
+            %
+            % which are linear in the predicate variables after substituting
+            % the affine forms of x and y, and enclose the bilinear term
+            % over the box [lx,ux] x [ly,uy]. The two stars are treated as
+            % independent (their predicate variables are not identified,
+            % even if their constraints coincide), which always yields a
+            % superset of the product under any dependency between them.
+
             if ~isa(X, 'Star')
                 error('Input matrix is not a Star');
             else
@@ -391,27 +408,68 @@ classdef Star
                     error('Input star and current star have different dimensions');
                 end
             end
-            
-            m1 = size(obj.V, 2);
-            m2 = size(X.V, 2);
-            V1 = obj.V(:, 2:m1);
-            V2 = X.V(:, 2:m2);
-            new_c = obj.V(:, 1) .* X.V(:, 1);
-            
-            % check if two Star has the same constraints
-            if size(obj.C, 1) == size(X.C, 1) && size(obj.C, 2) == size(X.C, 2) && norm(obj.C - X.C) + norm(obj.d - X.d) < 0.0001
-               V3 = V1 .* V2;
-               new_V = horzcat(new_c, V3);
-               S = Star(new_V, obj.C, obj.d, obj.predicate_lb, obj.predicate_ub); % new Star has the same number of basic vectors
+
+            n = obj.dim;
+            n1 = obj.nVar;
+            n2 = X.nVar;
+
+            cx = obj.V(:, 1);
+            cy = X.V(:, 1);
+            Wx = obj.V(:, 2:n1+1);
+            Wy = X.V(:, 2:n2+1);
+
+            % bounds of each factor (estimateRanges if predicate bounds are
+            % known, otherwise exact ranges via LP)
+            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub)
+                [lx, ux] = obj.estimateRanges;
             else
-                V3 = horzcat(V1, V2);
-                % new_c = obj.V(:, 1) + X.V(:, 1);
-                new_V = horzcat(new_c, V3);        
-                new_C = blkdiag(obj.C, X.C);        
-                new_d = vertcat(obj.d, X.d);
-                new_pred_lb = [obj.predicate_lb; X.predicate_lb];
-                new_pred_ub = [obj.predicate_ub; X.predicate_ub];
-                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                [lx, ux] = obj.getRanges;
+            end
+            if ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+                [ly, uy] = X.estimateRanges;
+            else
+                [ly, uy] = X.getRanges;
+            end
+
+            % output is the new predicate variables z, predicate vector is
+            % [alpha (n1); beta (n2); z (n)]
+            new_V = [zeros(n, 1+n1+n2, 'like', obj.V), eye(n, 'like', obj.V)];
+
+            % original constraints on alpha and beta, padded for z
+            C0 = blkdiag(obj.C, X.C);
+            C0 = [C0, zeros(size(C0, 1), n, 'like', obj.V)];
+            d0 = [obj.d; X.d];
+
+            % McCormick constraints, one block of n rows each, over
+            % [alpha; beta; z]:
+            %   lower:  a*Wy(i,:)*beta + b*Wx(i,:)*alpha - z(i) <= a*b - a*cy(i) - b*cx(i)
+            %           with (a,b) = (lx,ly) and (ux,uy)
+            %   upper: -a*Wy(i,:)*beta - b*Wx(i,:)*alpha + z(i) <= a*cy(i) + b*cx(i) - a*b
+            %           with (a,b) = (ux,ly) and (lx,uy)
+            I = eye(n, 'like', obj.V);
+            Cm = [ ly.*Wx,  lx.*Wy, -I;
+                   uy.*Wx,  ux.*Wy, -I;
+                  -ly.*Wx, -ux.*Wy,  I;
+                  -uy.*Wx, -lx.*Wy,  I];
+            dm = [lx.*ly - lx.*cy - ly.*cx;
+                  ux.*uy - ux.*cy - uy.*cx;
+                  ux.*cy + ly.*cx - ux.*ly;
+                  lx.*cy + uy.*cx - lx.*uy];
+
+            new_C = [C0; Cm];
+            new_d = [d0; dm];
+
+            % range of z is attained at the corners of the factor box
+            corners = [lx.*ly, lx.*uy, ux.*ly, ux.*uy];
+            z_lb = min(corners, [], 2);
+            z_ub = max(corners, [], 2);
+
+            if ~isempty(obj.predicate_lb) && ~isempty(X.predicate_lb)
+                new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
+                new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
+                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);
+            else
+                S = Star(new_V, new_C, new_d);
             end
 
         end

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -464,7 +464,7 @@ classdef Star
             z_lb = min(corners, [], 2);
             z_ub = max(corners, [], 2);
 
-            if ~isempty(obj.predicate_lb) && ~isempty(X.predicate_lb)
+            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub) && ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
                 new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
                 new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
                 S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -370,16 +370,25 @@ classdef Star
             else
                 V3 = horzcat(V1, V2);
                 new_c = obj.V(:, 1) + X.V(:, 1);
-                new_V = horzcat(new_c, V3);        
-                new_C = blkdiag(obj.C, X.C);        
+                new_V = horzcat(new_c, V3);
+                new_C = blkdiag(obj.C, X.C);
                 new_d = vertcat(obj.d, X.d);
-                new_pred_lb = [obj.predicate_lb; X.predicate_lb];
-                new_pred_ub = [obj.predicate_ub; X.predicate_ub];
-                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                % concatenating bounds is only valid when each operand's
+                % bounds cover all of its predicate variables (a
+                % 0-predicate star with 0x1 bounds counts as covered);
+                % otherwise the constructor would reject the short vector
+                if size(obj.predicate_lb, 1) == obj.nVar && size(obj.predicate_ub, 1) == obj.nVar ...
+                        && size(X.predicate_lb, 1) == X.nVar && size(X.predicate_ub, 1) == X.nVar
+                    new_pred_lb = [obj.predicate_lb; X.predicate_lb];
+                    new_pred_ub = [obj.predicate_ub; X.predicate_ub];
+                    S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                else
+                    S = Star(new_V, new_C, new_d);
+                end
             end
-                
+
         end
-        
+
         function S = HadamardProduct(obj, X)
             % HadamardProduct - sound over-approximation of the elementwise
             % product of two stars, z = x .* y for x in obj, y in X.
@@ -418,14 +427,17 @@ classdef Star
             Wx = obj.V(:, 2:n1+1);
             Wy = X.V(:, 2:n2+1);
 
-            % bounds of each factor (estimateRanges if predicate bounds are
-            % known, otherwise exact ranges via LP)
-            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub)
+            % bounds of each factor (estimateRanges if predicate bounds
+            % cover all predicate variables, otherwise exact ranges via
+            % LP; a 0-predicate star with 0x1 bounds counts as covered)
+            obj_has_bounds = size(obj.predicate_lb, 1) == n1 && size(obj.predicate_ub, 1) == n1;
+            X_has_bounds = size(X.predicate_lb, 1) == n2 && size(X.predicate_ub, 1) == n2;
+            if obj_has_bounds
                 [lx, ux] = obj.estimateRanges;
             else
                 [lx, ux] = obj.getRanges;
             end
-            if ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+            if X_has_bounds
                 [ly, uy] = X.estimateRanges;
             else
                 [ly, uy] = X.getRanges;
@@ -464,7 +476,7 @@ classdef Star
             z_lb = min(corners, [], 2);
             z_ub = max(corners, [], 2);
 
-            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub) && ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+            if obj_has_bounds && X_has_bounds
                 new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
                 new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
                 S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);

--- a/code/nnv/tests/set/star/test_star_HadamardProduct.m
+++ b/code/nnv/tests/set/star/test_star_HadamardProduct.m
@@ -1,0 +1,96 @@
+function test_star_HadamardProduct()
+    % TEST_STAR_HADAMARDPRODUCT - Test Star.HadamardProduct() method
+    %
+    % Tests that:
+    %   1. The product of two interval stars encloses the true product set,
+    %      including the products attained at the interval endpoints
+    %      (regression: the previous implementation returned [2, 2.5] for
+    %      [1,2].*[1,2] and [39, 51] for [2,4].*[10,20], both disjoint
+    %      from parts of the true product sets [1,4] and [20,80])
+    %   2. The product is sound: for sampled x in S1, y in S2, the point
+    %      x .* y is contained in S1.HadamardProduct(S2)
+    %   3. Output star dimensions are consistent
+
+    tol = 1e-6;
+
+    %% 1a) Regression witness: product of [1,2] with itself
+    % (two stars with identical constraints; previously the
+    % shared-constraint branch returned ranges [2, 2.5])
+    S = Star(1, 2);
+    P = S.HadamardProduct(S);
+    [lb, ub] = P.getRanges;
+    assert(lb <= 1 + tol, 'Product of [1,2]x[1,2] must contain 1*1 = 1');
+    assert(ub >= 4 - tol, 'Product of [1,2]x[1,2] must contain 2*2 = 4');
+
+    %% 1b) Regression witness: x in [2,4], y in [10,20], scaled encodings
+    % (different constraint matrices; previously the disjoint branch
+    % returned ranges [39, 51], the true product set is [20, 80])
+    S1 = Star([3 1],  [1; -1],     [1; 1]);      % x = 3 + a,   a in [-1,1]
+    S2 = Star([15 5], [0.5; -0.5], [0.5; 0.5]);  % y = 15 + 5b, b in [-1,1]
+    P2 = S1.HadamardProduct(S2);
+    [lb2, ub2] = P2.getRanges;
+    assert(lb2 <= 20 + tol, 'Product of [2,4]x[10,20] must contain 2*10 = 20');
+    assert(ub2 >= 80 - tol, 'Product of [2,4]x[10,20] must contain 4*20 = 80');
+
+    %% 2) Soundness on multi-dimensional stars with coupled predicates
+    rng(0);
+    V1 = [1 1 0; -2 1 1; 0.5 0 1];
+    C1 = [1 0; -1 0; 0 1; 0 -1; 1 1];
+    d1 = [1; 1; 1; 1; 1.5];
+    A = Star(V1, C1, d1);
+
+    V2 = [0 2 1; 3 0 1; -1 1 1];
+    C2 = [1 0; -1 0; 0 1; 0 -1];
+    d2 = [0.5; 0.5; 1; 1];
+    B = Star(V2, C2, d2);
+
+    PAB = A.HadamardProduct(B);
+    assert(PAB.dim == A.dim, 'Product star must have the same dimension as the factors');
+    assert(~PAB.isEmptySet, 'Product star should not be empty');
+
+    [plb, pub] = PAB.getRanges;
+
+    % bounds of the product star along random directions (catches
+    % unsoundness that per-dimension ranges cannot)
+    nDirs = 5;
+    W = randn(nDirs, PAB.dim);
+    wlb = zeros(nDirs, 1);
+    wub = zeros(nDirs, 1);
+    for k = 1:nDirs
+        Pk = PAB.affineMap(W(k, :), []);
+        [wlb(k), wub(k)] = Pk.getRanges;
+    end
+
+    % sample the factor predicates directly (rejection sampling, so no
+    % polytope toolbox is needed) and check x .* y lands inside
+    nChecked = 0;
+    for trial = 1:200
+        a = -1 + 2*rand(2, 1);
+        if any(C1*a > d1)
+            continue
+        end
+        b = -1 + 2*rand(2, 1);
+        if any(C2*b > d2)
+            continue
+        end
+        x = V1(:, 1) + V1(:, 2:end)*a;
+        y = V2(:, 1) + V2(:, 2:end)*b;
+        z = x .* y;
+        nChecked = nChecked + 1;
+        assert(all(z >= plb - tol) && all(z <= pub + tol), ...
+            sprintf('Sampled product point (trial %d) must lie within the product star ranges', trial));
+        wz = W*z;
+        assert(all(wz >= wlb - tol) && all(wz <= wub + tol), ...
+            sprintf('Sampled product point (trial %d) must lie within the product star projections', trial));
+    end
+    assert(nChecked > 50, 'Rejection sampling should accept a reasonable number of points');
+
+    %% 3) Soundness across sign changes (factors straddling zero)
+    S3 = Star(-1.5, 2);    % x in [-1.5, 2]
+    S4 = Star(-3, 1);      % y in [-3, 1]
+    P34 = S3.HadamardProduct(S4);
+    [lb34, ub34] = P34.getRanges;
+    % true product set is [-6, 4.5]
+    assert(lb34 <= -6 + tol, 'Product of [-1.5,2]x[-3,1] must contain 2*(-3) = -6');
+    assert(ub34 >= 4.5 - tol, 'Product of [-1.5,2]x[-3,1] must contain (-1.5)*(-3) = 4.5');
+end


### PR DESCRIPTION
## Summary

`Star.HadamardProduct` (engine/set/Star.m) did not over-approximate the elementwise product of two stars — both code paths returned sets that can be disjoint from the true product set, including the products of the interval endpoints. Since `LstmLayer.reach_star_single_input` builds `c_t = i_t .* g_t (+ f_t .* c_{t-1})` and `h_t = o_t .* tanh(c_t)` from this operation, LSTM star reachability results computed through it were not sound enclosures.

### Minimal reproduction (before this PR, MATLAB R2025b, master)

```matlab
% Shared-constraint branch: x in [1,2], product with itself.
% Any sound product set must contain 1*1 = 1 and 2*2 = 4.
S = Star(1, 2);
P = S.HadamardProduct(S);
[lb, ub] = P.getRanges     % returned [2, 2.5] -- contains neither 1 nor 4

% Disjoint branch: x in [2,4], y in [10,20], same boxes encoded with
% scaled constraints so the norm(C1-C2) check fails.
S1 = Star([3 1],  [1; -1],     [1; 1]);
S2 = Star([15 5], [0.5; -0.5], [0.5; 0.5]);
P2 = S1.HadamardProduct(S2);
[lb2, ub2] = P2.getRanges  % returned [39, 51] -- true products span [20, 80]
```

### Why

For `x = c1 + V1*a`, `y = c2 + V2*b`:

```
x .* y = c1.*c2 + c1.*(V2*b) + c2.*(V1*a) + (V1*a).*(V2*b)
```

The disjoint branch returned `c1.*c2 + V1*a + V2*b` (deviations enter unweighted by the opposite center; the bilinear term is dropped), and the shared branch returned `c1.*c2 + (V1.*V2)*a`. Neither is an enclosure: the returned ranges exclude products attained at interval endpoints, so no choice of predicate values can recover the lost set. The disjoint branch matches Definition 4.1 of the FMAS 2023 paper (arXiv:2311.12130), so the issue appears to originate in that construction rather than being a transcription error.

## Fix

Replace both branches with the standard McCormick relaxation: for each output neuron `z = x*y` with `x in [lx, ux]`, `y in [ly, uy]`, introduce one new predicate variable `z` bounded by

```
z >= lx*y + ly*x - lx*ly        z <= ux*y + ly*x - ux*ly
z >= ux*y + uy*x - ux*uy        z <= lx*y + uy*x - lx*uy
```

After substituting the affine forms of `x` and `y`, these are linear in the joint predicate vector `[a; b; z]`, so the result is a valid star with `dim` new predicate variables and `4*dim` extra constraints, sound for any bilinear term over the box of factor ranges (exact at the box corners). Factor ranges come from `estimateRanges` when predicate bounds are available, otherwise from `getRanges` (LP). The two stars' predicates are kept independent — sound under any dependency between the factors, including `x .* x`.

## Tests

* New `tests/set/star/test_star_HadamardProduct.m`:
  * both witnesses above now produce exactly the true product ranges (`[1,4]` and `[20,80]`);
  * a sign-straddling case `[-1.5,2] .* [-3,1]` encloses `[-6, 4.5]`;
  * randomized containment checks on 3-D stars with coupled predicate constraints, including projections of the product star along random directions (no MPT/`Polyhedron` dependency).
* Existing `test_VolumeStar` (exercises the `VolumeStar.HadamardProduct` wrapper) and `test_soundness_LstmLayer` pass with the new implementation.

## Notes / out of scope

A separate concern in `LstmLayer.reach_star_single_input_Sequence` is not addressed here: it propagates `im_lb`/`im_ub` concretely through `evaluateSequence` (and maps star generators individually through the nonlinear network when bounds are absent), which is not an enclosure for non-monotone maps. Happy to file that as a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
