### PR TITLE
fix(sweep): drop committed results_*.csv before run (clean sweep artifacts)

### DIFF
--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -135,6 +135,10 @@ jobs:
           restore-keys: |
             nnv-tbxmanager-${{ runner.os }}-
 
+      - name: Clear committed results CSVs from the checkout (avoid polluting the artifact)
+        shell: bash
+        run: rm -f code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
+
       - name: Run sweep for ${{ matrix.folder }} (run_which=${{ github.event.inputs.run_which }})
         uses: matlab-actions/run-command@v2
         timeout-minutes: 330


### PR DESCRIPTION
## Problem

Each matrix job's checkout contains the previously-committed `results_*.csv` files in `examples/Submission/VNN_COMP2025/`. The **Upload results** step globs `results_*.csv`, so those stale files were bundled into *every* sweep artifact and merged by the aggregate job -- contaminating `results_all.csv` with old verdicts.

Caught via the 2025 comparison: a stale `cora` row produced a spurious *false-unsat* flag (cora's real re-sweep job hadn't even finished). Filtering to the new files locally confirmed **0 false SATs / 0 false UNSATs** on the 16 completed benchmarks.

## Fix

Delete `results_*.csv` from the checkout before the sweep run, so each artifact contains only the fresh `results_<timestamp>.csv` that job produced. The committed files stay in the repo (referenced by progress docs); they're only removed from the ephemeral CI checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)