### PR TITLE
Add missing LstmLayer.reach_star_multipleInputs dispatch target

### DIFF
--- a/code/nnv/engine/nn/layers/LstmLayer.m
+++ b/code/nnv/engine/nn/layers/LstmLayer.m
@@ -207,14 +207,22 @@ classdef LstmLayer < handle
                     error('Invalid number of input arguments (should be 2, 3, 4, 5, or 6)');
             end
             
-            if strcmp(method, 'approx-star') || strcmp(method, 'exact-star') || strcmp(method, 'abs-dom') || contains(method, "relax-star")
+            if strcmp(method, 'exact-star')
+                % the LSTM star path composes over-approximations
+                % (per-step input boxing, approx-star activations,
+                % McCormick product envelopes), so an exact star set is
+                % not computable; fail closed rather than return an
+                % over-approximation labeled exact, which NN.verify
+                % would treat as a complete result
+                error("LstmLayer does not support 'exact-star' reachability: the LSTM star set is an over-approximation. Use 'approx-star'.");
+            elseif strcmp(method, 'approx-star') || strcmp(method, 'abs-dom') || contains(method, "relax-star")
                 IS = obj.reach_star_multipleInputs(in_images, option);
             elseif strcmp(method, 'approx-zono')
                 IS = obj.reach_zono_multipleInputs(in_images, option);
             else
                 error('Unknown reachability method');
             end
-            
+
         end
         
         function IS = reachSequence(varargin)
@@ -288,9 +296,9 @@ classdef LstmLayer < handle
             end
             
             if isa(in_image, 'ImageStar')
-                % reach using ImageStar
-                N = size(in_image.im_lb);
-                if N(1,1) ~= obj.InputSize
+                % reach using ImageStar (im_lb may be empty, e.g. for
+                % sets produced by other layers, so check the height)
+                if in_image.height ~= obj.InputSize
                     error('Inconsistency between the size of the input image and the InputSize of the network');
                 end
                 if ~all(obj.hiddenState == 0)
@@ -344,6 +352,37 @@ classdef LstmLayer < handle
             
         end
         
+        % handle multiple inputs
+        function S = reach_star_multipleInputs(obj, inputs, option)
+            % @inputs: an array of ImageStars
+            % @option: = 'parallel' or 'single'
+            % @S: output ImageStar
+
+            % The star-method branch of reach() dispatches here; the
+            % method was previously missing, so reach() errored for
+            % every star-based method.
+
+            n = length(inputs);
+            if isa(inputs, "ImageStar")
+                S(n) = ImageStar;
+            else
+                error("Input must be ImageStar");
+            end
+
+            if strcmp(option, 'parallel')
+                parfor i=1:n
+                    S(i) = obj.reach_star_single_input(inputs(i));
+                end
+            elseif strcmp(option, 'single') || isempty(option)
+                for i=1:n
+                    S(i) = obj.reach_star_single_input(inputs(i));
+                end
+            else
+                error('Unknown computation option, should be parallel or single');
+            end
+
+        end
+
         % handle multiple inputs
         function S = reach_star_multipleInputs_Sequence(obj, inputs, option)
             % @inputs: an array of ImageStars

--- a/code/nnv/engine/nn/layers/LstmLayer.m
+++ b/code/nnv/engine/nn/layers/LstmLayer.m
@@ -333,7 +333,7 @@ classdef LstmLayer < handle
                 elseif obj.outputMode == "sequence"
                     lb = [];
                     ub = [];
-                    for i = length(ht)
+                    for i = 1:length(ht)
                         [l, u] = ht(i).getRanges;
                         lb = [lb,l];
                         ub = [ub,u];

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -381,9 +381,26 @@ classdef Star
         end
         
         function S = HadamardProduct(obj, X)
+            % HadamardProduct - sound over-approximation of the elementwise
+            % product of two stars, z = x .* y for x in obj, y in X.
+            %
             % @X: another star with same dimension
