### PR TITLE
VNN-COMP hardening: parser soundness fixes + regression test suite

### DIFF
--- a/code/nnv/engine/utils/load_vnnlib.m
+++ b/code/nnv/engine/utils/load_vnnlib.m
@@ -134,6 +134,18 @@ function property = load_vnnlib(propertyFile)
                             last_ast.Hg(di).g = [last_ast.Hg(di).g; ast.Hg.g];
                         end
                         property.prop{n2} = last_ast;
+                    elseif numel(ast.Hg) > 1
+                        % Mirror of the case above, OPPOSITE order: a standalone conjunct c
+                        % was asserted BEFORE this (or ...). The result is still
+                        % (d1 AND c) OR (d2 AND c) OR ..., so AND the running conjunct's
+                        % rows into EVERY disjunct of the new OR and keep the OR.
+                        % (The old code did [last_ast.Hg.G; ast.Hg.G] with a multi-element
+                        % ast.Hg, which errored -> lost the instance.)
+                        for di = 1:numel(ast.Hg)
+                            ast.Hg(di).G = [ast.Hg(di).G; last_ast.Hg.G];
+                            ast.Hg(di).g = [ast.Hg(di).g; last_ast.Hg.g];
+                        end
+                        property.prop{n2} = ast;
                     else
                         last_ast.Hg.G = [last_ast.Hg.G; ast.Hg.G];
                         last_ast.Hg.g = [last_ast.Hg.g; ast.Hg.g];
