### PR TITLE
Fix sequence-mode output assembly loop in LstmLayer star reachability

### DIFF
--- a/code/nnv/engine/nn/layers/LstmLayer.m
+++ b/code/nnv/engine/nn/layers/LstmLayer.m
@@ -333,7 +333,7 @@ classdef LstmLayer < handle
                 elseif obj.outputMode == "sequence"
                     lb = [];
                     ub = [];
-                    for i = length(ht)
+                    for i = 1:length(ht)
                         [l, u] = ht(i).getRanges;
                         lb = [lb,l];
                         ub = [ub,u];

--- a/code/nnv/tests/soundness/test_LstmLayer_sequence_outputMode.m
+++ b/code/nnv/tests/soundness/test_LstmLayer_sequence_outputMode.m
@@ -1,0 +1,46 @@
+% test_LstmLayer_sequence_outputMode
+% Regression test: with OutputMode = 'sequence', star reachability must
+% return one set of ranges per time step. Previously the assembly loop
+% in reach_star_single_input iterated `for i = length(ht)` (instead of
+% `for i = 1:length(ht)`), so the output contained only the last time
+% step regardless of the input sequence length.
+% To run: results = runtests('test_LstmLayer_sequence_outputMode')
+
+%% Test 1: sequence-mode output has one column per time step
+rng(42);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 5;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_seq_mode', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'sequence');
+
+x = randn(inputSize, seqLength);
+ep = 0.05;
+IM = ImageStar(x - ep, x + ep);
+
+R = L.reach_star_single_input(IM);
+
+assert(isa(R, 'ImageStar'), 'sequence-mode output must be an ImageStar');
+assert(R.height == numHiddenUnits, ...
+    'sequence-mode output must have numHiddenUnits rows');
+assert(R.width == seqLength, ...
+    'sequence-mode output must have one column per time step');
+
+[lb, ub] = R.getRanges;
+assert(all(lb(:) <= ub(:) + 1e-12), ...
+    'lower bounds must not exceed upper bounds');


### PR DESCRIPTION
## Summary

In `LstmLayer.reach_star_single_input`, the `outputMode == "sequence"` branch assembles per-time-step output ranges with

```matlab
for i = length(ht)
```

which iterates **only the last time step** (missing `1:`), so the returned `ImageStar` always had width 1 regardless of the input sequence length. With the fix the output has one column per time step, as the surrounding code intends.

## Changes

* `for i = length(ht)` → `for i = 1:length(ht)` in the sequence-mode assembly loop.
* New regression test `tests/soundness/test_LstmLayer_sequence_outputMode.m`: builds a 5-step input set, runs `reach_star_single_input` with `OutputMode = 'sequence'`, and asserts the output is an `ImageStar` of height `numHiddenUnits` and width `seqLength` with consistent bounds. Verified in MATLAB R2025b (fails before the fix with width 1, passes after).

Related: #317 (soundness of the star Hadamard product used by this method); the dispatch and sequence-path fixes are in separate PRs so each change can be reviewed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