-            % @S: new star
-            
+            % @S: new star, guaranteed to contain {x .* y : x in obj, y in X}
+            %
+            % For each output neuron z(i) = x(i)*y(i) with x(i) in [lx, ux]
+            % and y(i) in [ly, uy], one new predicate variable z(i) is
+            % introduced, bounded by the four McCormick inequalities
+            %
+            %   z >= lx*y + ly*x - lx*ly      z <= ux*y + ly*x - ux*ly
+            %   z >= ux*y + uy*x - ux*uy      z <= lx*y + uy*x - lx*uy
+            %
+            % which are linear in the predicate variables after substituting
+            % the affine forms of x and y, and enclose the bilinear term
+            % over the box [lx,ux] x [ly,uy]. The two stars are treated as
+            % independent (their predicate variables are not identified,
+            % even if their constraints coincide), which always yields a
+            % superset of the product under any dependency between them.
+
             if ~isa(X, 'Star')
                 error('Input matrix is not a Star');
             else
@@ -391,27 +408,68 @@ classdef Star
                     error('Input star and current star have different dimensions');
                 end
             end
-            
-            m1 = size(obj.V, 2);
-            m2 = size(X.V, 2);
-            V1 = obj.V(:, 2:m1);
-            V2 = X.V(:, 2:m2);
-            new_c = obj.V(:, 1) .* X.V(:, 1);
-            
-            % check if two Star has the same constraints
-            if size(obj.C, 1) == size(X.C, 1) && size(obj.C, 2) == size(X.C, 2) && norm(obj.C - X.C) + norm(obj.d - X.d) < 0.0001
-               V3 = V1 .* V2;
-               new_V = horzcat(new_c, V3);
-               S = Star(new_V, obj.C, obj.d, obj.predicate_lb, obj.predicate_ub); % new Star has the same number of basic vectors
+
+            n = obj.dim;
+            n1 = obj.nVar;
+            n2 = X.nVar;
+
+            cx = obj.V(:, 1);
+            cy = X.V(:, 1);
+            Wx = obj.V(:, 2:n1+1);
+            Wy = X.V(:, 2:n2+1);
+
+            % bounds of each factor (estimateRanges if predicate bounds are
+            % known, otherwise exact ranges via LP)
+            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub)
+                [lx, ux] = obj.estimateRanges;
             else
-                V3 = horzcat(V1, V2);
-                % new_c = obj.V(:, 1) + X.V(:, 1);
-                new_V = horzcat(new_c, V3);        
-                new_C = blkdiag(obj.C, X.C);        
-                new_d = vertcat(obj.d, X.d);
-                new_pred_lb = [obj.predicate_lb; X.predicate_lb];
-                new_pred_ub = [obj.predicate_ub; X.predicate_ub];
-                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                [lx, ux] = obj.getRanges;
+            end
+            if ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+                [ly, uy] = X.estimateRanges;
+            else
+                [ly, uy] = X.getRanges;
+            end
+
+            % output is the new predicate variables z, predicate vector is
+            % [alpha (n1); beta (n2); z (n)]
+            new_V = [zeros(n, 1+n1+n2, 'like', obj.V), eye(n, 'like', obj.V)];
+
+            % original constraints on alpha and beta, padded for z
+            C0 = blkdiag(obj.C, X.C);
+            C0 = [C0, zeros(size(C0, 1), n, 'like', obj.V)];
+            d0 = [obj.d; X.d];
+
+            % McCormick constraints, one block of n rows each, over
+            % [alpha; beta; z]:
+            %   lower:  a*Wy(i,:)*beta + b*Wx(i,:)*alpha - z(i) <= a*b - a*cy(i) - b*cx(i)
+            %           with (a,b) = (lx,ly) and (ux,uy)
+            %   upper: -a*Wy(i,:)*beta - b*Wx(i,:)*alpha + z(i) <= a*cy(i) + b*cx(i) - a*b
+            %           with (a,b) = (ux,ly) and (lx,uy)
+            I = eye(n, 'like', obj.V);
+            Cm = [ ly.*Wx,  lx.*Wy, -I;
+                   uy.*Wx,  ux.*Wy, -I;
+                  -ly.*Wx, -ux.*Wy,  I;
+                  -uy.*Wx, -lx.*Wy,  I];
+            dm = [lx.*ly - lx.*cy - ly.*cx;
+                  ux.*uy - ux.*cy - uy.*cx;
+                  ux.*cy + ly.*cx - ux.*ly;
+                  lx.*cy + uy.*cx - lx.*uy];
+
+            new_C = [C0; Cm];
+            new_d = [d0; dm];
+
+            % range of z is attained at the corners of the factor box
+            corners = [lx.*ly, lx.*uy, ux.*ly, ux.*uy];
+            z_lb = min(corners, [], 2);
+            z_ub = max(corners, [], 2);
+
+            if ~isempty(obj.predicate_lb) && ~isempty(X.predicate_lb)
+                new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
+                new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
+                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);
+            else
+                S = Star(new_V, new_C, new_d);
             end
 
         end

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -464,7 +464,7 @@ classdef Star
             z_lb = min(corners, [], 2);
             z_ub = max(corners, [], 2);
 