@@ -361,7 +373,7 @@ function [lb_input, ub_input] =  process_input_constraint(tline, lb_input, ub_in
         dim = str2double(dim{2})+1;
         value = split(t{3},')');
         value = single(str2double(value{1}));
-        if contains(t{1},">=")
+        if contains(t{1},">")        % ">" or ">=" -> lower bound ("<"/"<=" never contain ">")
             lb_input(dim) = value;
         else
             ub_input(dim) = value;
@@ -435,6 +447,8 @@ function [lb_array, ub_array] = process_multiple_inputs(tline, lb_input, ub_inpu
     lb_array = {};
     ub_array = {};
     arr_count = 0;
+    lb_global = lb_input;   % the globally-declared bounds; each disjunct starts fresh from
+    ub_global = ub_input;   % these so a bound set in one disjunct cannot LEAK into the next.
     while ~isempty(tline) > 0 && pars > 0
         tline = strtrim(tline);
         if startsWith(tline,'(<=') || startsWith(tline,'(>=')
@@ -445,14 +459,16 @@ function [lb_array, ub_array] = process_multiple_inputs(tline, lb_input, ub_inpu
             constraint_char = constraint_char{1};
             [lb_input, ub_input] = process_input_constraint(constraint_char, lb_input, ub_input);
             tline = tline(length(constraint_char)+2:end); % update tline, process remainder of assertion
-        
+
         elseif startsWith(tline,'(or')
             error("Currently we do not support an OR statement within and OR statement.")
-    
+
         elseif startsWith(tline,'(and')
             % parse all constraints with the "and" statement
             % if multiple *and* statements, then H -> [# ands, dim], and g a [# ands, 1]
             arr_count = arr_count + 1;
+            lb_input = lb_global;   % reset to the global box for this disjunct (no leak from
+            ub_input = ub_global;   % the previous disjunct's per-dimension constraints)
             tline = tline(5:end);
             pars = pars + 1;
         

--- a/code/nnv/examples/Submission/VNN_COMP2025/vnncomp_pick_instances.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/vnncomp_pick_instances.m
@@ -1,0 +1,48 @@
+function pairs = vnncomp_pick_instances(inst_csv, bench_root, sub, run_which)
+% vnncomp_pick_instances  Resolve (onnx, vnnlib) pairs from an instances.csv.
+%
+%   Extracted (behavior-preserving) copy of the local `pick_instances` +
+%   `ensure_decompressed` helpers in run_all_benchmarks.m, so the CSV-parsing /
+%   instance-selection logic can be unit-tested without spinning up a parpool or
+%   importing a network. Adopting it as the single source of truth in
+%   run_all_benchmarks.m is a recommended follow-up; until then keep this file
+%   equivalent to those local functions.
+%
+%   Reads instances.csv (3 cols: onnx_rel, vnnlib_rel, timeout_s), strips a
+%   leading './' from each relative path, and returns a cell array of resolvable
+%   structs {onnx_rel, vnnlib_rel, onnx, vnnlib} (decompressing .gz on demand).
+%     run_which = 'first' -> the FIRST resolvable instance only.
+%     run_which = 'all'   -> EVERY resolvable instance.
+
+pairs = {};
+T = readtable(inst_csv, 'Delimiter', ',', 'ReadVariableNames', false, ...
+    'TextType', 'string', 'Format', '%s%s%s');
+for r = 1:height(T)
+    onnx_rel   = strrep(strtrim(char(T{r,1})), './', '');
+    vnnlib_rel = strrep(strtrim(char(T{r,2})), './', '');
+    onnx_p   = ensure_decompressed(fullfile(bench_root, sub, onnx_rel));
+    vnnlib_p = ensure_decompressed(fullfile(bench_root, sub, vnnlib_rel));
+    if ~isempty(onnx_p) && ~isempty(vnnlib_p)
+        pairs{end+1} = struct('onnx_rel', onnx_rel, 'vnnlib_rel', vnnlib_rel, ...
+            'onnx', onnx_p, 'vnnlib', vnnlib_p); %#ok<AGROW>
+        if strcmp(run_which, 'first'), return; end
+    end
+end
+end
+
+function p = ensure_decompressed(p)
+% Returns a path to a decompressed file, decompressing the .gz form if needed.
+% Returns '' if neither exists.
+if isfile(p), return; end
+gz = [p '.gz'];
+if isfile(gz)
+    try
+        gunzip(gz);
+    catch
+        p = '';
+        return;
+    end
+    if isfile(p), return; end
+end
+p = '';
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/vnncomp_status_to_str.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/vnncomp_status_to_str.m
@@ -1,0 +1,24 @@
+function s = vnncomp_status_to_str(code)
+% vnncomp_status_to_str  Map an integer verification status code to its string.
+%
+%   Extracted (behavior-preserving) copy of the local `status_to_str` helper in
+%   run_all_benchmarks.m so it can be unit-tested in isolation. Adopting it as the
+%   single source of truth in run_all_benchmarks.m is a recommended follow-up
+%   refactor (delete the local function and call this instead); until then this
+%   file MUST be kept byte-for-byte equivalent to that local function.
+%
+%   Status codes:
+%      0 = sat      1 = unsat       2 = unknown
+%     -1 = error   -2 = missing    -3 = decompress_failed
+%   anything else -> sprintf('code_%d', code)
+
+switch code
+    case 0,  s = 'sat';
+    case 1,  s = 'unsat';
+    case 2,  s = 'unknown';
+    case -1, s = 'error';
+    case -2, s = 'missing';
+    case -3, s = 'decompress_failed';
+    otherwise, s = sprintf('code_%d', code);
+end
+end

--- a/code/nnv/tests/utils/test_load_vnnlib_audit_fixes.m
+++ b/code/nnv/tests/utils/test_load_vnnlib_audit_fixes.m
@@ -1,0 +1,87 @@
+function tests = test_load_vnnlib_audit_fixes
+% test_load_vnnlib_audit_fixes
+% Regression tests for three latent soundness bugs in load_vnnlib found by the
+% VNN-COMP soundness audit (2026-06-11) and FIXED. Each test pins the CORRECT
+% post-fix behavior; the pre-fix behavior is noted in the comment so a regression
+% is unambiguous. All three are latent on the 2025 benchmark set (which dodges
+% them) but would flip verdicts on a 2026 benchmark using the form.
+%
+% To run: results = runtests('test_load_vnnlib_audit_fixes')
+    tests = functiontests(localfunctions);
+end
+
+% ---------------------------------------------------------------------------
+% Finding 2: a STRICT '>' input constraint must set the LOWER bound.
+% Pre-fix: process_input_constraint routed to lower only on '>=', so '(> X_i v)'
+% fell to the else branch and set the UPPER bound -> wrong (shifted) input box ->
+% the falsifier/reach ran on the wrong domain -> false sat or false unsat.
+% ---------------------------------------------------------------------------
+function test_strict_gt_input_is_lower_bound(testCase)
+    tf = [tempname '.vnnlib']; c = onCleanup(@() delete(tf));
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n(declare-const Y_0 Real)\n');
+    fprintf(fid, '(assert (<= X_0 1.0))\n(assert (> X_0 0.6))\n');
+    fprintf(fid, '(assert (<= Y_0 0.0))\n');
+    fclose(fid);
+    P = load_vnnlib(tf);
+    verifyEqual(testCase, double(P.lb(1)), 0.6, 'AbsTol', 1e-6, ...
+        'strict (> X_0 0.6) must set the LOWER bound to 0.6');
+    verifyEqual(testCase, double(P.ub(1)), 1.0, 'AbsTol', 1e-6, ...
+        'the (<= X_0 1.0) upper bound must be preserved');
+    verifyTrue(testCase, P.lb(1) <= P.ub(1), 'lb <= ub');
+end
+
+% ---------------------------------------------------------------------------
+% Finding 5: a standalone conjunct asserted BEFORE an (or ...) must be AND-ed
+% into every disjunct (mirror of the already-fixed after-the-or case).
+% Pre-fix: the else branch did [last_ast.Hg.G; ast.Hg.G] with a multi-element
+% ast.Hg -> "Dimensions of arrays being concatenated are not consistent" error
+% (lost the instance), or a silent mis-build dropping the disjunction.
+% ---------------------------------------------------------------------------
+function test_conjunct_before_or_is_conjoined(testCase)
+    tf = [tempname '.vnnlib']; c = onCleanup(@() delete(tf));
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n');
+    fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n(declare-const Y_2 Real)\n');
+    fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 0.0))\n');
+    fprintf(fid, '(assert (<= Y_0 0.0))\n');                                 % conjunct FIRST
+    fprintf(fid, '(assert (or (and (>= Y_1 1.0)) (and (>= Y_2 1.0))))\n');    % then the OR
+    fclose(fid);
+    P = load_vnnlib(tf);
+    Hg = P.prop{1}.Hg;
+    verifyEqual(testCase, numel(Hg), 2, 'two OR disjuncts');
+    verifyEqual(testCase, size(Hg(1).G, 1), 2, 'disjunct 1: the Y_0<=0 conjunct AND its own row');
+    verifyEqual(testCase, size(Hg(2).G, 1), 2, 'disjunct 2: the Y_0<=0 conjunct AND its own row');
+    % the conjunct constrains Y_0 (index 1) -> a nonzero coefficient in column 1 of every disjunct
+    verifyTrue(testCase, any(Hg(1).G(:, 1) ~= 0), 'Y_0 conjunct present in disjunct 1');
+    verifyTrue(testCase, any(Hg(2).G(:, 1) ~= 0), 'Y_0 conjunct present in disjunct 2');
+end
+
+% ---------------------------------------------------------------------------
+% Finding 1: in a multi-input-region (or ...), each disjunct's box must start
+% from the GLOBAL declared bounds, not inherit the previous disjunct's values.
+% Pre-fix: process_multiple_inputs never reset lb_input/ub_input between
+% disjuncts, so a dimension constrained in region 1 LEAKED into region 2 when
+% region 2 omitted it -> region 2's box was wrong -> false sat/unsat.
+% ---------------------------------------------------------------------------
+function test_multiinput_no_bound_leak(testCase)
+    tf = [tempname '.vnnlib']; c = onCleanup(@() delete(tf));
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n(declare-const X_1 Real)\n(declare-const Y_0 Real)\n');
+    % region 1 constrains X_0 and X_1; region 2 constrains ONLY X_0.
+    fprintf(fid, ['(assert (or (and (<= X_0 1.0) (>= X_0 0.0) (<= X_1 1.0) (>= X_1 0.0)) ' ...
+                  '(and (<= X_0 5.0) (>= X_0 4.0))))\n']);
+    fprintf(fid, '(assert (>= Y_0 0.0))\n');
+    fclose(fid);
+    P = load_vnnlib(tf);
+    verifyTrue(testCase, iscell(P.lb) && numel(P.lb) == 2, 'two input regions (cell lb/ub)');
+    % region 1: X_1 in [0,1] as specified.
+    verifyEqual(testCase, double(P.lb{1}(2)), 0.0, 'AbsTol', 1e-6, 'region 1 X_1 lb');
+    verifyEqual(testCase, double(P.ub{1}(2)), 1.0, 'AbsTol', 1e-6, 'region 1 X_1 ub');
+    % region 2: X_1 must NOT have leaked region 1's [0,1]; it falls back to the
+    % global default (here the unset template, 0/0), so ub{2}(2) ~= 1.0.
+    verifyNotEqual(testCase, double(P.ub{2}(2)), 1.0, ...
+        'region 2 X_1 must NOT inherit region 1''s upper bound (no leak)');
+    verifyEqual(testCase, double(P.lb{2}(1)), 4.0, 'AbsTol', 1e-6, 'region 2 X_0 lb as specified');
+    verifyEqual(testCase, double(P.ub{2}(1)), 5.0, 'AbsTol', 1e-6, 'region 2 X_0 ub as specified');
+end

--- a/code/nnv/tests/utils/test_load_vnnlib_errors.m
+++ b/code/nnv/tests/utils/test_load_vnnlib_errors.m
@@ -1,0 +1,161 @@
+function tests = test_load_vnnlib_errors
+% test_load_vnnlib_errors
+% Function-based tests (so try/catch + verifyError are allowed) that PIN the
+% CURRENT behavior of load_vnnlib on forms it does NOT fully support, and that
+% assert well-formedness of REAL multi-region benchmark vnnlib files.
+%
+% These document behavior as-is; where current behavior is a limitation (not a
+% deliberate design choice) it is flagged in the accompanying report, NOT fixed
+% here.
+%
+% To run: results = runtests('test_load_vnnlib_errors')
+    tests = functiontests(localfunctions);
+end
+
+% ---------------------------------------------------------------------------
+% (g) top-level (assert (and ...)) with NO surrounding (or ...) currently ERRORS.
+%     process_assertion hits the `startsWith(tline,'(and')` branch and throws:
+%       "Property not supported for now. Not allowed -> assertion starting with
+%        AND and no OR."
+%     Pinned so a future change that starts SUPPORTING bare top-level AND (or that
+%     changes the message) trips this test and gets a deliberate review.
+% ---------------------------------------------------------------------------
+function test_top_level_and_errors(testCase)
+    tf = [tempname '.vnnlib'];
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n');
+    fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n');
+    fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+    fprintf(fid, '(assert (and (>= Y_0 1.0) (<= Y_1 0.0)))\n');
+    fclose(fid);
+    c = onCleanup(@() delete(tf));
+
+    threw = false;
+    msg = '';
+    try
+        load_vnnlib(tf);
+    catch ME
+        threw = true;
+        msg = ME.message;
+    end
+    verifyTrue(testCase, threw, ...
+        'top-level (assert (and ...)) with no (or ...) should currently error');
+    % Stable substring of the current error message.
+    verifyTrue(testCase, contains(msg, 'assertion starting with AND'), ...
+        sprintf('unexpected error message: %s', msg));
+end
+
+% ---------------------------------------------------------------------------
+% (h) linear-combination constraint (assert (<= (+ Y_0 Y_1) 5)) is NOT supported.
+%     process_constraint splits the constraint on whitespace and treats token 2
+%     as a "Y_a" variable; for "(+" there is no "_a" index, so str2double indexing
+%     throws. PIN as: load_vnnlib raises an error (does NOT silently mis-parse).
+%     >>> FLAGGED IN REPORT: load_vnnlib cannot parse linear-combination output
+%         constraints; competitions that use them would need a parser extension.
+% ---------------------------------------------------------------------------
+function test_linear_combination_unsupported(testCase)
+    tf = [tempname '.vnnlib'];
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n');
+    fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n');
+    fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+    fprintf(fid, '(assert (<= (+ Y_0 Y_1) 5.0))\n');
+    fclose(fid);
+    c = onCleanup(@() delete(tf));
+
+    % Pin: this currently ERRORS (does not produce a well-formed HalfSpace).
+    verifyError(testCase, @() load_vnnlib(tf), '', ...
+        'linear-combination output constraint should currently error (not silently mis-parse)');
+end
+
+% ---------------------------------------------------------------------------
+% (i1) REAL benchmark: acasxu prop_6 -- (assert (or (and X ...) (and X ...)))
+%      gives MULTIPLE input regions, followed by an (or (and Y ...)) output spec.
+%      Asserts the multi-input CELL shape and well-formedness.
+% ---------------------------------------------------------------------------
+function test_real_multiregion_acasxu_prop6(testCase)
+    vf = acas_vnnlib('prop_6.vnnlib');
+    verifyTrue(testCase, isfile(vf), sprintf('missing benchmark file: %s', vf));
+    property = load_vnnlib(vf);
+
+    % prop_6's input (or (and X..)(and X..)) -> lb/ub are CELL arrays (one per region).
+    verifyTrue(testCase, iscell(property.lb), 'prop_6 lb should be a cell (multi-region)');
+    verifyTrue(testCase, iscell(property.ub), 'prop_6 ub should be a cell (multi-region)');
+    verifyEqual(testCase, numel(property.lb), 2, 'prop_6 has two input regions');
+    verifyEqual(testCase, numel(property.ub), 2, 'prop_6 has two input regions');
+
+    % Each region: 5 finite dims, lb <= ub elementwise.
+    for r = 1:numel(property.lb)
+        lb = property.lb{r}; ub = property.ub{r};
+        verifyEqual(testCase, numel(lb), 5, 'acasxu has 5 inputs');
+        verifyEqual(testCase, numel(ub), 5, 'acasxu has 5 inputs');
+        verifyTrue(testCase, all(isfinite(lb)) && all(isfinite(ub)), 'bounds finite');
+        verifyTrue(testCase, all(lb(:) <= ub(:)), 'lb <= ub elementwise');
+    end
+
+    % Single output spec; its Hg is an OR of disjuncts; every element is a HalfSpace.
+    verifyEqual(testCase, numel(property.prop), 1, 'prop_6 has a single output spec');
+    Hg = property.prop{1}.Hg;
+    verifyTrue(testCase, isa(Hg, 'HalfSpace'), 'Hg is HalfSpace array');
+    verifyTrue(testCase, numel(Hg) >= 1, 'at least one disjunct');
+    assert_all_halfspaces(testCase, Hg);
+end
+
+% ---------------------------------------------------------------------------
+% (i2) REAL benchmark: acasxu prop_7 -- output is (or (and Y..Y..Y..)(and Y..)).
+%      Single input box (vector lb/ub), output OR with 2 disjuncts of 3 rows each.
+% ---------------------------------------------------------------------------
+function test_real_or_of_and_acasxu_prop7(testCase)
+    vf = acas_vnnlib('prop_7.vnnlib');
+    verifyTrue(testCase, isfile(vf), sprintf('missing benchmark file: %s', vf));
+    property = load_vnnlib(vf);
+
+    % Single input region -> plain vectors.
+    verifyFalse(testCase, iscell(property.lb), 'prop_7 has a single input box');
+    verifyEqual(testCase, numel(property.lb), 5, 'acasxu 5 inputs');
+    verifyTrue(testCase, all(property.lb(:) <= property.ub(:)), 'lb <= ub');
+
+    verifyEqual(testCase, numel(property.prop), 1, 'single output spec');
+    Hg = property.prop{1}.Hg;
+    verifyEqual(testCase, numel(Hg), 2, 'prop_7 has two OR disjuncts');
+    % each disjunct is (and (<= ..)(<= ..)(<= ..)) -> 3 rows
+    verifyEqual(testCase, size(Hg(1).G, 1), 3, 'disjunct 1 has 3 AND rows');
+    verifyEqual(testCase, size(Hg(2).G, 1), 3, 'disjunct 2 has 3 AND rows');
+    assert_all_halfspaces(testCase, Hg);
+end
+
+% ---------------------------------------------------------------------------
+% (i3) REAL benchmark: acasxu prop_3 -- four standalone (<= Y_0 Y_k) asserts
+%      AND-ed into a single disjunct of 4 rows. Pins the "series of asserts -> one
+%      polytope" path on a real file.
+% ---------------------------------------------------------------------------
+function test_real_series_of_asserts_acasxu_prop3(testCase)
+    vf = acas_vnnlib('prop_3.vnnlib');
+    verifyTrue(testCase, isfile(vf), sprintf('missing benchmark file: %s', vf));
+    property = load_vnnlib(vf);
+
+    verifyEqual(testCase, numel(property.prop), 1, 'single output spec');
+    Hg = property.prop{1}.Hg;
+    verifyEqual(testCase, numel(Hg), 1, 'prop_3 output is a single conjunction (no OR)');
+    verifyEqual(testCase, size(Hg(1).G, 1), 4, 'four AND-ed (<= Y_0 Y_k) rows');
+    assert_all_halfspaces(testCase, Hg);
+end
+
+% ---------------------------------------------------------------------------
+% Helpers
+% ---------------------------------------------------------------------------
+function vf = acas_vnnlib(name)
+    vf = fullfile(nnvroot(), 'code', 'nnv', 'examples', 'NNV2.0', 'Submission', ...
+        'CAV2023', 'NNV_vs_MATLAB', 'acas', 'vnnlib', name);
+end
+
+function assert_all_halfspaces(testCase, Hg)
+    % Every element of an Hg array must be a HalfSpace with consistent G/g shapes.
+    verifyTrue(testCase, isa(Hg, 'HalfSpace'), 'Hg must be a HalfSpace array');
+    for i = 1:numel(Hg)
+        verifyTrue(testCase, isa(Hg(i), 'HalfSpace'), 'each disjunct is a HalfSpace');
+        verifyEqual(testCase, size(Hg(i).G, 1), numel(Hg(i).g), ...
+            'rows of G must match length of g');
+        verifyTrue(testCase, size(Hg(i).G, 1) >= 1, 'at least one constraint row');
+    end
+end

--- a/code/nnv/tests/utils/test_load_vnnlib_errors.m
+++ b/code/nnv/tests/utils/test_load_vnnlib_errors.m
@@ -64,7 +64,15 @@ function test_linear_combination_unsupported(testCase)
     c = onCleanup(@() delete(tf));
 
     % Pin: this currently ERRORS (does not produce a well-formed HalfSpace).
-    verifyError(testCase, @() load_vnnlib(tf), '', ...
+    % (Any error identifier is acceptable -- the point is it does not silently
+    % mis-parse; today it throws MATLAB:badsubscript in process_constraint.)
+    threw = false;
+    try
+        load_vnnlib(tf);
+    catch
+        threw = true;
+    end
+    verifyTrue(testCase, threw, ...
         'linear-combination output constraint should currently error (not silently mis-parse)');
 end
 

--- a/code/nnv/tests/utils/test_load_vnnlib_forms.m
+++ b/code/nnv/tests/utils/test_load_vnnlib_forms.m
@@ -1,0 +1,183 @@
+% test_load_vnnlib_forms
+% Regression tests pinning the SHAPE of the property structure load_vnnlib
+% produces for the common VNN-LIB output-specification forms used by the
+% VNN-COMP benchmarks. These complement the single regression in
+% test_load_vnnlib.m ("a constraint after an (or ...) is CONJOINED ...").
+%
+% Output-structure contract (see load_vnnlib.m header + HalfSpace.m):
+%   property.prop                -> 1xN cell; each prop{n} is a struct with field .Hg
+%   property.prop{n}.Hg          -> array of HalfSpace. An ARRAY (numel>1) is an
+%                                   OR / disjunction. Within ONE HalfSpace, the rows
+%                                   of .G (k x dim) and .g (k x 1) are an AND / polytope.
+%   HalfSpace encodes  G * y <= g  (so each row is one linear "<= " constraint).
+%
+% Sign convention (from process_constraint):
+%   (<= Y_a c)      -> row G(a)=+1,            g = c
+%   (>= Y_a c)      -> row G(a)=-1,            g = -c
+%   (<= Y_a Y_b)    -> row G(a)=+1, G(b)=-1,   g = 0
+%   (>= Y_a Y_b)    -> row G(a)=-1, G(b)=+1,   g = 0
+% (variable index a in Y_a is 0-based in the file -> column a+1 in G).
+%
+% To run: results = runtests('test_load_vnnlib_forms')
+
+%% (a) input box + single (<= Y_0 0) -> 1 disjunct, 1 row
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n(declare-const X_1 Real)\n');
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n(declare-const Y_2 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (<= X_1 2.0))\n(assert (>= X_1 -2.0))\n');
+fprintf(fid, '(assert (<= Y_0 0.0))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+% input box recovered exactly
+assert(numel(property.lb) == 2, '(a) two input dims');
+assert(isequal(double(property.lb(:)'), [-1 -2]), '(a) lb = [-1 -2]');
+assert(isequal(double(property.ub(:)'), [ 1  2]), '(a) ub = [1 2]');
+% one disjunct, one row
+assert(numel(property.prop) == 1, '(a) single prop cell');
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 1, '(a) exactly one HalfSpace (no OR)');
+assert(size(Hg(1).G, 1) == 1, '(a) one constraint row');
+assert(size(Hg(1).G, 2) == 3, '(a) three output dims wide');
+% (<= Y_0 0) -> G(1)=+1, rest 0, g=0
+assert(Hg(1).G(1, 1) == 1, '(a) Y_0 coeff = +1');
+assert(all(Hg(1).G(1, 2:3) == 0), '(a) Y_1, Y_2 coeffs = 0');
+assert(Hg(1).g(1) == 0, '(a) rhs g = 0');
+
+%% (b) two standalone conjunct asserts (<= Y_0 0) and (>= Y_1 0) -> 1 disjunct, 2 rows
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n');
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (<= Y_0 0.0))\n');
+fprintf(fid, '(assert (>= Y_1 0.0))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+assert(numel(property.prop) == 1, '(b) single prop cell');
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 1, '(b) one HalfSpace: two standalone asserts AND into one polytope');
+assert(size(Hg(1).G, 1) == 2, '(b) two constraint rows (AND)');
+% row 1: (<= Y_0 0) -> G=[+1 0], g=0
+assert(isequal(Hg(1).G(1, :), [1 0]), '(b) row1 = [1 0] for Y_0<=0');
+assert(Hg(1).g(1) == 0, '(b) row1 g = 0');
+% row 2: (>= Y_1 0) -> G=[0 -1], g=-0=0
+assert(isequal(Hg(1).G(2, :), [0 -1]), '(b) row2 = [0 -1] for Y_1>=0');
+assert(Hg(1).g(2) == 0, '(b) row2 g = 0');
+
+%% (c) pure (or (and >=)(and >=)(and >=)) -> 3 disjuncts, 1 row each
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n');
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n(declare-const Y_2 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (or (and (>= Y_0 1.0)) (and (>= Y_1 1.0)) (and (>= Y_2 1.0))))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+assert(numel(property.prop) == 1, '(c) single prop cell holding the OR');
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 3, '(c) three OR disjuncts -> three HalfSpaces');
+assert(size(Hg(1).G, 1) == 1, '(c) disjunct 1 has one row');
+assert(size(Hg(2).G, 1) == 1, '(c) disjunct 2 has one row');
+assert(size(Hg(3).G, 1) == 1, '(c) disjunct 3 has one row');
+% (>= Y_k 1) -> G(k)=-1, g=-1
+assert(isequal(Hg(1).G, [-1 0 0]) && Hg(1).g == -1, '(c) disjunct 1 = Y_0>=1');
+assert(isequal(Hg(2).G, [0 -1 0]) && Hg(2).g == -1, '(c) disjunct 2 = Y_1>=1');
+assert(isequal(Hg(3).G, [0 0 -1]) && Hg(3).g == -1, '(c) disjunct 3 = Y_2>=1');
+
+%% (d) OR followed by TWO standalone conjuncts -> every disjunct gains BOTH rows
+% This is the load_vnnlib bug-fix path generalized to >1 trailing conjunct.
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n');
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n(declare-const Y_2 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (or (and (>= Y_0 1.0)) (and (>= Y_1 1.0))))\n');
+fprintf(fid, '(assert (<= Y_2 5.0))\n');     % conjunct 1
+fprintf(fid, '(assert (>= Y_2 -5.0))\n');    % conjunct 2
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 2, '(d) still two OR disjuncts (conjuncts must NOT add disjuncts)');
+% each disjunct started with 1 row, grew by 2 -> 3 rows
+assert(size(Hg(1).G, 1) == 3, '(d) disjunct 1 grew by 2 trailing conjunct rows');
+assert(size(Hg(2).G, 1) == 3, '(d) disjunct 2 grew by 2 trailing conjunct rows');
+% the original disjunct constraints (Y_0>=1 / Y_1>=1) still present in row 1
+assert(isequal(Hg(1).G(1, :), [-1 0 0]) && Hg(1).g(1) == -1, '(d) disjunct1 row1 = Y_0>=1');
+assert(isequal(Hg(2).G(1, :), [0 -1 0]) && Hg(2).g(1) == -1, '(d) disjunct2 row1 = Y_1>=1');
+% both conjuncts on Y_2 appear in BOTH disjuncts (rows 2 and 3)
+% (<= Y_2 5) -> [0 0 1], g=5 ;  (>= Y_2 -5) -> [0 0 -1], g=5
+assert(isequal(Hg(1).G(2, :), [0 0 1]) && Hg(1).g(2) == 5,  '(d) disjunct1 conjunctA');
+assert(isequal(Hg(1).G(3, :), [0 0 -1]) && Hg(1).g(3) == 5, '(d) disjunct1 conjunctB');
+assert(isequal(Hg(2).G(2, :), [0 0 1]) && Hg(2).g(2) == 5,  '(d) disjunct2 conjunctA');
+assert(isequal(Hg(2).G(3, :), [0 0 -1]) && Hg(2).g(3) == 5, '(d) disjunct2 conjunctB');
+% the Y_2 conjunct variable appears in EVERY disjunct
+assert(any(Hg(1).G(:, 3) ~= 0), '(d) Y_2 conjunct present in disjunct 1');
+assert(any(Hg(2).G(:, 3) ~= 0), '(d) Y_2 conjunct present in disjunct 2');
+
+%% (e) argmax-style (or (and (>= Y_5 Y_0)) ... ) -> N disjuncts, two-variable +1/-1 rows
+% "Y_5 is NOT the strict argmin/argmax vs each other class" pattern.
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n');
+% Six output vars Y_0..Y_5 (unrolled: %%-section script tests cannot contain a for-loop).
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n(declare-const Y_2 Real)\n');
+fprintf(fid, '(declare-const Y_3 Real)\n(declare-const Y_4 Real)\n(declare-const Y_5 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (or (and (>= Y_5 Y_0)) (and (>= Y_5 Y_1)) (and (>= Y_5 Y_2)) (and (>= Y_5 Y_3)) (and (>= Y_5 Y_4))))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 5, '(e) five OR disjuncts');
+% (>= Y_5 Y_k) -> G(Y_5=col6) = -1, G(Y_k=col k+1) = +1, g = 0
+% disjunct i compares Y_5 against Y_(i-1)
+assert(size(Hg(1).G, 1) == 1, '(e) disjunct 1 single row');
+assert(Hg(1).G(1, 6) == -1, '(e) disjunct1 Y_5 coeff = -1');
+assert(Hg(1).G(1, 1) == 1,  '(e) disjunct1 Y_0 coeff = +1');
+assert(Hg(1).g(1) == 0,     '(e) disjunct1 g = 0');
+assert(Hg(2).G(1, 6) == -1 && Hg(2).G(1, 2) == 1, '(e) disjunct2 = Y_5>=Y_1');
+assert(Hg(3).G(1, 6) == -1 && Hg(3).G(1, 3) == 1, '(e) disjunct3 = Y_5>=Y_2');
+assert(Hg(4).G(1, 6) == -1 && Hg(4).G(1, 4) == 1, '(e) disjunct4 = Y_5>=Y_3');
+assert(Hg(5).G(1, 6) == -1 && Hg(5).G(1, 5) == 1, '(e) disjunct5 = Y_5>=Y_4');
+% each row is EXACTLY the two-variable +1/-1 pattern: one +1, one -1, rest 0
+assert(sum(Hg(1).G(1, :) == 1) == 1 && sum(Hg(1).G(1, :) == -1) == 1, '(e) one +1 and one -1');
+assert(nnz(Hg(1).G(1, :)) == 2, '(e) exactly two nonzero coeffs');
+
+%% (f) single (<= Y_0 Y_1) -> 1 row; exact coefficients
+rng(42);
+tf = [tempname '.vnnlib'];
+fid = fopen(tf, 'w');
+fprintf(fid, '(declare-const X_0 Real)\n');
+fprintf(fid, '(declare-const Y_0 Real)\n(declare-const Y_1 Real)\n');
+fprintf(fid, '(assert (<= X_0 1.0))\n(assert (>= X_0 -1.0))\n');
+fprintf(fid, '(assert (<= Y_0 Y_1))\n');
+fclose(fid);
+property = load_vnnlib(tf);
+delete(tf);
+
+Hg = property.prop{1}.Hg;
+assert(numel(Hg) == 1, '(f) single disjunct');
+assert(size(Hg(1).G, 1) == 1, '(f) single row');
+% (<= Y_0 Y_1) -> G(Y_0)=+1, G(Y_1)=-1, g=0
+assert(Hg(1).G(1, 1) == 1,  '(f) Y_0 coeff = +1');
+assert(Hg(1).G(1, 2) == -1, '(f) Y_1 coeff = -1');
+assert(Hg(1).g(1) == 0,     '(f) g = 0');
+
+%% Summary
+disp('test_load_vnnlib_forms: all sections passed');

--- a/code/nnv/tests/vnncomp25/test_run_all_benchmarks_helpers.m
+++ b/code/nnv/tests/vnncomp25/test_run_all_benchmarks_helpers.m
@@ -1,0 +1,153 @@
+function tests = test_run_all_benchmarks_helpers
+% test_run_all_benchmarks_helpers
+% Function-based unit tests for the PURE helpers of run_all_benchmarks.m that
+% need no network / parpool: instances.csv parsing + status-code stringification.
+%
+% NOTE ON TESTABILITY (see report): the production logic lives in LOCAL functions
+% `pick_instances` / `ensure_decompressed` / `status_to_str` INSIDE
+% run_all_benchmarks.m, which are not reachable from a test. This test exercises
+% the behavior-preserving extracted copies:
+%     examples/Submission/VNN_COMP2025/vnncomp_pick_instances.m
+%     examples/Submission/VNN_COMP2025/vnncomp_status_to_str.m
+% Recommended follow-up refactor: have run_all_benchmarks.m delegate to these so
+% the tested code IS the production code.
+%
+% Run: results = runtests('test_run_all_benchmarks_helpers')
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    % Make the extracted helpers visible on the path.
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+    testCase.TestData.subdir = sub;
+    testCase.TestData.addedPath = false;
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub);
+        testCase.TestData.addedPath = true;
+    end
+end
+
+function teardownOnce(testCase)
+    if isfield(testCase.TestData, 'addedPath') && testCase.TestData.addedPath
+        rmpath(testCase.TestData.subdir);
+    end
+end
+
+% --------------------------------------------------------------------------
+% status_to_str 0/1/2 + negatives + fallthrough
+% --------------------------------------------------------------------------
+function test_status_to_str_mapping(testCase)
+    verifyEqual(testCase, vnncomp_status_to_str(0),  'sat');
+    verifyEqual(testCase, vnncomp_status_to_str(1),  'unsat');
+    verifyEqual(testCase, vnncomp_status_to_str(2),  'unknown');
+    verifyEqual(testCase, vnncomp_status_to_str(-1), 'error');
+    verifyEqual(testCase, vnncomp_status_to_str(-2), 'missing');
+    verifyEqual(testCase, vnncomp_status_to_str(-3), 'decompress_failed');
+    % unrecognized code -> code_<n>
+    verifyEqual(testCase, vnncomp_status_to_str(7),   'code_7');
+    verifyEqual(testCase, vnncomp_status_to_str(-99), 'code_-99');
+end
+
+% --------------------------------------------------------------------------
+% pick_instances 'first' returns exactly ONE resolvable pair, './'-stripped
+% --------------------------------------------------------------------------
+function test_pick_instances_first(testCase)
+    [root, sub] = make_bench(testCase, { ...
+        './onnx/a.onnx', './vnnlib/p1.vnnlib'; ...
+        './onnx/b.onnx', './vnnlib/p2.vnnlib'; ...
+        './onnx/c.onnx', './vnnlib/p3.vnnlib'}, ...
+        {'onnx/a.onnx','vnnlib/p1.vnnlib','onnx/b.onnx','vnnlib/p2.vnnlib', ...
+         'onnx/c.onnx','vnnlib/p3.vnnlib'});
+    inst = fullfile(root, sub, 'instances.csv');
+    pairs = vnncomp_pick_instances(inst, root, sub, 'first');
+
+    verifyEqual(testCase, numel(pairs), 1, 'first -> exactly one instance');
+    verifyEqual(testCase, pairs{1}.onnx_rel,   'onnx/a.onnx', './ stripped from onnx_rel');
+    verifyEqual(testCase, pairs{1}.vnnlib_rel, 'vnnlib/p1.vnnlib', './ stripped from vnnlib_rel');
+    verifyTrue(testCase, isfile(pairs{1}.onnx),   'resolved onnx path exists');
+    verifyTrue(testCase, isfile(pairs{1}.vnnlib), 'resolved vnnlib path exists');
+end
+
+% --------------------------------------------------------------------------
+% pick_instances 'all' returns EVERY resolvable pair, in CSV order
+% --------------------------------------------------------------------------
+function test_pick_instances_all(testCase)
+    [root, sub] = make_bench(testCase, { ...
+        'onnx/a.onnx', 'vnnlib/p1.vnnlib'; ...
+        'onnx/b.onnx', 'vnnlib/p2.vnnlib'; ...
+        'onnx/c.onnx', 'vnnlib/p3.vnnlib'}, ...
+        {'onnx/a.onnx','vnnlib/p1.vnnlib','onnx/b.onnx','vnnlib/p2.vnnlib', ...
+         'onnx/c.onnx','vnnlib/p3.vnnlib'});
+    inst = fullfile(root, sub, 'instances.csv');
+    pairs = vnncomp_pick_instances(inst, root, sub, 'all');
+
+    verifyEqual(testCase, numel(pairs), 3, 'all -> every resolvable instance');
+    verifyEqual(testCase, pairs{1}.onnx_rel, 'onnx/a.onnx');
+    verifyEqual(testCase, pairs{2}.onnx_rel, 'onnx/b.onnx');
+    verifyEqual(testCase, pairs{3}.onnx_rel, 'onnx/c.onnx');
+    verifyEqual(testCase, pairs{2}.vnnlib_rel, 'vnnlib/p2.vnnlib');
+end
+
+% --------------------------------------------------------------------------
+% pick_instances skips rows whose files do NOT exist (unresolvable)
+% --------------------------------------------------------------------------
+function test_pick_instances_skips_unresolvable(testCase)
+    % Only create files for rows 1 and 3; row 2 references missing files.
+    [root, sub] = make_bench(testCase, { ...
+        'onnx/a.onnx', 'vnnlib/p1.vnnlib'; ...
+        'onnx/missing.onnx', 'vnnlib/missing.vnnlib'; ...
+        'onnx/c.onnx', 'vnnlib/p3.vnnlib'}, ...
+        {'onnx/a.onnx','vnnlib/p1.vnnlib','onnx/c.onnx','vnnlib/p3.vnnlib'});
+    inst = fullfile(root, sub, 'instances.csv');
+
+    % 'all' returns only the two resolvable rows
+    pairs = vnncomp_pick_instances(inst, root, sub, 'all');
+    verifyEqual(testCase, numel(pairs), 2, 'unresolvable middle row skipped');
+    verifyEqual(testCase, pairs{1}.onnx_rel, 'onnx/a.onnx');
+    verifyEqual(testCase, pairs{2}.onnx_rel, 'onnx/c.onnx');
+
+    % 'first' still returns the FIRST resolvable row (row 1 here)
+    pairs1 = vnncomp_pick_instances(inst, root, sub, 'first');
+    verifyEqual(testCase, numel(pairs1), 1);
+    verifyEqual(testCase, pairs1{1}.onnx_rel, 'onnx/a.onnx');
+end
+
+% --------------------------------------------------------------------------
+% pick_instances returns {} when nothing is resolvable
+% --------------------------------------------------------------------------
+function test_pick_instances_none_resolvable(testCase)
+    [root, sub] = make_bench(testCase, { ...
+        'onnx/x.onnx', 'vnnlib/x.vnnlib'}, ...
+        {});   % create NO files
+    inst = fullfile(root, sub, 'instances.csv');
+    pairs = vnncomp_pick_instances(inst, root, sub, 'all');
+    verifyTrue(testCase, isempty(pairs), 'no resolvable instances -> empty');
+end
+
+% --------------------------------------------------------------------------
+% Helpers
+% --------------------------------------------------------------------------
+function [root, sub] = make_bench(testCase, rows, files_to_create)
+    % rows: N x 2 cellstr of {onnx_rel, vnnlib_rel} (timeout col auto-added).
+    % files_to_create: cellstr of relative paths (under root/sub) to materialize.
+    root = tempname; mkdir(root);
+    sub = 'benchX';
+    mkdir(fullfile(root, sub));
+    mkdir(fullfile(root, sub, 'onnx'));
+    mkdir(fullfile(root, sub, 'vnnlib'));
+    % write instances.csv (3 columns: onnx_rel, vnnlib_rel, timeout)
+    csvfile = fullfile(root, sub, 'instances.csv');
+    fid = fopen(csvfile, 'w');
+    for r = 1:size(rows, 1)
+        fprintf(fid, '%s,%s,%d\n', rows{r,1}, rows{r,2}, 120);
+    end
+    fclose(fid);
+    % materialize the requested files
+    for k = 1:numel(files_to_create)
+        f = fullfile(root, sub, files_to_create{k});
+        fd = fopen(f, 'w'); fprintf(fd, 'x'); fclose(fd);
+    end
+    % cleanup at end of each test
+    testCase.addTeardown(@() rmdir(root, 's'));
+end

--- a/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
+++ b/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
@@ -62,12 +62,14 @@ function test_supported_categories_reach_import(testCase)
     for i = 1:numel(supported)
         cat = supported{i};
         kind = classify_dispatch(cat);
-        % A supported category must NOT be rejected by the dispatcher's final else.
+        % The meaningful check: a supported category must NOT be rejected by the
+        % dispatcher's final else ("ONNX model not supported"). Whether the bogus-input
+        % run then fails at vnnlib-parse or at model-import is implementation-order
+        % specific (the manifest categories -- lsnc_relu, traffic -- load the vnnlib
+        % before importing, so they surface 'vnnlib_parse'; that is NOT a dispatch
+        % rejection and is acceptable here).
         verifyNotEqual(testCase, kind, 'unsupported_category', ...
             sprintf('category "%s" was rejected as unsupported by the dispatcher', cat));
-        % And it must not look like a vnnlib parse error before import.
-        verifyNotEqual(testCase, kind, 'vnnlib_parse', ...
-            sprintf('category "%s" failed in vnnlib parsing before importing the model', cat));
     end
 end
 

--- a/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
+++ b/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
@@ -1,0 +1,144 @@
+function tests = test_run_vnncomp_dispatch_smoke
+% test_run_vnncomp_dispatch_smoke
+% Category-DISPATCH smoke scaffold for run_vnncomp_instance.m.
+%
+% run_vnncomp_instance(category, onnx, vnnlib, outputfile) selects, via a long
+% if/elseif on `category`, the ONNX import args / reachMethod / reshape for that
+% benchmark, then calls importNetworkFromONNX on `onnx`. This test does NOT verify
+% any network: it passes a NON-EXISTENT onnx/vnnlib and asserts, per category, that
+% the dispatch reaches the RIGHT branch -- i.e. the failure is a FILE / IMPORT
+% error (model can't be loaded), NOT a DISPATCH error:
+%   - the final `else error("ONNX model not supported")` (unknown category), or
+%   - a vnnlib parse error, etc.
+% Known-unsupported categories that deliberately error AT dispatch (before import)
+% are pinned separately with their stable messages.
+%
+% >>> THE MAIN AGENT MUST VALIDATE THIS IN MATLAB. Two things matter:
+%   1. It needs run_vnncomp_instance.m + its dependencies (load_manifest_net,
+%      matlab2nnv, importNetworkFromONNX, ...) on the path; add
+%      examples/Submission/VNN_COMP2025 and run startup_nnv first.
+%   2. For a REAL end-to-end dispatch check, point onnx/vnnlib at local files under
+%      vnncomp2025_benchmarks/benchmarks/<category>/ ; with the dummy paths used
+%      here the test only proves "dispatch did not reject the category", which is
+%      the regression we care about. If importNetworkFromONNX raises a DIFFERENT
+%      error class than expected on this MATLAB build, relax classify_error below.
+%
+% Run: results = runtests('test_run_vnncomp_dispatch_smoke')
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(testCase)
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+    testCase.TestData.subdir = sub;
+    testCase.TestData.addedPath = false;
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub);
+        testCase.TestData.addedPath = true;
+    end
+    % Skip the whole file gracefully if the runner isn't importable here.
+    testCase.assumeTrue(exist('run_vnncomp_instance', 'file') == 2, ...
+        'run_vnncomp_instance not on path; add examples/Submission/VNN_COMP2025 + startup_nnv');
+end
+
+function teardownOnce(testCase)
+    if isfield(testCase.TestData, 'addedPath') && testCase.TestData.addedPath
+        rmpath(testCase.TestData.subdir);
+    end
+end
+
+% --------------------------------------------------------------------------
+% Supported categories: dispatch must NOT reject them. With a bogus onnx path the
+% expected failure is a file/import error (or a manifest-not-found for the two
+% manifest categories), never "ONNX model not supported".
+% --------------------------------------------------------------------------
+function test_supported_categories_reach_import(testCase)
+    supported = { 'acasxu', 'cersyve', 'cgan', 'cifar100', ...
+        'collins_aerospace_benchmark', 'collins_rul', 'cora', 'dist_shift', ...
+        'linearize', 'lsnc_relu', 'malbeware', 'metaroom', 'ml4acopf', ...
+        'nn4sys', 'relusplitter', 'safenlp', 'sat_relu', 'soundness', ...
+        'tinyimagenet', 'tllverify', 'traffic', 'vggnet', 'vit', 'yolo' };
+
+    for i = 1:numel(supported)
+        cat = supported{i};
+        kind = classify_dispatch(cat);
+        % A supported category must NOT be rejected by the dispatcher's final else.
+        verifyNotEqual(testCase, kind, 'unsupported_category', ...
+            sprintf('category "%s" was rejected as unsupported by the dispatcher', cat));
+        % And it must not look like a vnnlib parse error before import.
+        verifyNotEqual(testCase, kind, 'vnnlib_parse', ...
+            sprintf('category "%s" failed in vnnlib parsing before importing the model', cat));
+    end
+end
+
+% --------------------------------------------------------------------------
+% Known-unsupported-at-dispatch categories: they deliberately error in the
+% if/elseif BEFORE importing. Pin the stable messages so a future change that
+% silently starts/stops handling them is caught.
+% --------------------------------------------------------------------------
+function test_cctsdb_yolo_errors_at_dispatch(testCase)
+    msg = dispatch_error_message(testCase, 'cctsdb_yolo');
+    verifyTrue(testCase, contains(msg, 'Working on supporting this one'), ...
+        sprintf('cctsdb_yolo should error at dispatch; got: %s', msg));
+end
+
+function test_unknown_category_is_rejected(testCase)
+    % A category the dispatcher does not recognize must hit the final else.
+    msg = dispatch_error_message(testCase, 'no_such_benchmark_xyz');
+    verifyTrue(testCase, contains(msg, 'ONNX model not supported'), ...
+        sprintf('unknown category should be rejected as unsupported; got: %s', msg));
+end
+
+% --------------------------------------------------------------------------
+% Helpers
+% --------------------------------------------------------------------------
+function msg = dispatch_error_message(testCase, cat)
+    % Invoke run_vnncomp_instance with bogus inputs; return the error message.
+    onnx = [tempname '.onnx'];          % does not exist
+    vnnlib = [tempname '.vnnlib'];      % does not exist
+    outf = [tempname '.txt'];
+    c = onCleanup(@() cleanup_file(outf));
+    msg = '';
+    try
+        run_vnncomp_instance(cat, onnx, vnnlib, outf);
+        % Reaching here means no error at all -- unexpected for bogus inputs.
+        verifyFail(testCase, sprintf('expected an error for category "%s" with bogus inputs', cat));
+    catch ME
+        msg = ME.message;
+    end
+end
+
+function kind = classify_dispatch(cat)
+    % Classify the failure of run_vnncomp_instance with a non-existent model into:
+    %   'unsupported_category' : final else "ONNX model not supported"
+    %   'vnnlib_parse'         : failed parsing the (bogus) vnnlib before import
+    %   'import_or_file'       : import/file error AFTER a real dispatch branch (GOOD)
+    %   'none'                 : no error (unexpected)
+    onnx = [tempname '.onnx'];
+    vnnlib = [tempname '.vnnlib'];
+    outf = [tempname '.txt'];
+    c = onCleanup(@() cleanup_file(outf));
+    try
+        run_vnncomp_instance(cat, onnx, vnnlib, outf);
+        kind = 'none';
+        return;
+    catch ME
+        m = ME.message;
+    end
+    if contains(m, 'ONNX model not supported')
+        kind = 'unsupported_category';
+    elseif contains(m, 'load_vnnlib') || contains(m, 'vnnlib') || ...
+            contains(m, 'fopen') || contains(lower(m), 'property not supported')
+        % NB: with a non-existent vnnlib, load_vnnlib may fail; but import happens
+        % FIRST in run_vnncomp_instance, so a real model would import before the
+        % vnnlib is read. With a bogus onnx the import error fires first, so this
+        % branch should not normally trigger for supported cats.
+        kind = 'vnnlib_parse';
+    else
+        kind = 'import_or_file';
+    end
+end
+
+function cleanup_file(f)
+    if exist(f, 'file'), delete(f); end
+end

--- a/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
+++ b/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
@@ -13,6 +13,26 @@ function tests = test_validate_witness_onnx
     tests = functiontests(localfunctions);
 end
 
+function setupOnce(tc)
+    % validate_witness_onnx lives in examples/Submission/VNN_COMP2025. The matrix CI splits
+    % tests into shards and nothing guarantees that dir is on the path, so add it here to be
+    % self-sufficient -- otherwise these tests intermittently error 'Undefined function
+    % validate_witness_onnx' depending on which other tests share the shard.
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+    tc.TestData.addedPath = '';
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub);
+        tc.TestData.addedPath = sub;
+    end
+end
+
+function teardownOnce(tc)
+    if isfield(tc.TestData, 'addedPath') && ~isempty(tc.TestData.addedPath)
+        rmpath(tc.TestData.addedPath);
+    end
+end
+
 % ---------- fallback contract (environment-independent) ----------
 
 function test_missing_onnx_returns_false(tc)

--- a/code/nnv/tools/vnncomp_compare/compare_to_2025.py
+++ b/code/nnv/tools/vnncomp_compare/compare_to_2025.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
-"""compare_to_2025.py -- put NNV's fresh sweep next to the official VNN-COMP 2025
-results for context.
+"""compare_to_2025.py -- soundness gate + scorecard for an NNV sweep against the official
+VNN-COMP 2025 results.
 
-CURRENT behaviour (the VNN-COMP results repo layout has varied year to year, so this is
-deliberately conservative):
-  1. Prints NNV NEW (this sweep) solved/sat/unsat per benchmark + totals, against the
-     published 2025 NNV baseline (1082 solved / 697.3 pts).
-  2. DISCOVERS the 2025 results repo structure (walks it for *.csv, identifies the likely
-     NNV file, and prints a sample) so the exact column format is visible.
+Reads `<results2025>/<tool>/2025_<bench>/results.csv` for each reference tool and, for every
+NNV definitive (sat/unsat) verdict, compares against the cross-tool result:
+  1. Per-benchmark NNV-NEW vs NNV-2025 solved (sat/unsat) + the NNV-new unknown/timeout/error
+     split, against the published 2025 NNV baseline (1082 solved / 697.3 pts).
+  2. Soundness check (classify_instances): reference = STRICT majority of the other tools'
+     definitive verdicts. NNV sat vs majority unsat -> FALSE-SAT (-150 risk); NNV unsat vs
+     majority sat -> FALSE-UNSAT. A sat-vs-unsat TIE is reported as "no majority" (NOT
+     hard-flagged). Plus a separate "disagrees with alpha-beta-CROWN (gold standard)" list
+     (a-b-CROWN was 0-incorrect in 2025), high-signal even on a tie.
+  3. Coverage gap: instances the field solved but NNV left unknown/timeout/error.
 
-NOT yet implemented (the format above must be confirmed first): per-instance parsing of
-the 2025 verdicts, per-tool totals, and flagging NNV-NEW sat/unsat that disagree with the
-2025 consensus (the -150 risk). The discovery output makes wiring those a small, targeted
-follow-up; the NNV NEW scorecard is exact and self-contained.
+The per-instance classification lives in the pure function `classify_instances` (unit-tested
+in test_compare.py); main() only formats its output.
 
 Usage:
   python3 compare_to_2025.py --new results_all.csv --results2025 <dir>
@@ -42,6 +44,141 @@ def base(name):
     return n
 
 
+def norm(v):
+    """Alias of norm_verdict (verdict-string normalizer)."""
+    return norm_verdict(v)
+
+
+def load_tool_bench(root, tool, bench):
+    """Load one tool's per-benchmark results.
+
+    Expects:  <root>/<tool>/2025_<bench>/results.csv
+    with the VNN-COMP per-tool column layout:
+        category,onnx_path,vnnlib_path,prepare_time,result,run_time
+    Returns {(onnx_base, vnnlib_base): normalized_verdict}. The HEADER row is
+    skipped (so the literal ('onnx_path','vnnlib_path') key never appears); only
+    data rows are keyed. Missing file -> {}.
+    """
+    path = os.path.join(root, tool, '2025_%s' % bench, 'results.csv')
+    out = {}
+    if not os.path.isfile(path):
+        return out
+    with open(path, newline='') as f:
+        for r in csv.reader(f):
+            if len(r) < 6:
+                continue
+            onnx_col, vnnlib_col, verdict_col = r[1], r[2], r[4]
+            # skip the header row (literal column names), not a real instance
+            if onnx_col.strip() == 'onnx_path' and vnnlib_col.strip() == 'vnnlib_path':
+                continue
+            out[(base(onnx_col), base(vnnlib_col))] = norm_verdict(verdict_col)
+    return out
+
+
+def _majority(verdicts):
+    """Given an iterable of solved (sat/unsat) verdicts, return ('sat'|'unsat', strict)
+    where strict is True iff there is a UNIQUE majority. A tie (equal sat/unsat) ->
+    (None, False): there is no majority, so NNV must NOT be hard-flagged against it.
+    Verdicts that are neither sat nor unsat are ignored.
+    """
+    c = Counter(v for v in verdicts if v in ('sat', 'unsat'))
+    sat = c.get('sat', 0)
+    unsat = c.get('unsat', 0)
+    if sat == 0 and unsat == 0:
+        return None, False
+    if sat == unsat:
+        return None, False           # tie -> no majority
+    return ('sat' if sat > unsat else 'unsat'), True
+
+
+def classify_instances(new_inst, ref_cache, tools, ref_tool='alpha_beta_crown'):
+    """Pure soundness classifier for an NNV sweep against reference-tool verdicts.
+
+    Args:
+      new_inst   : {(bench, onnx_base, vnnlib_base): nnv_verdict}  (from load_new)
+      ref_cache  : {(tool, bench): {(onnx_base, vnnlib_base): verdict}}  (load_tool_bench)
+      tools      : list of reference tool names to form the majority over.
+      ref_tool   : the gold-standard tool (default alpha_beta_crown). NNV verdicts that
+                   DISAGREE with this tool specifically are collected separately, even
+                   on a majority tie.
+
+    Returns a dict of lists of keys:
+      agree        : NNV solved verdict == majority.
+      false_sat    : NNV says sat, strict majority says unsat (HARD false flag, -150 risk).
+      false_unsat  : NNV says unsat, strict majority says sat (HARD false flag).
+      ties         : NNV solved but reference is a sat/unsat TIE -> NO majority, NOT a
+                     hard false-flag (counted separately).
+      no_ref       : no reference solved verdict available for the instance.
+      contested    : the reference tools THEMSELVES disagree (both sat and unsat appear
+                     among them) -> the instance is contested in the field, independent of
+                     what NNV said. (A superset of `ties`: a tie is the special case of
+                     an even split; an odd split is contested with a strict majority.)
+      gold_disagree: NNV's solved verdict disagrees specifically with ref_tool's solved
+                     verdict (the gold standard), regardless of majority/tie.
+      coverage_gap : the field (majority) SOLVED the instance but NNV did NOT (unknown/
+                     timeout/error/missing) -> a coverage gap, not a soundness error.
+    """
+    res = {
+        'agree': [], 'false_sat': [], 'false_unsat': [], 'ties': [],
+        'no_ref': [], 'contested': [], 'gold_disagree': [], 'coverage_gap': [],
+    }
+    for key, nnv_v in new_inst.items():
+        bench, onnx_b, vnnlib_b = key
+        ikey = (onnx_b, vnnlib_b)
+
+        # gather reference verdicts for this instance across the requested tools
+        ref_verdicts = []
+        for t in tools:
+            d = ref_cache.get((t, bench))
+            if d and ikey in d:
+                ref_verdicts.append(d[ikey])
+
+        # gold-standard (ref_tool) verdict, if present
+        gold = None
+        gd = ref_cache.get((ref_tool, bench))
+        if gd and ikey in gd:
+            gold = gd[ikey]
+
+        nnv_solved = nnv_v in ('sat', 'unsat')
+        maj, strict = _majority(ref_verdicts)
+        solved_ref = [v for v in ref_verdicts if v in ('sat', 'unsat')]
+
+        # reference tools themselves split (both polarities present) -> contested instance
+        if 'sat' in solved_ref and 'unsat' in solved_ref:
+            res['contested'].append(key)
+
+        # gold-standard disagreement: both sides solved and differ (independent of majority)
+        if nnv_solved and gold in ('sat', 'unsat') and gold != nnv_v:
+            res['gold_disagree'].append(key)
+
+        if not solved_ref:
+            res['no_ref'].append(key)
+            continue
+
+        # coverage gap: field solved it, NNV did not
+        if strict and not nnv_solved:
+            res['coverage_gap'].append(key)
+            continue
+
+        if not nnv_solved:
+            # NNV unknown and no strict field majority either -> nothing to flag
+            continue
+
+        if not strict:
+            # reference is a sat/unsat tie -> no majority -> NOT a hard false-flag
+            res['ties'].append(key)
+            continue
+
+        if maj == nnv_v:
+            res['agree'].append(key)
+        elif nnv_v == 'sat':           # NNV sat vs majority unsat
+            res['false_sat'].append(key)
+        else:                          # NNV unsat vs majority sat
+            res['false_unsat'].append(key)
+
+    return res
+
+
 def load_new(path):
     """NNV's fresh sweep -> {benchmark: Counter(verdicts)} and per-instance verdict map."""
     by_bench = defaultdict(Counter)
@@ -56,28 +193,27 @@ def load_new(path):
     return by_bench, inst
 
 
-def discover_csvs(root):
-    out = []
-    for dp, _, fns in os.walk(root):
-        for fn in fns:
-            if fn.lower().endswith('.csv'):
-                out.append(os.path.join(dp, fn))
+# The reference tools whose verdicts form the cross-tool majority (alpha-beta-CROWN first
+# -- it was sound+complete with 0 incorrect verdicts in 2025, so it is also the gold standard).
+TOOLS = ['alpha_beta_crown', 'neuralsat', 'nnenum', 'pyrat', 'cora', 'rover', 'sobolbox']
+REF_TOOL = 'alpha_beta_crown'
+
+
+def _solved_counts(inst_map):
+    """(#sat, #unsat) over a {key: verdict} map."""
+    sat = sum(1 for v in inst_map.values() if v == 'sat')
+    unsat = sum(1 for v in inst_map.values() if v == 'unsat')
+    return sat, unsat
+
+
+def _votes(ref_cache, bench, onnx, vl):
+    """{tool: verdict} for the tools that gave a definitive verdict on this instance."""
+    out = {}
+    for t in TOOLS:
+        v = ref_cache.get((t, bench), {}).get((onnx, vl))
+        if v in ('sat', 'unsat'):
+            out[t] = v
     return out
-
-
-def sniff(path, max_rows=3):
-    # Read up to max_rows lines; a short file (fewer lines) must still return what it has
-    # -- don't let StopIteration (or any read error) swallow the whole sample.
-    rows = []
-    try:
-        with open(path, newline='', errors='replace') as f:
-            for line in f:
-                rows.append(line.rstrip('\n'))
-                if len(rows) >= max_rows:
-                    break
-    except OSError:
-        pass
-    return rows
 
 
 def main():
@@ -86,47 +222,70 @@ def main():
     ap.add_argument('--results2025', required=True)
     args = ap.parse_args()
 
-    new_by_bench, _ = load_new(args.new)
+    new_by_bench, new_inst = load_new(args.new)
+    rd = args.results2025
+    benches = sorted(new_by_bench)
+
     print("# NNV sweep vs VNN-COMP 2025\n")
-    print("## NNV NEW (this sweep)\n")
-    print("| benchmark | n | sat | unsat | solved | unknown | timeout | error |")
-    print("|---|--:|--:|--:|--:|--:|--:|--:|")
-    tot = Counter()
-    for b in sorted(new_by_bench):
+
+    # --- per-benchmark: NNV NEW vs NNV 2025 ---
+    print("## Per-benchmark: NNV NEW vs NNV 2025\n")
+    print("| benchmark | NNV-new solved (sat/unsat) | NNV-2025 solved (sat/unsat) | NNV-new unk/to/err |")
+    print("|---|---|---|---|")
+    tot_new = Counter()
+    for b in benches:
         c = new_by_bench[b]
+        nsat, nunsat = c.get('sat', 0), c.get('unsat', 0)
         err = sum(v for k, v in c.items() if k in ('error', 'missing', 'decompress_failed',
                                                    'no_instances_csv', 'no_resolvable_instance'))
-        solved = c.get('sat', 0) + c.get('unsat', 0)
-        for k in ('sat', 'unsat', 'unknown', 'timeout'):
-            tot[k] += c.get(k, 0)
-        tot['solved'] += solved
-        print(f"| {b} | {sum(c.values())} | {c.get('sat',0)} | {c.get('unsat',0)} | {solved} | "
-              f"{c.get('unknown',0)} | {c.get('timeout',0)} | {err} |")
-    print(f"\n**NNV NEW totals:** solved {tot['solved']} (sat {tot['sat']} / unsat {tot['unsat']}), "
-          f"unknown {tot['unknown']}, timeout {tot['timeout']}.")
+        osat, ounsat = _solved_counts(load_tool_bench(rd, 'nnv', b))
+        tot_new['sat'] += nsat
+        tot_new['unsat'] += nunsat
+        print(f"| {b} | {nsat+nunsat} ({nsat}/{nunsat}) | {osat+ounsat} ({osat}/{ounsat}) | "
+              f"{c.get('unknown',0)}/{c.get('timeout',0)}/{err} |")
+    print(f"\n**Totals -- NNV NEW:** solved {tot_new['sat']+tot_new['unsat']} "
+          f"(sat {tot_new['sat']} / unsat {tot_new['unsat']}).")
     print("Baseline (2025 official): NNV solved 1082 (354 sat / 728 unsat), 6th/7, 697.3 pts.\n")
 
-    # --- discover the 2025 results structure ---
-    csvs = discover_csvs(args.results2025)
-    print(f"## 2025 results repo: discovered {len(csvs)} CSV file(s)\n")
-    if not csvs:
-        print("No CSVs found -- the repo layout may differ; inspect "
-              f"`{args.results2025}` and extend this script. NNV NEW scorecard above stands alone.")
-        return 0
-    # Show a sample so the format is obvious and the heuristics refinable.
-    nnv_csvs = [p for p in csvs if 'nnv' in p.lower()]
-    print("Sample files (first 12):")
-    for p in csvs[:12]:
-        print(f"- `{os.path.relpath(p, args.results2025)}`")
-    if nnv_csvs:
-        print(f"\nLikely NNV 2025 file(s): {[os.path.relpath(p, args.results2025) for p in nnv_csvs[:5]]}")
-        print("```\n" + "\n".join(sniff(nnv_csvs[0])) + "\n```")
-    else:
-        print("\nNo file path contained 'nnv'; 2025 per-tool results may be columns in a combined CSV.")
-        print("```\n" + "\n".join(sniff(csvs[0])) + "\n```")
-    print("\n> NEXT: per-instance parsing of the 2025 verdicts and agreement-checking against the "
-          "consensus are NOT yet implemented -- add them to `compare_to_2025.py` using the format "
-          "shown above (a small, targeted follow-up). The NNV NEW scorecard is exact and self-contained.")
+    # --- soundness check: NNV verdicts vs the cross-tool MAJORITY (and gold standard) ---
+    ref_cache = {(t, b): load_tool_bench(rd, t, b) for t in TOOLS for b in benches}
+    res = classify_instances(new_inst, ref_cache, TOOLS, REF_TOOL)
+    nchecked = (len(res['agree']) + len(res['false_sat']) + len(res['false_unsat'])
+                + len(res['ties']) + len(res['no_ref']))
+    print("## Soundness check: NNV-NEW verdicts vs the cross-tool MAJORITY\n")
+    print(f"- NNV-NEW definitive verdicts checked: {nchecked}")
+    print(f"- **AGREE with majority:** {len(res['agree'])}")
+    print(f"- **NO reference** (no other tool gave a definitive verdict): {len(res['no_ref'])}")
+    print(f"- **NO majority** (tools tied sat-vs-unsat): {len(res['ties'])} -- contested, not hard-flagged")
+    print(f"- !! **NNV sat but majority unsat (probable FALSE SAT, -150 risk):** {len(res['false_sat'])}")
+    print(f"- !! **NNV unsat but majority sat (probable unsound proof):** {len(res['false_unsat'])}")
+    print(f"- !! **NNV disagrees with alpha-beta-CROWN (gold standard):** {len(res['gold_disagree'])}\n")
+
+    def show(title, keys):
+        if not keys:
+            return
+        print(f"### {title}\n")
+        for (b, onnx, vl) in keys[:80]:
+            print(f"- `{b}` {onnx} / {vl}: NNV={new_inst[(b, onnx, vl)]}, tool votes {_votes(ref_cache, b, onnx, vl)}")
+        if len(keys) > 80:
+            print(f"- ... and {len(keys)-80} more")
+        print()
+    show("FALSE-SAT: NNV=sat vs the majority", res['false_sat'])
+    show("FALSE-UNSAT: NNV=unsat vs the majority", res['false_unsat'])
+    show("NNV disagrees with alpha-beta-CROWN (review first -- gold standard)", res['gold_disagree'])
+    if not res['false_sat'] and not res['false_unsat'] and not res['gold_disagree']:
+        print("OK: No NNV-NEW verdict disagreed with the majority or with alpha-beta-CROWN -- "
+              "sound on the checked instances.\n")
+
+    # --- coverage gap: the field solved it but NNV did not (minimize these) ---
+    print("## Coverage gap: instances the FIELD solved but NNV did not (minimize these)\n")
+    gap_by_bench = Counter(b for (b, o, vl) in res['coverage_gap'])
+    solved_by_bench = Counter(b for (b, o, vl), v in new_inst.items() if v in ('sat', 'unsat'))
+    print("| benchmark | field-solved & NNV-unknown/to/err | NNV-solved |")
+    print("|---|--:|--:|")
+    for b in benches:
+        if gap_by_bench[b] or solved_by_bench[b]:
+            print(f"| {b} | {gap_by_bench[b]} | {solved_by_bench[b]} |")
     return 0
 
 

--- a/code/nnv/tools/vnncomp_compare/test_compare.py
+++ b/code/nnv/tools/vnncomp_compare/test_compare.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Unit tests for the VNN-COMP comparison tooling (stdlib unittest only).
+
+Run from this directory:
+    python -m unittest test_compare
+
+Covers:
+  - compare_to_2025.base / norm_verdict / norm
+  - compare_to_2025.load_tool_bench  (header skipping + keying)
+  - compare_to_2025.classify_instances  (per-instance soundness logic)
+  - summarize_sweep tallies + time-stat exclusion of 0-time rows
+"""
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+# import the modules under test (this file lives alongside them)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import compare_to_2025 as cmp  # noqa: E402
+import summarize_sweep as summ  # noqa: E402
+
+
+class TestBase(unittest.TestCase):
+    def test_strip_extensions(self):
+        self.assertEqual(cmp.base('foo.onnx'), 'foo')
+        self.assertEqual(cmp.base('foo.vnnlib'), 'foo')
+        self.assertEqual(cmp.base('foo.csv'), 'foo')
+        self.assertEqual(cmp.base('foo.gz'), 'foo')
+
+    def test_strips_directory(self):
+        self.assertEqual(cmp.base('a/b/c/model.onnx'), 'model')
+        # os.path.basename uses the platform separator; backslash on Windows.
+        self.assertEqual(cmp.base(os.path.join('x', 'y', 'spec.vnnlib')), 'spec')
+
+    def test_ext_strip_is_single_pass_outer_first(self):
+        # base() strips ONE matching extension per ext in order (.gz then .onnx ...).
+        # 'model.onnx.gz' -> '.gz' stripped -> 'model.onnx' -> '.onnx' stripped -> 'model'
+        self.assertEqual(cmp.base('model.onnx.gz'), 'model')
+        # '.vnnlib.gz' -> 'spec.vnnlib' -> 'spec'
+        self.assertEqual(cmp.base('spec.vnnlib.gz'), 'spec')
+
+    def test_no_known_extension_kept(self):
+        self.assertEqual(cmp.base('weird.txt'), 'weird.txt')
+        self.assertEqual(cmp.base('plain'), 'plain')
+
+    def test_whitespace_trimmed(self):
+        self.assertEqual(cmp.base('  spaced.onnx  '), 'spaced')
+
+
+class TestNormVerdict(unittest.TestCase):
+    def test_holds_to_unsat(self):
+        self.assertEqual(cmp.norm_verdict('holds'), 'unsat')
+
+    def test_violated_to_sat(self):
+        self.assertEqual(cmp.norm_verdict('violated'), 'sat')
+
+    def test_true_to_unsat(self):
+        self.assertEqual(cmp.norm_verdict('true'), 'unsat')
+
+    def test_false_to_sat(self):
+        self.assertEqual(cmp.norm_verdict('false'), 'sat')
+
+    def test_trim_and_lowercase(self):
+        self.assertEqual(cmp.norm_verdict('  SAT '), 'sat')
+        self.assertEqual(cmp.norm_verdict('UNSAT'), 'unsat')
+        self.assertEqual(cmp.norm_verdict(' Holds '), 'unsat')
+
+    def test_passthrough_unknown(self):
+        self.assertEqual(cmp.norm_verdict('unknown'), 'unknown')
+        self.assertEqual(cmp.norm_verdict('timeout'), 'timeout')
+        self.assertEqual(cmp.norm_verdict('error'), 'error')
+
+    def test_none_and_empty(self):
+        self.assertEqual(cmp.norm_verdict(None), '')
+        self.assertEqual(cmp.norm_verdict(''), '')
+
+    def test_norm_is_alias(self):
+        for v in ('holds', 'violated', ' TRUE ', 'false', 'sat', None):
+            self.assertEqual(cmp.norm(v), cmp.norm_verdict(v))
+
+
+class TestLoadToolBench(unittest.TestCase):
+    HEADER = 'category,onnx_path,vnnlib_path,prepare_time,result,run_time\n'
+
+    def _write(self, root, tool, bench, body):
+        d = os.path.join(root, tool, '2025_%s' % bench)
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, 'results.csv'), 'w', newline='') as f:
+            f.write(self.HEADER)
+            f.write(body)
+
+    def test_header_skipped_and_keyed_by_bases(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._write(root, 'nnv', 'acasxu',
+                        'acasxu,model_a.onnx,prop_1.vnnlib,0.1,holds,2.3\n'
+                        'acasxu,model_b.onnx.gz,prop_2.vnnlib.gz,0.2,violated,1.1\n')
+            d = cmp.load_tool_bench(root, 'nnv', 'acasxu')
+
+        # the header row's literal column names must NOT appear as a key
+        self.assertNotIn(('onnx_path', 'vnnlib_path'), d)
+        # data rows keyed by (onnx_base, vnnlib_base) with normalized verdicts
+        self.assertEqual(d[('model_a', 'prop_1')], 'unsat')   # holds -> unsat
+        self.assertEqual(d[('model_b', 'prop_2')], 'sat')     # violated -> sat ; .gz/.onnx stripped
+        self.assertEqual(len(d), 2)
+
+    def test_missing_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as root:
+            self.assertEqual(cmp.load_tool_bench(root, 'nnv', 'nope'), {})
+
+    def test_short_rows_ignored(self):
+        with tempfile.TemporaryDirectory() as root:
+            self._write(root, 't', 'b',
+                        'b,m.onnx,s.vnnlib,0.0,sat,0.5\n'
+                        'truncated,row\n')              # < 6 cols -> skipped
+            d = cmp.load_tool_bench(root, 't', 'b')
+        self.assertEqual(d, {('m', 's'): 'sat'})
+
+
+class TestClassifyInstances(unittest.TestCase):
+    REF_TOOL = 'alpha_beta_crown'
+
+    def _cache(self, mapping):
+        # mapping: {(tool, bench): {(onnx, vnnlib): verdict}}
+        return dict(mapping)
+
+    def test_nnv_sat_vs_majority_unsat_is_false_sat(self):
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'unsat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+            ('t3', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2', 't3'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['false_sat'])
+        self.assertEqual(out['false_unsat'], [])
+        self.assertEqual(out['agree'], [])
+
+    def test_nnv_unsat_vs_majority_sat_is_false_unsat(self):
+        new = {('b', 'm', 's'): 'unsat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'sat'},
+            ('t2', 'b'): {('m', 's'): 'sat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['false_unsat'])
+        self.assertEqual(out['false_sat'], [])
+
+    def test_agreement(self):
+        new = {('b', 'm', 's'): 'unsat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'unsat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['agree'])
+        self.assertEqual(out['false_sat'], [])
+        self.assertEqual(out['false_unsat'], [])
+
+    def test_tie_is_not_a_hard_false_flag(self):
+        # 1 sat vs 1 unsat -> NO majority. NNV sat must be in 'ties', not 'false_sat'.
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'sat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['ties'])
+        self.assertNotIn(('b', 'm', 's'), out['false_sat'])
+        self.assertNotIn(('b', 'm', 's'), out['false_unsat'])
+        # a tie with both polarities is also a 'contested' instance
+        self.assertIn(('b', 'm', 's'), out['contested'])
+
+    def test_gold_disagree_listed_even_on_a_tie(self):
+        # NNV sat; alpha_beta_crown says unsat; the field is a tie overall.
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({
+            (self.REF_TOOL, 'b'): {('m', 's'): 'unsat'},
+            ('other', 'b'): {('m', 's'): 'sat'},
+        })
+        out = cmp.classify_instances(new, ref, [self.REF_TOOL, 'other'], ref_tool=self.REF_TOOL)
+        # tie -> not a hard flag
+        self.assertIn(('b', 'm', 's'), out['ties'])
+        self.assertNotIn(('b', 'm', 's'), out['false_sat'])
+        # but it DOES disagree with the gold standard specifically
+        self.assertIn(('b', 'm', 's'), out['gold_disagree'])
+
+    def test_gold_agree_not_flagged(self):
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({
+            (self.REF_TOOL, 'b'): {('m', 's'): 'sat'},
+            ('other', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, [self.REF_TOOL, 'other'], ref_tool=self.REF_TOOL)
+        self.assertNotIn(('b', 'm', 's'), out['gold_disagree'])
+
+    def test_no_ref_when_reference_unknown(self):
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'unknown'},
+            ('t2', 'b'): {('m', 's'): 'timeout'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['no_ref'])
+        self.assertEqual(out['false_sat'], [])
+
+    def test_no_ref_when_instance_absent(self):
+        new = {('b', 'm', 's'): 'sat'}
+        ref = self._cache({('t1', 'b'): {('other', 'spec'): 'unsat'}})
+        out = cmp.classify_instances(new, ref, ['t1'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['no_ref'])
+
+    def test_coverage_gap_field_solved_nnv_unknown(self):
+        # field has a strict majority (solved); NNV says unknown -> coverage gap, not error.
+        new = {('b', 'm', 's'): 'unknown'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'unsat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['coverage_gap'])
+        self.assertEqual(out['false_sat'], [])
+        self.assertEqual(out['false_unsat'], [])
+
+    def test_nnv_unknown_and_field_tie_not_coverage_gap(self):
+        # field is a tie (no strict majority) and NNV unknown -> nothing flagged,
+        # specifically NOT a coverage gap (the field didn't "solve" it either).
+        new = {('b', 'm', 's'): 'unknown'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'sat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2'], ref_tool=self.REF_TOOL)
+        self.assertNotIn(('b', 'm', 's'), out['coverage_gap'])
+        self.assertIn(('b', 'm', 's'), out['contested'])
+
+    def test_contested_odd_split_with_majority(self):
+        # 2 unsat vs 1 sat: strict majority unsat, but the field is contested.
+        new = {('b', 'm', 's'): 'unsat'}
+        ref = self._cache({
+            ('t1', 'b'): {('m', 's'): 'unsat'},
+            ('t2', 'b'): {('m', 's'): 'unsat'},
+            ('t3', 'b'): {('m', 's'): 'sat'},
+        })
+        out = cmp.classify_instances(new, ref, ['t1', 't2', 't3'], ref_tool=self.REF_TOOL)
+        self.assertIn(('b', 'm', 's'), out['agree'])       # NNV matches the majority
+        self.assertIn(('b', 'm', 's'), out['contested'])   # but tools split
+
+
+class TestSummarizeSweep(unittest.TestCase):
+    def _run(self, csv_text):
+        with tempfile.NamedTemporaryFile('w', suffix='.csv', delete=False, newline='') as f:
+            f.write(csv_text)
+            path = f.name
+        try:
+            buf = io.StringIO()
+            old = sys.argv
+            sys.argv = ['summarize_sweep.py', path]
+            try:
+                with redirect_stdout(buf):
+                    rc = summ.main()
+            finally:
+                sys.argv = old
+            return rc, buf.getvalue()
+        finally:
+            os.unlink(path)
+
+    CSV = (
+        'subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message\n'
+        'acasxu,acasxu,a.onnx,p1.vnnlib,0,sat,1.5,\n'
+        'acasxu,acasxu,a.onnx,p2.vnnlib,1,unsat,2.5,\n'
+        'acasxu,acasxu,a.onnx,p3.vnnlib,2,unknown,3.0,\n'
+        'cersyve,cersyve,b.onnx,q1.vnnlib,-1,timeout,0,exceeded\n'
+        'cersyve,cersyve,b.onnx,q2.vnnlib,-1,error,0,boom\n'
+        'cersyve,cersyve,b.onnx,q3.vnnlib,-2,missing,0,\n'
+    )
+
+    def test_tallies(self):
+        rc, out = self._run(self.CSV)
+        self.assertEqual(rc, 0)
+        self.assertIn('**Instances:** 6', out)
+        self.assertIn('**Solved:** 2  (sat 1 / unsat 1)', out)
+        # unknown 1, timeout 1, error/missing = error + missing = 2
+        self.assertIn('**Unknown:** 1', out)
+        self.assertIn('**Timeout:** 1', out)
+        self.assertIn('**Error/missing:** 2', out)
+
+    def test_time_stats_exclude_zero_time_rows(self):
+        # only the 3 acasxu rows have time>0 (1.5, 2.5, 3.0) -> mean 2.3, max 3.0.
+        # the 0-time timeout/error/missing rows must NOT drag the mean down.
+        rc, out = self._run(self.CSV)
+        self.assertIn('mean 2.3s', out)
+        self.assertIn('max 3.0s', out)
+
+    def test_no_time_line_when_all_zero(self):
+        csv_text = (
+            'subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message\n'
+            'x,x,a.onnx,p.vnnlib,-2,missing,0,\n'
+        )
+        rc, out = self._run(csv_text)
+        self.assertEqual(rc, 0)
+        self.assertNotIn('Time/instance', out)   # no time>0 rows -> stat suppressed
+
+    def test_optimistic_score(self):
+        rc, out = self._run(self.CSV)
+        # 2 solved * 10 = 20
+        self.assertIn('**20**', out)
+
+    def test_per_benchmark_rows(self):
+        rc, out = self._run(self.CSV)
+        self.assertIn('| acasxu |', out)
+        self.assertIn('| cersyve |', out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hardening NNV's VNN-COMP infrastructure with regression tests **and** fixing latent parser soundness bugs surfaced by an adversarial audit. Three commits:

### 1. `fix(load_vnnlib)`: 3 latent soundness bugs (audit)
An adversarial audit of the soundness-critical parser found three latent wrong-verdict bugs. All are dodged by the 2025 benchmark set but each would flip a sat/unsat on a 2026 benchmark using the form. **Confirmed manifesting (MCP probe), fixed, regression-tested:**
1. **Strict `>` input constraint set the UPPER bound** (`process_input_constraint` routed to lower only on `>=`) → wrong input domain → false sat/unsat.
2. **Conjunct before an `(or ...)`** errored / dropped the disjunction (mirror of the already-fixed after-the-or case) → AND it into every disjunct now.
3. **Multi-input-region `(or ...)` leaked bounds across disjuncts** (no per-disjunct reset) → reset each disjunct to the global box.

No behavior change for current benchmarks (existing `test_load_vnnlib` 10/10, plus acasxu multi-region tests, all pass).

### 2. `test(vnncomp)`: regression suite
- **test_load_vnnlib_forms** (7), **test_load_vnnlib_errors** (5): parsing forms incl. OR+conjunct, argmax OR, Y-to-Y signs; pins top-level-`(and)` and linear-combo as current errors; real acasxu prop_3/6/7 multi-region well-formedness.
- **test_run_all_benchmarks_helpers** (5) + extracted `vnncomp_pick_instances.m`/`vnncomp_status_to_str.m`: unit-testable helpers.
- **test_run_vnncomp_dispatch_smoke** (3): every supported category is dispatched (not rejected as unsupported).

### 3. `test+refactor(compare)`
Extracts the per-instance soundness logic into a pure, unit-tested `classify_instances` (strict majority; ties not hard-flagged; gold-standard α-β-CROWN list) + **32** python tests. Output verified identical on the clean re-sweep (229/229 agree, 0 false sat/unsat).

**Validation:** all MATLAB tests pass in R2026a (runtests); python 32/32. Authored largely by a subagent, reconciled + fixed two test-signature issues on validation.

**Deferred (documented, no current benchmark):** `process_combined_input_output` (option-3) has the same leak + a fragile `extractBetween('))')`; and a defensive 'every declared input got both bounds' guard. Tracked for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)