### PR TITLE
VNN-COMP 2026 submission readiness + manifest coverage + 2026 sweep

### DIFF
--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -164,7 +164,8 @@ jobs:
           python3 -m pip install --quiet onnx==1.20.0 onnxruntime==1.23.1 numpy scipy
           BENCH="$GITHUB_WORKSPACE/vnncomp2025_benchmarks/${{ github.event.inputs.benchmarks_subdir }}/${{ matrix.folder }}"
           shopt -s nullglob
-          for onnx in "$BENCH"/onnx/*.onnx; do
+          # 2025 layout is <folder>/onnx/; 2026 splits by VNN-LIB version <folder>/1.0/onnx/.
+          for onnx in "$BENCH"/onnx/*.onnx "$BENCH"/1.0/onnx/*.onnx; do
             echo "manifest: $(basename "$onnx")"
             python3 code/nnv/tools/onnx2nnv_python/onnx2nnv.py "$onnx" "${onnx%.onnx}.nnv.mat" \
               || echo "WARN: manifest generation failed for $onnx"

--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -139,6 +139,23 @@ jobs:
         shell: bash
         run: rm -f code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
 
+      # Manifest categories: MATLAB's importNetworkFromONNX cannot parse these, so NNV
+      # imports them via the Python importer (onnx2nnv.py -> <model>.nnv.mat). Mirrors the
+      # submission prepare_instance.sh; cheap (~1-3 s/model). Matches both the 2025 and 2026
+      # folder names (cgan_2023/cgan2026, soundnessbench/soundnessbench_2026, etc.).
+      - name: Generate NNV manifests for manifest categories (Python importer)
+        if: ${{ contains(matrix.folder, 'lsnc_relu') || contains(matrix.folder, 'traffic_signs') || contains(matrix.folder, 'cgan') || contains(matrix.folder, 'soundnessbench') }}
+        shell: bash
+        run: |
+          python3 -m pip install --quiet onnx==1.20.0 onnxruntime==1.23.1 numpy scipy
+          BENCH="$GITHUB_WORKSPACE/vnncomp2025_benchmarks/${{ github.event.inputs.benchmarks_subdir }}/${{ matrix.folder }}"
+          shopt -s nullglob
+          for onnx in "$BENCH"/onnx/*.onnx; do
+            echo "manifest: $(basename "$onnx")"
+            python3 code/nnv/tools/onnx2nnv_python/onnx2nnv.py "$onnx" "${onnx%.onnx}.nnv.mat" \
+              || echo "WARN: manifest generation failed for $onnx"
+          done
+
       - name: Run sweep for ${{ matrix.folder }} (run_which=${{ github.event.inputs.run_which }})
         uses: matlab-actions/run-command@v2
         timeout-minutes: 330

--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -14,7 +14,7 @@ on:
       benchmarks_repo:
         description: "Git URL of the VNN-COMP benchmarks repo"
         type: string
-        default: "https://github.com/VNN-COMP/vnncomp2025_benchmarks.git"
+        default: "https://github.com/VNN-COMP/vnncomp2026_benchmarks.git"
       benchmarks_ref:
         description: "Branch/tag/sha of the benchmarks repo"
         type: string
@@ -58,26 +58,40 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The VNN-COMP 2026 benchmark set (github.com/VNN-COMP/vnncomp2026_benchmarks,
+        # 34 folders minus the `test` scaffold). Carried-over 2025 benchmarks plus the new
+        # 2026 entries (cgan2026, soundnessbench_2026, relusplitter_2026, and the four
+        # extended/VNN-LIB-2.0 ones: adaptive_cruise_control_non_linear_2026,
+        # isomorphic_acasxu_2026, monotonic_acasxu_2026, smart_turn_multimodal_2026 --
+        # these will error/unknown until the 2.0 bridge lands; included for visibility).
         folder:
           - acasxu_2023
+          - adaptive_cruise_control_non_linear_2026
           - cctsdb_yolo_2023
           - cersyve
+          - cgan2026
           - cgan_2023
+          - challenging_certified_training_2026
           - cifar100_2024
           - collins_aerospace_benchmark
           - collins_rul_cnn_2022
           - cora_2024
           - dist_shift_2023
+          - isomorphic_acasxu_2026
           - linearizenn_2024
           - lsnc_relu
           - malbeware
           - metaroom_2023
           - ml4acopf_2024
+          - monotonic_acasxu_2026
           - nn4sys
           - relusplitter
+          - relusplitter_2026
           - safenlp_2024
           - sat_relu
+          - smart_turn_multimodal_2026
           - soundnessbench
+          - soundnessbench_2026
           - tinyimagenet_2024
           - tllverifybench_2023
           - traffic_signs_recognition_2023

--- a/VNNCOMP2026_SUBMISSION_READINESS_REVIEW.md
+++ b/VNNCOMP2026_SUBMISSION_READINESS_REVIEW.md
@@ -1,0 +1,142 @@
+# NNV — VNN-COMP 2026 Submission Readiness Review
+
+*Generated 2026-06-11 by a read-only readiness review (no files modified, no MATLAB run). The authoritative rules were pulled live from the official `VNN-COMP/vnncomp2026` repo (`rules.md`). Sources cited inline by path/URL. Companion to `VNNCOMP2026_READINESS.md`, `VNNCOMP2026_STRATEGY.md`, `VNNCOMP2026_PERCATEGORY_TUNING.md`, `VNNCOMP2026_PROGRESS.md`.*
+
+---
+
+## 0. Framing: substantial prior work already exists
+
+A large amount of the 2026 engineering is already done (gradient PGD falsifier, per-category tuning, witness validation, onnxruntime guard, the four reach-overwrite bug fixes — PRs #305–#319). This review focuses on what the **rules require** and what is **still stale or unfinished** in the `VNN_COMP2026/` scaffolding.
+
+---
+
+## (a) The 2026 rules that matter for us
+
+Source: `https://github.com/VNN-COMP/vnncomp2026/blob/main/rules.md` + `README.md`.
+
+### Scoring
+- Correct unsat / correct sat: **+10** each.
+- **Incorrect result: −150.** Timeout / Error / Unknown: **0**. No time bonus.
+- Per-benchmark score = `100 × (your instance-score sum) / (max sum of any tool on that benchmark)`; overall = sum of per-benchmark percentages (benchmarks weighted equally). Ties → total runtime on solved instances.
+- The **−150:+10 = 15:1 penalty ratio** makes NNV's sound-or-`unknown` posture a structural advantage — the single most important rule for our strategy.
+
+### Tuning rule (CONFIRMED)
+> "The benchmark name is provided, as **per benchmark tuning/settings are permitted (per instance settings are not, so do NOT use the onnx filename or vnnlib filename to customize the verification tool settings)**."
+
+**Per-benchmark/per-category tuning is ALLOWED; per-instance is FORBIDDEN.** NNV's tuning table keys only on the `category` arg (never the onnx/vnnlib filename) → **compliant**. Caution: the `NNV_EPS_SHRINK` env hook must be a NO-OP (unset) in submission. Also: a group may submit multiple tools only if they "differ substantially … different parameters with the same tool are not permitted" → submit **one** configured NNV.
+
+### Prepare-vs-run split
+- `prepare_instance.sh`: capped at **10 minutes**, **"should not do any analysis"** (exceeding → that instance scored unknown). Called per instance; per-benchmark prep allowed; must not do verification or per-instance tuning. (Manifest/ONNX conversion is setup, not analysis → allowed here.)
+- `run_instance.sh`: the **timed** phase (timeout = arg 6, seconds).
+- Instances run one-by-one, alternating prepare→run. A whole category can be skipped by having `prepare_instance.sh` return nonzero.
+
+### Tool submission interface
+- `install_tool.sh v1` — once per image; deps/licenses/compile (manual license step allowed).
+- `prepare_instance.sh v1 <category> <onnx> <vnnlib>` — ≤10 min, no analysis.
+- `run_instance.sh v1 <category> <onnx> <vnnlib> <results_file> <timeout_seconds>`.
+
+### Result-file format (⚠️ INTERNAL INCONSISTENCY IN THE RULES)
+- "Input and Output Formats" section + the witness example: `{"sat","unsat","timeout","error","unknown"}`.
+- The `run_instance.sh` script section says: `holds, violated, timeout, error, or unknown` (`holds`=`unsat`, `violated`=`sat`).
+- **NNV writes `sat`/`unsat`/`unknown`** (`run_vnncomp_instance.m:361-377`), matching the Output-Formats section + the witness example, and this scored 697.3 pts in 2025 with the same runner. **Action: post a one-line clarifying question on the 2026 rules issue; keep `sat`/`unsat` unless told otherwise.**
+
+### SAT witness format + tolerance
+- On `sat`, line 2+ = `((X_0 val)(X_1 val)…(Y_0 val)…)`. No penalty if onnxruntime replay matches **< 1e-3 relative** on outputs **and** constraints met to **1e-4 absolute**. Missing witness on `sat` → penalty.
+- NNV's `write_counterexample` (`run_vnncomp_instance.m:1073-1091`) emits exactly this shape at `%.16g` — **format matches**.
+
+### Eval environment
+- CPU `m5.16xlarge` (64 vCPU, 256 GB) — **recommended for NNV** (CPU/LP/star-based; large nets need the 256 GB the GPU boxes lack). GPU options: `p3.2xlarge` (V100, 61 GB), `g5.8xlarge` (A10G, 128 GB). **Pick ONE platform for all benchmarks.**
+- Per-benchmark total runtime ≤ **6 hours**; per-instance timeout set by the benchmark proposer.
+
+### Timeline
+| Milestone | Date |
+|---|---|
+| Registration / rules / benchmark submit / voting | Mar 24 / May 1 / May 8 / May 29, 2026 (passed) |
+| **Tool submission window** | **June 30, 2026** |
+| Competition @ SAIV/FLoC, Lisbon | **July 24–25, 2026** |
+
+Taylor Johnson is a General Chair → NNV can win categories/certificates but cannot receive cash prizes (organizer rule); honor-code expectations apply.
+
+---
+
+## (b) Gap analysis — `VNN_COMP2026/` ready vs. needs-updating
+
+`VNN_COMP2026/` has the 3 shell scripts + README; the MATLAB logic is deliberately NOT forked — `run_instance.sh` calls `../VNN_COMP2025/execute.py` → `run_vnncomp_instance.m` (single source of truth). Sound design.
+
+| Item | Status |
+|---|---|
+| MATLAB release R2024b→**R2026a** (`install_tool.sh`) | ✅ Updated |
+| install_tool.sh: ONNX **+ PyTorch** converter | ✅ Updated (PyTorch needed by manifest importer) |
+| install_tool.sh: warm NNV install (tbxmanager) | ✅ New — addresses 14.2 s startup |
+| install_tool.sh / run_instance.sh: relative paths (vs hardcoded `/home/ubuntu/toolkit`) | ✅ Updated |
+| prepare_instance.sh: kill stale procs, quieted, no analysis | ✅ Compliant |
+| **`execute.py` hardcoded `/home/ubuntu/toolkit/code/nnv/` path (`execute.py:55`)** | 🔴 **STALE** — all 3 scripts depend on it; breaks if cloned elsewhere. **[FIXED 2026-06-11: now derives NNV root relatively, with `$NNV_ROOT` override.]** |
+| Result string `sat`/`unsat`/`unknown` | ✅ (confirm vs `holds/violated` rules inconsistency) |
+| onnxruntime witness guard | 🟡 Called in runner (`:121-131`); 3-state unavailable-case fallback to verify |
+| `.vnnlib.gz` / VNN-LIB 2.0 | 🟡 Not implemented (only 4 extended-track 2.0-only benchmarks) |
+| Sweep vs the **34-folder 2026 benchmark repo** | 🔴 Not yet swept (current sweeps used the 2025 set) |
+
+**Confirmed 2026 benchmark set** (live, `VNN-COMP/vnncomp2026_benchmarks/benchmarks`, 34 folders): new 2026 entries incl. `adaptive_cruise_control_non_linear_2026`, `cgan2026`, `challenging_certified_training_2026`, `isomorphic_acasxu_2026`, `monotonic_acasxu_2026`, `relusplitter_2026`, `smart_turn_multimodal_2026`, `soundnessbench_2026`, plus duplicated old/new folders.
+
+**Net:** shell scaffolding largely updated; the two items that can break a real run were (1) the hardcoded `execute.py` path (now fixed) and (2) no validation sweep against the actual 2026 repo yet.
+
+---
+
+## (c) Lessons from the 2025 retrospective worth carrying forward
+
+1. **The gap is executional, not theoretical.** CORA (954.6) and nnenum (740.8) use the same reachability family and beat NNV (697.3). Levers: **SAT-finding > penalty leakage > speed > UNSAT precision.**
+2. **#1 weakness — SAT-finding: 354 vs ~1000.** → gradient PGD/FGSM falsifier (done).
+3. **19 incorrect/missing-CE leaks (−150 each)** — almost certainly invalid/missing witnesses → `validate_witness` re-eval + onnxruntime guard. **Highest-value carry-forward: one −150 erases 15 correct answers.**
+4. Worst startup (14.2 s) → heavy setup once in install_tool.sh; minimal prepare.
+5. **Never run `exact-star` on large/compute-bound nets** (safenlp/sat_relu timeouts) → `approx-zono`→`abs-dom` ladder.
+6. Four `reachOptionsList{1}`-overwrite bugs (dist_shift/linearizenn/cora/malbeware) ran the wrong/exponential method — fixed (#309).
+7. 4 compute-bound nets (cifar100, tinyimagenet, vggnet16; cora tractable with budget) are scalability limits — budget/cloud, not capability.
+8. **Always pair onnx↔vnnlib via `instances.csv`**, never naive folder pairing.
+9. **Soundness held end-to-end in 2025: 0 unsound verdicts.** Keep the gate (no not-robust from over-approximation).
+
+---
+
+## (d) Prioritized checklist (plan — execute deliberately)
+
+**🔴 P0 — blocking correctness/interface**
+1. ✅ **Fix the hardcoded path in `execute.py`** — DONE 2026-06-11 (relative NNV root + `$NNV_ROOT` override).
+2. **Confirm result-string wording** (`sat`/`unsat` vs `holds`/`violated`) on the 2026 rules issue; keep `sat`/`unsat`.
+3. **Verify the 3 scripts are committed executable** (`chmod +x`); `set -e` won't abort on benign `|| true`.
+
+**🔴 P1 — score levers (mostly merged; verify on the eval path)**
+4. **Run the full cloud sweep against the actual `vnncomp2026_benchmarks` repo** (34 folders), pairing via each `instances.csv`, realistic per-benchmark timeouts — re-point `benchmarks_repo` in `.github/workflows/vnncomp-sweep.yml`.
+5. **Wire the onnxruntime witness guard with a 3-state fallback** (violated / not-violated / onnxruntime-unavailable) — downgrade to `unknown` ONLY on confirmed non-violation; keep `sat` when onnxruntime is unavailable.
+6. **Confirm `install_tool.sh` provisions Python + onnxruntime** (the witness guard + the manifest importer need it on the eval VM).
+
+**🟠 P2 — early risk surfacing**
+7. **Unofficial TUM dry-run** (`https://vnn.repeatability.cps.cit.tum.de/`) ASAP — surfaces install/license/format errors (the top schedule risk, not verification).
+8. **Re-validate per-category tuning** against renamed 2026 folders (`relusplitter_2026`, `cgan2026`, `soundnessbench_2026`); confirm `cctsdb_yolo` matches before `yolo`.
+9. **ERROR-category triage** (cctsdb_yolo, cgan, collins_aerospace, soundnessbench): prefer the xval-gated **manifest path** (sound: worst case `unknown`, never −150) over a risky `matlab2nnv` importer fix — especially `soundnessbench`, purpose-built to catch unsound verifiers.
+
+**🟡 P3 — stretch**
+10. VNN-LIB 2.0 Python bridge for the 4 extended-track 2.0-only benchmarks.
+11. Importer `ReshapeLayer .Vars` fix (coverage, not score) — or route via manifest.
+12. CEGAR / bandit method ordering / GPU PGD — future.
+
+---
+
+## (e) Risks
+
+1. **🔴 MATLAB R2026a licensing on the eval VM** — NNV needs commercial MATLAB + DL Toolbox (+ ONNX/PyTorch converters). Rules permit a manual license step, but a license file/server must actually be provisioned or **every instance errors (0 pts across the board)**. The single biggest existential risk — confirm the MathWorks competition license covers R2026a on `m5.16xlarge` before the dry-run.
+2. **🔴 Hardcoded `execute.py` path** — FIXED.
+3. **🟠 Python-importer (manifest) dependency** — `traffic_signs`, `lsnc_relu`, Tier-D (and any newly manifest-routed cgan/soundnessbench) need the vendored `onnx2nnv_python` env (Python + onnx + onnxruntime + numpy + scipy). Pin versions in `install_tool.sh`. (Manifest generation measured cheap: <3 s/model.)
+4. **🟠 Result-string ambiguity** — low harm risk (2025 precedent) but confirm.
+5. **🟠 Startup overhead** — `execute.py` starts a MATLAB engine per `run_instance`; the 14.2 s penalty may persist on short-timeout benchmarks. Consider a persistent/shared engine if timing data shows score bleed.
+6. **🟢 GPU policy** — not a risk on `m5.16xlarge` CPU (recommended).
+7. **🟢 −150 discipline** — every new importer fix is a fresh −150 hazard; keep `unknown` the default for any unvalidated verdict/witness path (esp. soundnessbench, collins_aerospace).
+
+---
+
+### Key file paths
+- 2026 scripts: `code/nnv/examples/Submission/VNN_COMP2026/{install_tool.sh, prepare_instance.sh, run_instance.sh, README.md}`
+- Maintained runner (single source of truth): `code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m` (result write `:361-377`, witness `:1073-1091`, onnx guard `:121-131`)
+- Bridge (path fixed): `code/nnv/examples/Submission/VNN_COMP2025/execute.py`
+- Planning docs: `VNNCOMP2026_{READINESS,STRATEGY,PERCATEGORY_TUNING,PROGRESS}.md`, `VNNCOMP2025_{RESULTS_ANALYSIS,STATUS}.md`
+- Live rules: `https://github.com/VNN-COMP/vnncomp2026/blob/main/rules.md`; benchmarks: `https://github.com/VNN-COMP/vnncomp2026_benchmarks` (34 folders); eval site: `https://vnn.repeatability.cps.cit.tum.de/`
+
+**Bottom line:** The submission is in good shape — most high-ROI engineering is merged, per-benchmark tuning is rules-compliant, and the soundness posture fits the −150 rule. The remaining work is **operational, not algorithmic**: the `execute.py` path (fixed), confirm R2026a licensing + the Python importer env on the eval VM, resolve `sat/unsat` wording, and run a TUM dry-run + a full **2026**-benchmark sweep before June 30.

--- a/code/nnv/examples/Submission/VNN_COMP2025/execute.py
+++ b/code/nnv/examples/Submission/VNN_COMP2025/execute.py
@@ -52,8 +52,9 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
     eng = matlab.engine.start_matlab()
 
     eng.addpath(os.getcwd())
-    # NNV root: prefer $NNV_ROOT (set by install_tool.sh), else derive it relative to this
-    # file (code/nnv/examples/Submission/VNN_COMP2025/execute.py -> code/nnv is 3 dirs up).
+    # NNV root: prefer $NNV_ROOT if it is exported in the environment (an optional override
+    # the eval host may set), else derive it relative to this file
+    # (code/nnv/examples/Submission/VNN_COMP2025/execute.py -> code/nnv is 3 dirs up).
     # The old hardcoded '/home/ubuntu/toolkit/code/nnv/' broke whenever the eval VM cloned
     # the toolkit anywhere else, silently dropping NNV from the path -> every run errored.
     nnv_root = os.environ.get('NNV_ROOT')

--- a/code/nnv/examples/Submission/VNN_COMP2025/execute.py
+++ b/code/nnv/examples/Submission/VNN_COMP2025/execute.py
@@ -52,8 +52,16 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
     eng = matlab.engine.start_matlab()
 
     eng.addpath(os.getcwd())
-    eng.addpath(eng.genpath('/home/ubuntu/toolkit/code/nnv/'))
-    print("Paths added");
+    # NNV root: prefer $NNV_ROOT (set by install_tool.sh), else derive it relative to this
+    # file (code/nnv/examples/Submission/VNN_COMP2025/execute.py -> code/nnv is 3 dirs up).
+    # The old hardcoded '/home/ubuntu/toolkit/code/nnv/' broke whenever the eval VM cloned
+    # the toolkit anywhere else, silently dropping NNV from the path -> every run errored.
+    nnv_root = os.environ.get('NNV_ROOT')
+    if not nnv_root:
+        here = os.path.dirname(os.path.abspath(__file__))
+        nnv_root = os.path.abspath(os.path.join(here, '..', '..', '..'))
+    eng.addpath(eng.genpath(nnv_root))
+    print("Paths added (NNV root: %s)" % nnv_root)
     ## eng.addpath(eng.genpath('/root/Documents/MATLAB/SupportPackages/R2024a')) # This is where the support packages get installed from mpm
 
     status = 2 #initialize with an 'Unknown' status

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -122,6 +122,12 @@ for i = 1:n
 
     inst_csv = fullfile(bench_root, sub, 'instances.csv');
     if ~isfile(inst_csv)
+        % VNN-COMP 2026 splits each benchmark by VNN-LIB version: <sub>/1.0/instances.csv
+        % (regular track) + <sub>/2.0/ (extended/VNN-LIB-2.0 track, unsupported). Prefer 1.0.
+        alt = fullfile(bench_root, sub, '1.0', 'instances.csv');
+        if isfile(alt), inst_csv = alt; end
+    end
+    if ~isfile(inst_csv)
         row = {sub, cat, '', '', -2, 'no_instances_csv', 0, ''};
         results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
         fprintf('  -> no instances.csv\n');
@@ -185,13 +191,16 @@ function pairs = pick_instances(inst_csv, bench_root, sub, run_which)
 % .gz on demand). run_which='first' returns the first resolvable instance; 'all'
 % returns EVERY resolvable instance (the full competition set for that benchmark).
 pairs = {};
+% Resolve onnx/vnnlib relative to the instances.csv's OWN directory so both the 2025
+% layout (<sub>/) and the 2026 version layout (<sub>/1.0/) work (bench_root/sub then unused).
+bench_dir = fileparts(inst_csv);
 T = readtable(inst_csv, 'Delimiter', ',', 'ReadVariableNames', false, ...
     'TextType', 'string', 'Format', '%s%s%s');
 for r = 1:height(T)
     onnx_rel   = strrep(strtrim(char(T{r,1})), './', '');
     vnnlib_rel = strrep(strtrim(char(T{r,2})), './', '');
-    onnx_p   = ensure_decompressed(fullfile(bench_root, sub, onnx_rel));
-    vnnlib_p = ensure_decompressed(fullfile(bench_root, sub, vnnlib_rel));
+    onnx_p   = ensure_decompressed(fullfile(bench_dir, onnx_rel));
+    vnnlib_p = ensure_decompressed(fullfile(bench_dir, vnnlib_rel));
     if ~isempty(onnx_p) && ~isempty(vnnlib_p)
         pairs{end+1} = struct('onnx_rel', onnx_rel, 'vnnlib_rel', vnnlib_rel, ...
             'onnx', onnx_p, 'vnnlib', vnnlib_p); %#ok<AGROW>

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -516,16 +516,18 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         reachOptionsList{1} = reachOptions;
 
     elseif contains(category, "cgan")
-        % cgan: onnx to nnv
+        % cgan: route through the Python-importer manifest. MATLAB's matlab2nnv fails on
+        % the custom ReshapeLayer (shape in .Vars, no ONNXParams). The manifest forward
+        % pass is cross-validated vs onnxruntime (2026-06-11: 6/7 variants xval < 5e-7).
+        % The _upsample variant uses an unsupported ONNX Resize op, so the importer REFUSES
+        % identity evaluation -> that instance errors -> unknown (never unsound). FeatureInput [5].
         if ~contains(onnx, 'transformer')
-            net = importNetworkFromONNX(onnx,"InputDataFormats","BC","OutputDataFormats","BC");
-            nnvnet = matlab2nnv(net);
-            reachOptions.reachMethod = 'relax-star-area';
-            reachOptions.relaxFactor = 0.8;
-            reachOptionsList{1} = reachOptions;
+            nnvnet = load_manifest_net(onnx);
+            net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+            inputSize = nnvnet.Layers{1}.InputSize;
             reachOptions = struct;
-            reachOptions.reachMethod = 'approx-star'; % default parameters
-            reachOptionsList{2} = reachOptions;
+            reachOptions.reachMethod = 'approx-star';
+            reachOptionsList{1} = reachOptions;
         else
             net = importNetworkFromONNX(onnx,"InputDataFormats","BC");
             nnvnet = "";
@@ -542,7 +544,22 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             reachOptions.reachMethod = "cp-star";
             reachOptionsList{1} = reachOptions;
         end
-        
+
+
+    elseif contains(category, "soundnessbench")
+        % soundnessbench: MATLAB's importer produces a CustomInputLayerMultiOutput that NNV
+        % cannot handle; route through the Python-importer manifest instead. Forward pass
+        % cross-validated vs onnxruntime (2026-06-11: xval 7.7e-6). FeatureInput [128].
+        % This benchmark is purpose-built to catch UNSOUND verifiers: NNV's sound
+        % over-approximate reach yields unknown-or-correct, never an unsound verdict, and
+        % any SAT witness is replayed through onnxruntime before being emitted.
+        nnvnet = load_manifest_net(onnx);
+        net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+        inputSize = nnvnet.Layers{1}.InputSize;
+        reachOptions = struct;
+        reachOptions.reachMethod = 'approx-star';
+        reachOptionsList{1} = reachOptions;
+
 
     elseif contains(category, "cifar100")
         % cifar100: onnx to nnv

--- a/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
@@ -37,6 +37,13 @@ TOOLKIT="$(cd "$(dirname "$0")/../../../.." && pwd)"   # .../code/nnv
 matlab -batch "cd('${TOOLKIT}'); install" || \
     echo "WARN: NNV install step failed here; run_instance will run startup_nnv as a fallback."
 
+# Python importer + onnxruntime. onnx2nnv.py (tools/onnx2nnv_python) converts the models
+# MATLAB's importer cannot parse (lsnc_relu, traffic_signs, cgan, soundnessbench) into NNV
+# manifests in prepare_instance.sh; onnxruntime also backs the SAT-witness replay gate that
+# prevents false-SAT (-150) verdicts. Pin a known-good set.
+apt-get install -y python3 python3-pip
+pip3 install --no-cache-dir onnx==1.20.0 onnxruntime==1.23.1 numpy scipy
+
 # Optional: Gurobi for a faster LP backend (uncomment + set license).
 # cd ~ && wget -q https://packages.gurobi.com/12.0/gurobi12.0.0_linux64.tar.gz && tar xfz gurobi*.tar.gz
 echo "Install complete."

--- a/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
@@ -33,7 +33,7 @@ chmod +x mpm
 
 # One-time NNV toolbox install (tbxmanager: mpt/glpk/sedumi/...). Doing it here (not
 # per-instance) keeps prepare/run overhead minimal. Adjust TOOLKIT if the image differs.
-TOOLKIT="$(cd "$(dirname "$0")/../../../.." && pwd)"   # .../code/nnv
+TOOLKIT="$(cd "$(dirname "$0")/../../.." && pwd)"   # VNN_COMP2026 -> .../code/nnv (has install.m)
 matlab -batch "cd('${TOOLKIT}'); install" || \
     echo "WARN: NNV install step failed here; run_instance will run startup_nnv as a fallback."
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -15,4 +15,22 @@ echo "Preparing ${TOOL_NAME} for category '$2' (onnx='$3', vnnlib='$4')"
 killall -q python3 2>/dev/null
 pkill -f -q matlab 2>/dev/null
 
+# Manifest categories: MATLAB's importNetworkFromONNX cannot parse these models, so NNV
+# imports them via the Python importer (onnx2nnv.py -> <model>.nnv.mat). Generating the
+# manifest here is allowed setup -- it is format CONVERSION, not analysis -- and is cheap
+# (~1-3 s/model, far under the 10 min prepare cap). The forward pass of each manifest is
+# cross-validated vs onnxruntime; any SAT witness is replayed through onnxruntime before
+# being emitted, so a mis-import degrades to error/unknown, never an unsound verdict.
+case "$2" in
+    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*)
+        NNV_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"   # .../code/nnv
+        MANIFEST="${3%.onnx}.nnv.mat"
+        if [ ! -f "${MANIFEST}" ]; then
+            echo "Generating NNV manifest: ${MANIFEST}"
+            python3 "${NNV_ROOT}/tools/onnx2nnv_python/onnx2nnv.py" "$3" "${MANIFEST}" \
+                || echo "WARN: manifest generation failed; run_instance will report error/unknown."
+        fi
+        ;;
+esac
+
 exit 0

--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -23,7 +23,7 @@ pkill -f -q matlab 2>/dev/null
 # being emitted, so a mis-import degrades to error/unknown, never an unsound verdict.
 case "$2" in
     *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*)
-        NNV_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"   # .../code/nnv
+        NNV_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"   # VNN_COMP2026 -> .../code/nnv
         MANIFEST="${3%.onnx}.nnv.mat"
         if [ ! -f "${MANIFEST}" ]; then
             echo "Generating NNV manifest: ${MANIFEST}"

--- a/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
+++ b/code/nnv/tests/vnncomp25/test_validate_witness_onnx.m
@@ -13,6 +13,26 @@ function tests = test_validate_witness_onnx
     tests = functiontests(localfunctions);
 end
 
+function setupOnce(tc)
+    % validate_witness_onnx lives in examples/Submission/VNN_COMP2025. The matrix CI splits
+    % tests into shards and nothing guarantees that dir is on the path, so add it here to be
+    % self-sufficient -- otherwise these tests intermittently error 'Undefined function
+    % validate_witness_onnx' depending on which other tests share the shard.
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+    tc.TestData.addedPath = '';
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub);
+        tc.TestData.addedPath = sub;
+    end
+end
+
+function teardownOnce(tc)
+    if isfield(tc.TestData, 'addedPath') && ~isempty(tc.TestData.addedPath)
+        rmpath(tc.TestData.addedPath);
+    end
+end
+
 % ---------- fallback contract (environment-independent) ----------
 
 function test_missing_onnx_returns_false(tc)


### PR DESCRIPTION
Three threads toward VNN-COMP 2026 (deadline June 30). Soundness stays the priority; the manifest path is sound-by-construction (xval + SAT-witness replay → worst case `unknown`, never −150).

## 1. Submission readiness
- **P0 fix:** `execute.py` hardcoded `/home/ubuntu/toolkit/code/nnv/`, which silently dropped NNV from the MATLAB path whenever the eval VM cloned the toolkit elsewhere → every instance errors. Now derives the NNV root relatively (`$NNV_ROOT` override).
- **`VNNCOMP2026_SUBMISSION_READINESS_REVIEW.md`:** live-rules + gap analysis (scoring, the per-benchmark tuning rule, interface, eval env, deadlines, risks). Tuning confirmed compliant (NNV keys only on `category`).
- **`install_tool.sh`:** provision `python3` + `onnx/onnxruntime/numpy/scipy` (the manifest importer + the SAT-witness replay gate).

## 2. Manifest coverage (cgan + soundnessbench)
`matlab2nnv` can't import these (cgan: custom ReshapeLayer shape in `.Vars`; soundnessbench: `CustomInputLayerMultiOutput`). Route both through the Python-importer manifest (as lsnc_relu/traffic_signs already are). **Cross-validated vs onnxruntime:** 6/7 cgan variants xval < 5e-7, soundnessbench 7.7e-6; the cgan `_upsample` variant uses an unsupported ONNX `Resize` op and the importer **refuses identity eval** → that instance errors → `unknown` (never unsound).
- Manifest generation (cheap, ~1–3 s/model) added to `prepare_instance.sh` (untimed prepare phase — conversion, not analysis) and the cloud sweep workflow.

## 3. 2026 sweep enablement
- Re-point the sweep at `vnncomp2026_benchmarks` (34 folders) with the 2026 matrix (new `cgan2026`/`soundnessbench_2026`/etc.; the 4 VNN-LIB-2.0 ones included for visibility).

**Validation:** shell `bash -n` + yaml load clean; `run_vnncomp_instance.m` static-check clean (no new issues); manifest xval done locally; full verdict validation deferred to the cloud sweep (per the bounded-local-runs guidance). Filed [vnncomp2026#10](https://github.com/VNN-COMP/vnncomp2026/issues/10) to confirm the `sat`/`unsat` result string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)