-            if ~isempty(obj.predicate_lb) && ~isempty(X.predicate_lb)
+            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub) && ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
                 new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
                 new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
                 S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -370,16 +370,25 @@ classdef Star
             else
                 V3 = horzcat(V1, V2);
                 new_c = obj.V(:, 1) + X.V(:, 1);
-                new_V = horzcat(new_c, V3);        
-                new_C = blkdiag(obj.C, X.C);        
+                new_V = horzcat(new_c, V3);
+                new_C = blkdiag(obj.C, X.C);
                 new_d = vertcat(obj.d, X.d);
-                new_pred_lb = [obj.predicate_lb; X.predicate_lb];
-                new_pred_ub = [obj.predicate_ub; X.predicate_ub];
-                S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                % concatenating bounds is only valid when each operand's
+                % bounds cover all of its predicate variables (a
+                % 0-predicate star with 0x1 bounds counts as covered);
+                % otherwise the constructor would reject the short vector
+                if size(obj.predicate_lb, 1) == obj.nVar && size(obj.predicate_ub, 1) == obj.nVar ...
+                        && size(X.predicate_lb, 1) == X.nVar && size(X.predicate_ub, 1) == X.nVar
+                    new_pred_lb = [obj.predicate_lb; X.predicate_lb];
+                    new_pred_ub = [obj.predicate_ub; X.predicate_ub];
+                    S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub); % new Star has more number of basic vectors
+                else
+                    S = Star(new_V, new_C, new_d);
+                end
             end
-                
+
         end
-        
+
         function S = HadamardProduct(obj, X)
             % HadamardProduct - sound over-approximation of the elementwise
             % product of two stars, z = x .* y for x in obj, y in X.
@@ -418,14 +427,17 @@ classdef Star
             Wx = obj.V(:, 2:n1+1);
             Wy = X.V(:, 2:n2+1);
 
-            % bounds of each factor (estimateRanges if predicate bounds are
-            % known, otherwise exact ranges via LP)
-            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub)
+            % bounds of each factor (estimateRanges if predicate bounds
+            % cover all predicate variables, otherwise exact ranges via
+            % LP; a 0-predicate star with 0x1 bounds counts as covered)
+            obj_has_bounds = size(obj.predicate_lb, 1) == n1 && size(obj.predicate_ub, 1) == n1;
+            X_has_bounds = size(X.predicate_lb, 1) == n2 && size(X.predicate_ub, 1) == n2;
+            if obj_has_bounds
                 [lx, ux] = obj.estimateRanges;
             else
                 [lx, ux] = obj.getRanges;
             end
-            if ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+            if X_has_bounds
                 [ly, uy] = X.estimateRanges;
             else
                 [ly, uy] = X.getRanges;
@@ -464,7 +476,7 @@ classdef Star
             z_lb = min(corners, [], 2);
             z_ub = max(corners, [], 2);
 
-            if ~isempty(obj.predicate_lb) && ~isempty(obj.predicate_ub) && ~isempty(X.predicate_lb) && ~isempty(X.predicate_ub)
+            if obj_has_bounds && X_has_bounds
                 new_pred_lb = [obj.predicate_lb; X.predicate_lb; z_lb];
                 new_pred_ub = [obj.predicate_ub; X.predicate_ub; z_ub];
                 S = Star(new_V, new_C, new_d, new_pred_lb, new_pred_ub);

--- a/code/nnv/tests/set/star/test_star_HadamardProduct.m
+++ b/code/nnv/tests/set/star/test_star_HadamardProduct.m
@@ -1,0 +1,96 @@
+function test_star_HadamardProduct()
+    % TEST_STAR_HADAMARDPRODUCT - Test Star.HadamardProduct() method
+    %
+    % Tests that:
+    %   1. The product of two interval stars encloses the true product set,
+    %      including the products attained at the interval endpoints
+    %      (regression: the previous implementation returned [2, 2.5] for
+    %      [1,2].*[1,2] and [39, 51] for [2,4].*[10,20], both disjoint
+    %      from parts of the true product sets [1,4] and [20,80])
+    %   2. The product is sound: for sampled x in S1, y in S2, the point
+    %      x .* y is contained in S1.HadamardProduct(S2)
+    %   3. Output star dimensions are consistent
+
+    tol = 1e-6;
+
+    %% 1a) Regression witness: product of [1,2] with itself
+    % (two stars with identical constraints; previously the
+    % shared-constraint branch returned ranges [2, 2.5])
+    S = Star(1, 2);
+    P = S.HadamardProduct(S);
+    [lb, ub] = P.getRanges;
+    assert(lb <= 1 + tol, 'Product of [1,2]x[1,2] must contain 1*1 = 1');
+    assert(ub >= 4 - tol, 'Product of [1,2]x[1,2] must contain 2*2 = 4');
+
+    %% 1b) Regression witness: x in [2,4], y in [10,20], scaled encodings
+    % (different constraint matrices; previously the disjoint branch
+    % returned ranges [39, 51], the true product set is [20, 80])
+    S1 = Star([3 1],  [1; -1],     [1; 1]);      % x = 3 + a,   a in [-1,1]
+    S2 = Star([15 5], [0.5; -0.5], [0.5; 0.5]);  % y = 15 + 5b, b in [-1,1]
+    P2 = S1.HadamardProduct(S2);
+    [lb2, ub2] = P2.getRanges;
+    assert(lb2 <= 20 + tol, 'Product of [2,4]x[10,20] must contain 2*10 = 20');
+    assert(ub2 >= 80 - tol, 'Product of [2,4]x[10,20] must contain 4*20 = 80');
+
+    %% 2) Soundness on multi-dimensional stars with coupled predicates
+    rng(0);
+    V1 = [1 1 0; -2 1 1; 0.5 0 1];
+    C1 = [1 0; -1 0; 0 1; 0 -1; 1 1];
+    d1 = [1; 1; 1; 1; 1.5];
+    A = Star(V1, C1, d1);
+
+    V2 = [0 2 1; 3 0 1; -1 1 1];
+    C2 = [1 0; -1 0; 0 1; 0 -1];
+    d2 = [0.5; 0.5; 1; 1];
+    B = Star(V2, C2, d2);
+
+    PAB = A.HadamardProduct(B);
+    assert(PAB.dim == A.dim, 'Product star must have the same dimension as the factors');
+    assert(~PAB.isEmptySet, 'Product star should not be empty');
+
+    [plb, pub] = PAB.getRanges;
+
+    % bounds of the product star along random directions (catches
+    % unsoundness that per-dimension ranges cannot)
+    nDirs = 5;
+    W = randn(nDirs, PAB.dim);
+    wlb = zeros(nDirs, 1);
+    wub = zeros(nDirs, 1);
+    for k = 1:nDirs
+        Pk = PAB.affineMap(W(k, :), []);
+        [wlb(k), wub(k)] = Pk.getRanges;
+    end
+
+    % sample the factor predicates directly (rejection sampling, so no
+    % polytope toolbox is needed) and check x .* y lands inside
+    nChecked = 0;
+    for trial = 1:200
+        a = -1 + 2*rand(2, 1);
+        if any(C1*a > d1)
+            continue
+        end
+        b = -1 + 2*rand(2, 1);
+        if any(C2*b > d2)
+            continue
+        end
+        x = V1(:, 1) + V1(:, 2:end)*a;
+        y = V2(:, 1) + V2(:, 2:end)*b;
+        z = x .* y;
+        nChecked = nChecked + 1;
+        assert(all(z >= plb - tol) && all(z <= pub + tol), ...
+            sprintf('Sampled product point (trial %d) must lie within the product star ranges', trial));
+        wz = W*z;
+        assert(all(wz >= wlb - tol) && all(wz <= wub + tol), ...
+            sprintf('Sampled product point (trial %d) must lie within the product star projections', trial));
+    end
+    assert(nChecked > 50, 'Rejection sampling should accept a reasonable number of points');
+
+    %% 3) Soundness across sign changes (factors straddling zero)
+    S3 = Star(-1.5, 2);    % x in [-1.5, 2]
+    S4 = Star(-3, 1);      % y in [-3, 1]
+    P34 = S3.HadamardProduct(S4);
+    [lb34, ub34] = P34.getRanges;
+    % true product set is [-6, 4.5]
+    assert(lb34 <= -6 + tol, 'Product of [-1.5,2]x[-3,1] must contain 2*(-3) = -6');
+    assert(ub34 >= 4.5 - tol, 'Product of [-1.5,2]x[-3,1] must contain (-1.5)*(-3) = 4.5');
+end

--- a/code/nnv/tests/soundness/test_LstmLayer_reach_dispatch.m
+++ b/code/nnv/tests/soundness/test_LstmLayer_reach_dispatch.m
@@ -1,0 +1,154 @@
+% test_LstmLayer_reach_dispatch
+% Regression test: LstmLayer.reach() with a star-based method dispatches
+% to reach_star_multipleInputs. That method was previously missing, so
+% reach() raised "Unrecognized method ... 'reach_star_multipleInputs'"
+% for every star-based method. 'exact-star' now fails closed with a
+% clear message, since the LSTM star set is an over-approximation.
+% To run: results = runtests('test_LstmLayer_reach_dispatch')
+
+%% Test 1: reach() works for approx-star on a single input
+rng(42);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 5;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_dispatch', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'last');
+
+x = randn(inputSize, seqLength);
+ep = 0.05;
+IM = ImageStar(x - ep, x + ep);
+
+R1 = L.reach(IM, 'approx-star', []);
+assert(isa(R1, 'ImageStar'), 'reach output must be an ImageStar');
+assert(R1.height == numHiddenUnits, 'output must have numHiddenUnits rows');
+
+% 'exact-star' must fail closed: the LSTM star set is an
+% over-approximation, and NN.verify treats exact-star results as
+% complete, so silently aliasing it to approx-star would be unsound
+threw = false;
+try
+    L.reach(IM, 'exact-star', 'single');
+catch
+    threw = true;
+end
+assert(threw, "reach() must reject 'exact-star' for LstmLayer");
+
+%% Test 2: reach() works for an array of input sets
+rng(43);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 4;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_dispatch_multi', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'last');
+
+x1 = randn(inputSize, seqLength);
+x2 = randn(inputSize, seqLength);
+ep = 0.05;
+IMs = [ImageStar(x1 - ep, x1 + ep), ImageStar(x2 - ep, x2 + ep)];
+
+R = L.reach(IMs, 'approx-star', 'single');
+assert(length(R) == 2, 'one output set per input set');
+assert(all(arrayfun(@(s) isa(s, 'ImageStar'), R)), 'outputs must be ImageStars');
+assert(all(arrayfun(@(s) s.height == numHiddenUnits, R)), ...
+    'each output must have numHiddenUnits rows');
+
+%% Test 3: sequence output mode through reach() has one column per step
+rng(44);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 5;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_dispatch_seq', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'sequence');
+
+x = randn(inputSize, seqLength);
+ep = 0.05;
+IM = ImageStar(x - ep, x + ep);
+
+R = L.reach(IM, 'approx-star', []);
+assert(isa(R, 'ImageStar'), 'sequence-mode output must be an ImageStar');
+assert(R.height == numHiddenUnits, 'output must have numHiddenUnits rows');
+assert(R.width == seqLength, 'sequence-mode output must have one column per time step');
+
+%% Test 4: predicate-only ImageStar input (no im_lb/im_ub) is accepted
+rng(45);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 4;
+ep = 0.05;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_dispatch_pred', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'last');
+
+% one shared predicate variable: input = x + a*ep, a in [-1, 1]; this
+% is the form produced by upstream layers (im_lb/im_ub empty), which
+% the previous size(im_lb) check rejected
+x = randn(inputSize, seqLength);
+V = zeros(inputSize, seqLength, 1, 2);
+V(:,:,1,1) = x;
+V(:,:,1,2) = ep*ones(inputSize, seqLength);
+C = [1; -1];
+d = [1; 1];
+IM = ImageStar(V, C, d, -1, 1);
+
+R = L.reach(IM, 'approx-star', []);
+assert(isa(R, 'ImageStar'), 'reach output must be an ImageStar');
+assert(R.height == numHiddenUnits, 'output must have numHiddenUnits rows');

--- a/code/nnv/tests/soundness/test_LstmLayer_sequence_outputMode.m
+++ b/code/nnv/tests/soundness/test_LstmLayer_sequence_outputMode.m
@@ -1,0 +1,46 @@
+% test_LstmLayer_sequence_outputMode
+% Regression test: with OutputMode = 'sequence', star reachability must
+% return one set of ranges per time step. Previously the assembly loop
+% in reach_star_single_input iterated `for i = length(ht)` (instead of
+% `for i = 1:length(ht)`), so the output contained only the last time
+% step regardless of the input sequence length.
+% To run: results = runtests('test_LstmLayer_sequence_outputMode')
+
+%% Test 1: sequence-mode output has one column per time step
+rng(42);
+
+inputSize = 3;
+numHiddenUnits = 4;
+seqLength = 5;
+
+inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+bias = 0.1*randn(4*numHiddenUnits, 1);
+cellState = zeros(numHiddenUnits, 1);
+hiddenState = zeros(numHiddenUnits, 1);
+
+L = LstmLayer('Name', 'lstm_seq_mode', ...
+    'InputSize', inputSize, ...
+    'NumHiddenUnits', numHiddenUnits, ...
+    'InputWeights', inputWeights, ...
+    'RecurrentWeights', recurrentWeights, ...
+    'Bias', bias, ...
+    'CellState', cellState, ...
+    'HiddenState', hiddenState, ...
+    'OutputMode', 'sequence');
+
+x = randn(inputSize, seqLength);
+ep = 0.05;
+IM = ImageStar(x - ep, x + ep);
+
+R = L.reach_star_single_input(IM);
+
+assert(isa(R, 'ImageStar'), 'sequence-mode output must be an ImageStar');
+assert(R.height == numHiddenUnits, ...
+    'sequence-mode output must have numHiddenUnits rows');
+assert(R.width == seqLength, ...
+    'sequence-mode output must have one column per time step');
+
+[lb, ub] = R.getRanges;
+assert(all(lb(:) <= ub(:) + 1e-12), ...
+    'lower bounds must not exceed upper bounds');


### PR DESCRIPTION
## Summary

`LstmLayer.reach()` dispatches every star-based method to `reach_star_multipleInputs`:

```matlab
IS = obj.reach_star_multipleInputs(in_images, option);
```

but that method was never defined (missing since the layer was introduced in 1394bf4ed), so `reach()` raises

```
Unrecognized method, property, or field 'reach_star_multipleInputs' for class 'LstmLayer'.
```

for **every** star-based method. As a consequence, `reach_star_single_input` — the layer's symbolic gate-by-gate star reachability — has been unreachable from the public dispatcher since it was written; the only working entry point was `reachSequence` (which takes a different, concrete-evaluation path — see the companion PR).

## Changes

* Add `reach_star_multipleInputs`, mirroring the existing `reach_star_multipleInputs_Sequence`: loops `reach_star_single_input` over the input array with `'single'`/`'parallel'` options.
* `reach()` now **fails closed for `'exact-star'`** with a clear message. The LSTM star set composes over-approximations (per-step input boxing, approx-star sigmoid/tanh, McCormick product envelopes), so an exact star set is not computable here; silently aliasing exact-star to approx-star would be dangerous because `NN.verify_robustness` gives exact-star results *complete* semantics (a non-empty intersection becomes a definite violation verdict). `'abs-dom'`/`'relax-star*'` remain accepted as over-approximating methods.
* Relax `reach_star_single_input`'s input check from `size(in_image.im_lb)` to `in_image.height`, so predicate-only `ImageStar` inputs (`im_lb` empty — the form produced by upstream layers mid-network) are accepted instead of erroring with a misleading size message.
* New regression test `tests/soundness/test_LstmLayer_reach_dispatch.m`: approx-star on single and multiple input sets, exact-star rejection, sequence-output-mode width, and predicate-only inputs. Verified in MATLAB R2025b.

## Stack

This PR is **stacked on #317** (sound `Star.HadamardProduct`) **and the sequence-mode loop fix PR**, and the diff includes their commits until they merge. The ordering is deliberate: merging this dispatch fix alone would make the newly callable path return silently unsound sets through the old `HadamardProduct` (a fail-closed error would become silent unsoundness). Once the prerequisites merge, this reduces to the `LstmLayer.m` dispatch/guard changes plus the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
