### PR TITLE
VNN-LIB 2.0 single-network parser (VNN-COMP 2026 extended track)

### DIFF
--- a/code/nnv/VNNLIB2_SUPPORT_PLAN.md
+++ b/code/nnv/VNNLIB2_SUPPORT_PLAN.md
@@ -1,0 +1,596 @@
+# VNN-LIB 2.0 Support Plan for NNV (VNN-COMP 2026 Extended Track)
+
+Status: PLANNING / research deliverable. No production code changed by this document.
+Date: 2026-06-12.
+Author: research+planning pass (Claude).
+
+> ## IMPLEMENTATION STATUS (2026-06-12) — Phase 0 + 1 + 3a SHIPPED
+> The recommended scope (§5.1) is implemented and tested:
+> - **`engine/utils/load_vnnlib2.m`** — single-network 2.0 parser. STREAMING design
+>   (one S-expression statement at a time) so the 96 MB / 124 MB image benchmarks
+>   parse without a whole-file token tree; multi-network/multimodal files gate from
+>   the header alone (smart_turn 124 MB gated in 4 ms). Sound-or-unknown throughout.
+> - **`engine/utils/load_vnnlib.m`** — `(vnnlib-version <2.0>)` sniff dispatches 2.0
+>   files to `load_vnnlib2`; the 1.0 path is byte-for-byte unchanged.
+> - **`examples/Submission/VNN_COMP2025/run_vnncomp_instance.m`** — `property.unsupported`
+>   → emit `unknown` (Phase 3a) rather than risk a −150 wrong verdict.
+> - **`tests/utils/test_load_vnnlib2.m`** — 13 tests (forms, multi-dim row-major flatten,
+>   ==, var-var, OR/conjunct distribution, dispatch, and the four gates).
+> - **Validation:** acasxu prop_1 parsed via 2.0 == via 1.0 EXACTLY (lb/ub/G/g diff 0);
+>   the single-net 2.0 benchmarks parse to sound boxes; multi-net/nonlinear/multimodal
+>   /mixed gate to `unknown`.
+> - **Adversarial review (19-agent workflow):** found + fixed one real soundness bug —
+>   a standalone output conjunct adjacent to an `(or ...)` must be distributed into
+>   every disjunct (one prop cell), else the runner's `length(prop)==1` path silently
+>   ignores it. Strict `<`/`>` are treated as `<=`/`>=` to match the battle-tested 1.0
+>   parser (sound for the UNSAT proof; the boundary SAT case is within VNN-COMP's 1e-4
+>   constraint tolerance and guarded by the onnxruntime witness replay).
+> - **Deferred (still per §5.2):** multi-network `equal-to`/`isomorphic-to` (Phase 2),
+>   `smart_turn` multimodal input set (Phase 3b), pointing the sweep driver at the
+>   `2.0/` instances.csv, and PGD-on-the-box for nonlinear-gated instances.
+Discipline: any 2.0 path proposed here must be **sound-or-unknown** (the −150 rule:
+never emit `sat`/`unsat` we cannot defend; on any doubt return `unknown`).
+
+Sources are cited inline as `[Sn]` and collected at the bottom. Local file evidence
+is cited as `path:line`. Benchmark evidence is cited by `zcat` of the actual
+`*.vnnlib.gz` under `../vnncomp2026_benchmarks/benchmarks/<bench>/2.0/`.
+
+---
+
+## 0. TL;DR / headline
+
+- **34 benchmark folders ship a `2.0/` directory.** Of those, **4 are 1.0-syntax
+  files mislabeled into a `2.0/` folder** (cersyve, cora_2024, malbeware,
+  safenlp_2024 — they still use `(declare-const X_0 Real)` and have *no*
+  `(vnnlib-version <2.0>)` header), so the existing 1.0 parser already reads them.
+  **28 are genuine single-network 2.0** (one `declare-network`, box input + linear
+  output — i.e. 1.0 semantics re-expressed in 2.0 syntax). **2 are genuine
+  multi-network 2.0** (`monotonic_acasxu_2026`, `isomorphic_acasxu_2026` — two
+  networks `f`,`g` with `equal-to`/`isomorphic-to` + cross-network constraints).
+- **Tractable by June 30 with a parser extension + existing NNV reach: the 28
+  single-network 2.0 benchmarks** (plus the 4 mislabeled-1.0). Two of these are
+  extended-only and *only* reachable with a 2.0 parser:
+  `adaptive_cruise_control_non_linear_2026` (single-net but **nonlinear** property →
+  parse yes, sound-verify mostly no) and `smart_turn_multimodal_2026` (single-net
+  but **2 input tensors** / multimodal → needs multi-input set construction).
+- **Research-grade / likely out of scope for June 30: the 2 multi-network
+  benchmarks.** They need a product/difference construction over two networks plus
+  a runner that loads a *list* of `(name, onnx)` pairs. A sound construction exists
+  for `equal-to` (Section 3) but the runner plumbing is a substantial change.
+- **Recommended path: extend the MATLAB parser** (`load_vnnlib.m`) to a new
+  `load_vnnlib2.m` dispatched on the `(vnnlib-version <2.0>)` header, scoped first to
+  single-network linear properties; **keep the `vnnlib` PyPI package (dlshriver) as a
+  cross-check oracle, not the primary path.** Multi-network is a separate, optional
+  phase.
+
+---
+
+## 1. VNN-LIB 2.0 grammar summary (what matters for NNV)
+
+VNN-LIB 2.0 ("Rigorous Foundations for Neural Network Verification", Roy, Antony,
+Gimelli, Daggitt, CAV 2026) was released **2025-12-15** as `standard.pdf` v2.0.0
+[S1][S2][S6]. The grammar is given in LBNF in `syntax/grammar.cf` [S3]. A 2.0 query
+is: a `(vnnlib-version <2.0>)` header, then a list of typed `declare-network` blocks,
+then a list of `(assert <bool-expr>)` statements [S3][S6].
+
+### 1.1 Declarations
+
+- **Version:** `(vnnlib-version <2.0>)` — first non-comment line; this is the
+  dispatch key for "is this a 2.0 file?" [S3]. Confirmed present in every genuine
+  2.0 file, e.g. `monotonic_acasxu_2026/2.0/vnnlib/instance_0.vnnlib.gz`.
+- **Network:** `(declare-network <name> [<equivalence>] (declare-input ...)+
+  (declare-output ...)+ (declare-hidden ...)* )` [S3][S5]. A network is a *named*
+  scope; inputs/outputs are *namespaced by network name* in genuine multi-network
+  files (`X_f`, `Y_g`).
+- **Input/Output:** `(declare-input <name> <elementType> <shape>)`,
+  `(declare-output <name> <elementType> <shape>)` [S5]. `<elementType>` is a type
+  from the network theory (`float32`, `float64`, `int32`, ...) **or** the
+  distinguished type `real` for "real-valued queries" [S6]. `<shape>` is a bracketed
+  dim list: `[5]`, `[1,5]`, `[1,3,32,32]`, `[]` for scalar.
+- **Hidden (new in 2.0):** `(declare-hidden <name> <elementType> <shape>
+  <onnxNodeName>)` — lets a property constrain an *intermediate* ONNX node by its
+  graph name [S4][S5]. Use case: encoder–decoder bottlenecks, attention. **No 2026
+  benchmark uses this** (grep over all `2.0/` files: zero `declare-hidden`), so it is
+  out of scope for NNV 2026.
+- **`real` vs `float32` semantics:** declaring inputs as `real` is "explicit
+  permission for the solver to interpret ONNX networks as real-valued functions and
+  acknowledges that the result may be unsound due to numerical imprecision" [S6]. The
+  2026 single-net benchmarks use `float32`; the multi-net acasxu ones use `real`.
+
+### 1.2 Network equivalence relations (the genuinely new semantics)
+
+- **`(equal-to <other>)`:** "each `declare-network` declaration is intended to map to
+  the same network implementation" [S5]; formally the two networks "must actually be
+  the *same* model file" and "both the element types and shapes of the input and
+  output declarations for the two networks have to match" [S6]. Evidence:
+  `monotonic_acasxu_2026/2.0/instances.csv` maps both `f` and `g` to the *same* onnx
+  (`('f','onnx/ACASXU_..._2_2_...onnx'), ('g','onnx/ACASXU_..._2_2_...onnx')`).
+- **`(isomorphic-to <other>)`:** "the same graph structure but with different weights"
+  [S5]; "the shapes, but not the element types ... have to match" [S6]. Evidence:
+  `isomorphic_acasxu_2026/2.0/instances.csv` maps `f`→`onnx/original/...onnx`,
+  `g`→`onnx/perturbed/..._perturbed_0.onnx`.
+- **No transitive chaining:** "an `equal-to` or `isomorphic-to` declaration cannot
+  reference another network declaration that also contains an equivalence
+  statement" [S6] → at most 2 networks effectively coupled in 2026.
+
+### 1.3 Variable references and indexing
+
+- **Multi-dimensional, 0-based:** `X[0,2]` = "row 0, column 2" [S6]. **Partial
+  indexing is not allowed** — the number of indices must equal the tensor rank [S6].
+  Confirmed: `adaptive_cruise.../instance_0.vnnlib.gz` uses `X[0,0]`, `X[0,1]`;
+  `acasxu_2023/2.0` uses `X[0,0,0,0]`; `smart_turn` uses `X1[0,0,0]`.
+- **Network-namespaced names:** in multi-net files variables are `X_f[0]`, `Y_g[3]`;
+  in single-net files they are just `X`, `Y` (or `X1`,`X2` for multimodal). The
+  trailing-`_f` is part of the *variable name*, not an index.
+
+### 1.4 Operators
+
+- **Comparisons (binary):** `<`, `<=`, `>`, `>=`, `==`, `!=` [S3][S5][S6]. (1.0 NNV
+  supports only `<`,`<=`,`>`,`>=` — `load_vnnlib.m:16` "only >= or <= are
+  supported".) `==` appears in the acasxu multi-net input equalities
+  (`(== X_f[3] 0.227...)`) and `!=` in the nonlinear ACC property.
+- **Boolean (n-ary):** `and`, `or` [S3][S6]. (1.0 NNV supports limited `and`/`or`
+  shapes; see `load_vnnlib.m:13-15`.)
+- **Arithmetic (n-ary, n≥2, plus unary negation):** `(+ a b ...)`, `(- a b ...)`,
+  `(- a)`, `(* a b ...)` [S5][S6]. **Nonlinear products of variables are
+  grammatically allowed** — `(* X[0,1] X[0,1])` appears in
+  `adaptive_cruise.../instance_0.vnnlib.gz`. The spec delegates the actual arithmetic
+  to the network theory and does **not** forbid variable·variable products [S6].
+
+### 1.5 Satisfiability / sat–unsat / witness convention (vs 1.0)
+
+- **Same polarity as 1.0.** A 2.0 query is **satisfiable iff there exists an input
+  assignment under which all assertions evaluate true** [S6]: *"A query is
+  satisfiable if such an assignment exists, and unsatisfiable otherwise."* The
+  benchmark assertions encode the **negation of the safety property** (the unsafe /
+  counterexample region), exactly as in 1.0. So for the verifier:
+  **`sat` = counterexample found = property disproved; `unsat` = property proved;
+  `unknown`/timeout otherwise** [S7]. This matches `run_vnncomp_instance.m`'s
+  existing convention (`status 0=sat, 1=unsat, 2=unknown`,
+  `run_vnncomp_instance.m:361-377`) — **no change to the result encoding is needed.**
+- **Witness format:** a satisfying assignment is a mapping from each declared input
+  variable to a concrete tensor [S6]. For single-network queries this is identical to
+  1.0's `(X_i v) ... (Y_j v)` text dump (`run_vnncomp_instance.m:1059-1092`
+  `write_counterexample`). For **multi-network** queries the spec does *not* pin a
+  standardized witness text format [S6] — the witness must give *both* `X_f` and
+  `X_g`; VNN-COMP's accompanying tooling decides the exact serialization. **This is an
+  open risk for the multi-net path** (Section 3/5).
+
+---
+
+## 2. The 2026 2.0 benchmark catalog
+
+Method: for each `<bench>/2.0/vnnlib/<first>.vnnlib.gz`, `zcat | grep` for
+`vnnlib-version`, `declare-network`, `declare-input`, `declare-output`, `equal-to`,
+`isomorphic-to`, `(or `, `(* `, `==`/`!=`, and counted `declare-input`. The `1.0/`
+column is whether a sibling `1.0/` dir exists (NNV's existing path already covers it).
+
+### 2.1 Classification table
+
+| Benchmark | Has 1.0? | 2.0 syntax? | #nets | equiv? | cross-net? | #inputs | property shape | NNV tractability (2.0 path) |
+|---|---|---|---|---|---|---|---|---|
+| acasxu_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| adaptive_cruise_control_non_linear_2026 | **no (2.0-only)** | **2.0** | 1 | – | – | 1 | box+**nonlinear** in, deeply nested or/and/`!=`/`*` out | **Parse yes; sound-verify mostly NO (nonlinear)** |
+| cctsdb_yolo_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | Single-net parse OK (net unsupported already) |
+| cersyve | yes | **1.0 (mislabeled)** | (1.0 consts) | – | – | 1 | 1.0 file | **Existing 1.0 parser** |
+| cgan2026 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| cgan_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| challenging_certified_training_2026 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| cifar100_2024 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| collins_aerospace_benchmark | yes | **2.0** | 1 | – | – | 1 | box in, **`or`** out | **Single-net: tractable** (disjunctive out) |
+| collins_rul_cnn_2022 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| cora_2024 | yes | **1.0 (mislabeled)** | (1.0 consts) | – | – | 1 | 1.0 file | **Existing 1.0 parser** |
+| dist_shift_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| isomorphic_acasxu_2026 | **no (2.0-only)** | **2.0** | **2** | **isomorphic-to** | **yes (in==, out ±ε)** | 1 ea | ε-equivalence of two nets | **Multi-net: research-grade** |
+| linearizenn_2024 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| lsnc_relu | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** (manifest net) |
+| malbeware | yes | **1.0 (mislabeled)** | (1.0 consts) | – | – | 1 | 1.0 file | **Existing 1.0 parser** |
+| metaroom_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| ml4acopf_2024 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** (cp-star already) |
+| monotonic_acasxu_2026 | **no (2.0-only)** | **2.0** | **2** | **equal-to** | **yes (in≥, out<)** | 1 ea | monotonicity across 2 evals of *same* net | **Multi-net: research-grade (but `equal-to` ⇒ feasible, Section 3)** |
+| nn4sys | yes | **2.0** | 1 | – | – | 1 | box in, **`or`** out | **Single-net: tractable** |
+| relusplitter | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| relusplitter_2026 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| safenlp_2024 | yes | **1.0 (mislabeled)** | (1.0 consts) | – | – | 1 | 1.0 file | **Existing 1.0 parser** |
+| sat_relu | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| smart_turn_multimodal_2026 | **no (2.0-only)** | **2.0** | 1 | – | – | **2 (X1,X2)** | box in (per modality), `(> Y[0,0] 0.5)` out | **Parse yes; needs multi-input-tensor set** |
+| soundnessbench | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| soundnessbench_2026 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| test | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** (toy) |
+| tinyimagenet_2024 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| tllverifybench_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| traffic_signs_recognition_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** (manifest net) |
+| vggnet16_2022 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| vit_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+| yolo_2023 | yes | **2.0** | 1 | – | – | 1 | box in, linear out | **Single-net: tractable** |
+
+### 2.2 Headline counts
+
+- **34** folders with a `2.0/` directory.
+- **4** are **1.0 syntax mislabeled** into `2.0/` (cersyve, cora_2024, malbeware,
+  safenlp_2024) → the existing `load_vnnlib.m` already parses these; "supporting 2.0"
+  is a *no-op* for them (only a folder-path/dispatch concern).
+- **28** are **genuine single-network 2.0** (one `declare-network`, box input,
+  linear or disjunctive output) → **tractable** with a 2.0 *parser extension* + the
+  existing NNV single-network reach pipeline. (Network-import support is orthogonal
+  and unchanged — whatever `load_vnncomp_network.m` does today.)
+- **2** are **genuine multi-network 2.0** (monotonic, isomorphic acasxu) →
+  **research-grade**; need product/difference reasoning + new runner plumbing.
+- **The 4 extended-only (2.0-only) benchmarks** break down as:
+  - `monotonic_acasxu_2026` — **multi-net, `equal-to`**, cross-net in/out.
+  - `isomorphic_acasxu_2026` — **multi-net, `isomorphic-to`**, cross-net in/out (±ε).
+  - `adaptive_cruise_control_non_linear_2026` — **single-net but nonlinear** property
+    (variable·variable products, `!=`, deep nesting). Parser can read it; NNV's linear
+    Star/ImageStar reach cannot soundly verify the nonlinear assertion in general.
+  - `smart_turn_multimodal_2026` — **single-net but 2 input tensors** (multimodal:
+    `X1 [1,80,800]`, `X2 [1,3,32,112,112]`); output `(> Y[0,0] 0.5)` is trivial. The
+    blocker is constructing one input set over two tensors, not the property.
+
+### 2.3 Concrete 2.0 examples (verbatim, abbreviated)
+
+`monotonic_acasxu_2026/2.0/vnnlib/instance_0.vnnlib.gz` (multi-net, `equal-to`):
+```
+(vnnlib-version <2.0>)
+(declare-network f (declare-input X_f real [5]) (declare-output Y_f real [5]))
+(declare-network g (equal-to f) (declare-input X_g real [5]) (declare-output Y_g real [5]))
+(assert (and (<= X_f[0] 0.667...) (>= X_f[0] -0.162...)))   ; box on f
+(assert (== X_f[3] 0.227...))                               ; equality (point) on f
+(assert (and (>= X_f[0] X_g[0]) (>= X_g[0] -0.162...)))     ; cross-net INPUT relation
+(assert (== X_f[1] X_g[1])) ...                             ; X_g pinned to X_f elsewhere
+(assert (< Y_f[3] Y_g[3]))                                  ; cross-net OUTPUT property
+```
+
+`isomorphic_acasxu_2026/2.0/vnnlib/instance_0.vnnlib.gz` (multi-net, `isomorphic-to`,
+output ±ε band — and note the band is `> Y_f+0.05` AND `< Y_f-0.05`, an *empty*
+region, i.e. the unsafe set is unsatisfiable by construction unless interpreted as OR):
+```
+(declare-network g (isomorphic-to f) ...)
+(assert (== X_f[0] X_g[0]) ...)                             ; inputs identified
+(assert (and (> Y_g[0] (+ Y_f[0] 0.05)) (< Y_g[0] (- Y_f[0] 0.05))))   ; ε-equivalence
+```
+
+`adaptive_cruise_control_non_linear_2026` (single-net, **nonlinear**):
+```
+(assert (and (> X[0,0] 0.0) (>= (* X[0,0] 200.0) (* X[0,1] X[0,1]))))   ; nonlinear input region
+(assert (or (or (< Y[0,0] -100.001) ...) (and ... (* (+ X[0,0] (* X[0,1] 0.1)) 200.0) ...)))
+```
+
+`smart_turn_multimodal_2026` (single-net, **2 inputs**):
+```
+(declare-input X1 real [1, 80, 800])
+(declare-input X2 real [1, 3, 32, 112, 112])
+(declare-output Y real [1, 1])
+(assert (and (>= X1[0,0,0] 0.894...) (<= X1[0,0,0] 0.994...)))   ; per-element box on X1
+... (asserts on X2) ...
+(assert (> Y[0,0] 0.5))                                          ; trivial linear output
+```
+
+---
+
+## 3. Verification feasibility for multi-network properties
+
+The interesting question: can NNV's **single-network reachability** decide a
+cross-network property like `(X_f ≥ X_g) ⇒ (Y_f[3] < Y_g[3])` on two copies of a net?
+
+### 3.1 `equal-to` (monotonic_acasxu) — *feasible in principle* via a difference/product net
+
+Because `g` `equal-to` `f` means **literally the same ONNX** (confirmed in
+`instances.csv`), the query is: over inputs `(X_f, X_g)` constrained by a box on `X_f`
+and `X_g` plus cross-input linear relations (`X_f[0] ≥ X_g[0]`, `X_f[i] == X_g[i]`
+for i≠0), is the unsafe output relation `Y_f[3] ≥ Y_g[3]` (negation of the property
+`Y_f[3] < Y_g[3]`) reachable? Two sound NNV-compatible constructions:
+
+1. **Product network + joint input Star.** Build a single network `h(X_f, X_g) =
+   [f(X_f); f(X_g)]` (two parallel copies of `f` sharing weights). The cross-input
+   linear constraints (`X_f[0] ≥ X_g[0]`, `X_f[i]=X_g[i]`) are exactly linear
+   predicate constraints on a joint **Star** over the stacked input `[X_f; X_g]` —
+   NNV `Star(V, C, d, pred_lb, pred_ub)` already supports arbitrary linear predicate
+   constraints `C·a ≤ d`, so the coupled input region is representable *without
+   approximation*. Reach `h` to a joint output Star `[Y_f; Y_g]`, then check the
+   linear unsafe halfspace `Y_f[3] − Y_g[3] ≥ 0` with the existing
+   `verify_specification`/HalfSpace machinery. **Soundness: yes** (over-approx reach +
+   linear output halfspace is the standard NNV flow). The `X_f[i]==X_g[i]` equalities
+   collapse shared predicates so the *effective* number of input predicates is ~5,
+   not 10 — i.e. it is essentially a single acasxu reach with a wider/линейно-coupled
+   box, well within NNV's acasxu exact-star capability.
+   - **Catch (monotonic over-approx):** with `approx-star`, `Y_f` and `Y_g` are
+     over-approximated *independently*, losing the correlation that they come from the
+     *same* network on *correlated* inputs — so `Y_f[3] − Y_g[3]` bounds blow up and
+     you likely get `unknown`, not `unsat`. The product-net construction above keeps
+     the correlation **only if reach is run jointly on `h`** (shared predicates), which
+     `exact-star` honors. For acasxu (small) **exact-star is already the configured
+     method** (`run_vnncomp_instance.m:481`), so monotonic acasxu is plausibly
+     *soundly verifiable* — promising but unproven; must be validated empirically.
+2. **Difference net `d(X_f,X_g)=f(X_f)−f(X_g)` then check `d[3] ≥ 0`.** Equivalent;
+   appends a final linear `(−I, I)` layer onto the product net. Same soundness.
+
+**Bottom line for `equal-to`:** **sound construction exists and reuses NNV reach**;
+the work is (a) parsing the cross-network constraints into a joint Star, (b) building
+the weight-shared product net (a small `NN` assembly), (c) runner plumbing to load
+*one* onnx but instantiate it twice. Tractable as a *research-grade* item, **not a
+safe June-30 commitment** because of the empirical-tightness risk and runner rework.
+
+### 3.2 `isomorphic-to` (isomorphic_acasxu) — *harder*
+
+`f` and `g` are **different weights** (`onnx/original` vs `onnx/perturbed`), so the
+product net stacks **two distinct** networks `h(X)=[f(X); g(X)]` (inputs identified
+by `X_f==X_g`, so a *single* shared input `X`). The construction is the same (joint
+reach, linear output check), and **still sound**, but:
+- Two networks must be imported and composed into one `NN` — more plumbing than the
+  weight-shared case.
+- The output property is an **ε-equivalence band** written as `(and (> Y_g (+ Y_f ε))
+  (< Y_g (- Y_f ε)))` per output — note this literal AND is the *empty* set (can't be
+  both `> Y_f+ε` and `< Y_f−ε`), so either the benchmark intends per-clause OR
+  semantics or the unsafe region is "outside the ±ε band" (`|Y_f−Y_g| > ε`), which is
+  a **disjunction of two halfspaces per output** → NNV can represent it as an OR of
+  HalfSpaces (the existing `prop` cell-of-HalfSpaces structure already encodes OR).
+  This ambiguity must be resolved against the spec/VNN-COMP tooling before trusting
+  any verdict (−150 risk).
+
+### 3.3 Honest verdict
+
+- **Single-network linear 2.0 (28 benches):** fully within NNV today — *parser only*.
+- **`equal-to` multi-net (monotonic):** sound construction exists, likely verifiable
+  with exact-star on acasxu; **research-grade, not guaranteed by June 30.**
+- **`isomorphic-to` multi-net (isomorphic):** sound construction exists but more
+  plumbing + an output-semantics ambiguity to resolve; **research-grade, lower
+  priority.**
+- **Nonlinear single-net (adaptive_cruise):** NNV's linear reach **cannot soundly
+  verify** the variable·variable product constraints in general → **`unknown` is the
+  honest answer** (parser can still *read* it; falsification/PGD can still find `sat`).
+- **Multimodal single-net (smart_turn):** property is trivial; the only work is a
+  two-tensor input set. Feasible but needs `create_input_set` to handle a *list* of
+  input boxes feeding a multi-input ONNX — moderate effort.
+
+---
+
+## 4. Phased implementation plan (least-effort-highest-value first)
+
+### Phase 0 — Dispatch + recognize 2.0 (tiny, do first)
+
+- Add a one-line sniff: read the first non-comment line; if it matches
+  `(vnnlib-version <2.0>)`, route to `load_vnnlib2`; else fall through to the existing
+  `load_vnnlib` (which keeps handling the 4 *mislabeled-1.0* files in `2.0/` dirs —
+  they have no version header, so they correctly take the 1.0 path).
+- File: a small `load_vnnlib_dispatch.m` (or a guard at the top of a renamed entry
+  point) that `run_vnncomp_instance.m:41` calls instead of `load_vnnlib` directly.
+- **Risk: none** (pure addition; 1.0 behavior byte-for-byte unchanged).
+
+### Phase 1 — Single-network 2.0 parser (`load_vnnlib2.m`) — THE high-value phase
+
+Scope: one `declare-network`, `float32`/`real` inputs/outputs, box input + linear
+(possibly disjunctive `or`) output. **Recommendation: extend in MATLAB, do NOT make
+the Python `vnnlib` package the primary path** (rationale in §4.5).
+
+**Output data structure (must be drop-in compatible with `run_vnncomp_instance.m`):**
+```
+property.lb   : single column vector (single)   OR cell{M} of vectors (disjunctive input)
+property.ub   : same shape as lb
+property.prop : cell{N} of structs, each with field .Hg = array of HalfSpace
+                (HalfSpace.G·y <= HalfSpace.g encodes the UNSAFE output region;
+                 array length > 1 = OR of disjuncts, exactly as 1.0 produces)
+```
+This is the **identical contract** the runner already consumes
+(`run_vnncomp_instance.m:42-44, 79-97, 159-184`), so **no runner change is needed for
+single-network 2.0** beyond Phase 0 dispatch. New parser responsibilities:
+1. Parse `declare-network`/`declare-input`/`declare-output`; record per-network input
+   shape (product of dims = flat dimension) and output dimension. Single-net ⇒ ignore
+   the `_f` namespacing (variable is `X`/`Y`, or `X1`/`X2`).
+2. **Multi-dim index → flat index.** `X[i,j,...]` with declared shape `[d0,d1,...]` →
+   row-major flat `idx = ((i*d1)+j)*d2+...`. (Matches ONNX/vnnlib row-major; the
+   runner already permutes per category via `needReshape`, so the parser should emit
+   the **flat ONNX order** the 1.0 parser emits, keeping `needReshape` semantics
+   intact.) **Soundness-critical:** an off-by-one or wrong-major-order here silently
+   mislabels dimensions → wrong box → −150. Add a unit test against a hand-checked
+   small instance (`test/2.0`).
+3. Box input from `(<= X[..] u)` / `(>= X[..] l)` and `(and ...)` of these → fill
+   `lb/ub`. Support the `(assert (and (>= ..) (<= ..)))` paired form used by 2026
+   files (1.0 used two separate asserts; 2.0 pairs them in one `and`).
+4. Output assertions → `HalfSpace` arrays exactly as `process_assertion`/`process_or`
+   do in 1.0 (`load_vnnlib.m:190-362`); reuse that code. Handle `(or ...)` (nn4sys,
+   collins_aerospace) as OR of HalfSpaces (already supported shape).
+5. **`==`/`!=` handling (single-net):** `(== X[i] c)` ⇒ `lb[i]=ub[i]=c` (degenerate
+   box; runner already special-cases `lb==ub` as trivially verified,
+   `run_vnncomp_instance.m:149,205,281`). `(== Y[i] c)` in an unsafe region ⇒ two
+   halfspaces `Y[i]≤c ∧ Y[i]≥c`. `!=` in an *unsafe* region is a disjunction
+   (`Y<c ∨ Y>c`) → OR of halfspaces. **If a single-net file mixes `==`/`!=` into a
+   form the HalfSpace encoding can't represent soundly, return a sentinel that makes
+   the runner emit `unknown`** (never guess).
+6. **Multimodal (smart_turn): two input tensors.** Emit `property.lb`/`ub` as the
+   concatenation of the two flattened boxes **plus** a record of the per-tensor split
+   (`property.inputSplit = [numel(X1), numel(X2)]`) so the runner can build a
+   multi-input set. This is the one place the runner *does* need a small change
+   (Phase 3b). If multimodal is descoped, the parser can still flag it `unknown`.
+7. **Nonlinear (adaptive_cruise): detect and refuse soundly.** If any assertion
+   contains a `(* <var> <var>)` (variable·variable) or nested nonlinear arithmetic the
+   linear HalfSpace encoding can't represent, set `property.unsupported = true`. The
+   runner then **skips reach (→ unknown)** but **may still run falsification/PGD** to
+   find a `sat` witness (sound: a concrete violating point is always valid). Wire this
+   as: parse the *input* box if it is linear (most ACC input bounds are simple boxes)
+   so PGD has a region to sample, and mark the *output* property nonlinear→unknown.
+
+**Deliverables of Phase 1:** `load_vnnlib2.m`, a `flatten_index.m` helper, and a
+script-test under `engine/utils/` or the submission test dir that parses one file per
+single-net benchmark and asserts `lb≤ub`, correct dims, and HalfSpace polarity against
+a hand-checked oracle for `test/2.0` and `acasxu_2023/2.0`.
+
+### Phase 2 — Multi-network handling (OPTIONAL, research-grade)
+
+Only if Phase 1 lands with time to spare. Scope `equal-to` first (monotonic), then
+`isomorphic-to` (isomorphic).
+
+Parser additions (a *separate* output shape, since the runner contract differs):
+```
+property.networks   : struct array, one per declare-network:
+                        .name, .inputName(s), .outputName, .inShape, .outShape,
+                        .equivOf (name or ''), .equivKind ('equal'|'isomorphic'|'')
+property.jointLb/jointUb : box over the STACKED input [X_f; X_g]
+property.jointC, .jointd : linear predicate constraints coupling X_f,X_g
+                           (from cross-network input asserts: X_f[0]>=X_g[0], ==, ...)
+property.crossProp  : HalfSpace(s) over STACKED output [Y_f; Y_g] (unsafe region),
+                       e.g. [0..,+1 at Y_f[3], -1 at Y_g[3]] <= 0  for  Y_f[3] >= Y_g[3]
+```
+Verification (new helper, e.g. `verify_multinet.m`):
+1. Build product net `h` = stack of the per-network NNs (weight-shared for `equal-to`;
+   two imports for `isomorphic-to`). A thin `NN` wrapper that runs each sub-net on its
+   slice of the stacked input and concatenates outputs.
+2. Build the joint input **Star** from `jointLb/jointUb` + `jointC/jointd`.
+3. `h.reach(IS, exact-star)` → joint output Star; check `crossProp` with
+   `verify_specification`. Sound by construction (§3.1).
+4. Falsification: sample the joint box (respecting equality couplings), evaluate both
+   sub-nets, check the cross-output halfspace → sound `sat` witnesses.
+
+**Gate hard:** if the cross-network constraints are not expressible as linear joint
+predicates, or the product-net assembly fails, **return `unknown`.**
+
+### Phase 3 — Wiring into the sweep
+
+- **3a (single-net, required):** in `run_vnncomp_instance.m:41`, call the Phase-0
+  dispatch. **Nothing else changes** for the 28 single-net benches — same `lb/ub/prop`
+  contract. Add the `category` strings for the 2.0-only single-net benches to
+  `load_vnncomp_network.m` (adaptive_cruise → linear-input net but mark nonlinear-out
+  unknown; smart_turn → multimodal). The sweep driver must point at the `2.0/`
+  instances.csv (same `onnx,vnnlib,timeout` format — confirmed for all single-net
+  2.0, including the 2 extended-only single-net ones).
+- **3b (multimodal, small):** teach `create_input_set` (and `create_random_examples`)
+  to consume `property.inputSplit` and build a set over two input tensors for
+  smart_turn. Only needed if smart_turn is in scope.
+- **3c (multi-net, optional):** a *separate* runner branch that, on
+  `property.networks` present, loads the `(name,onnx)` **tuple list** from the
+  multi-net `instances.csv` (Python-literal column 0 — needs a small CSV/tuple
+  parser), builds the product net, and calls `verify_multinet`. This is the only place
+  the runner's `(category, onnx, vnnlib)` signature must be generalized to a *list* of
+  onnx paths.
+
+### 4.5 Parser approach: extend MATLAB vs Python bridge — RECOMMENDATION
+
+**Recommend: extend in MATLAB (`load_vnnlib2.m`), use the Python `vnnlib` package
+(dlshriver) as an offline cross-check oracle only.**
+
+- The Python `vnnlib` package *does* parse 2.0 — it released **v1.0.0 on 2025-12-15**,
+  the same day as the 2.0 standard, and provides "a full VNN-LIB parser which
+  generates an AST ... and a transformer class," with `declare-network` support
+  [S8][S9]. So a bridge is *possible*.
+- **But** the NNV runner is MATLAB and already has a battle-tested 1.0 parser whose
+  helper functions (`process_assertion`, `process_or`, `process_constraint`,
+  HalfSpace assembly) are **directly reusable** for single-net 2.0 — the only genuinely
+  new parsing is the `declare-network` header and multi-dim index flattening. A MATLAB
+  extension avoids a Python⇄MATLAB serialization layer on the hot path and keeps the
+  −150-critical box/halfspace construction in one auditable place.
+- The vendored `tools/onnx2nnv_python/` shows the team already runs Python for ONNX
+  import; adding `pip install git+https://github.com/dlshriver/vnnlib.git` and a tiny
+  script that parses a 2.0 file to a normalized JSON (`{lb, ub, prop_halfspaces}`)
+  makes an excellent **differential oracle** for the MATLAB parser in tests (parse the
+  same file both ways, assert identical lb/ub/HalfSpaces). Use it for *trust*, not for
+  the live verdict.
+- For the **multi-network** case specifically, the Python AST is more attractive
+  (cross-network constraint extraction is fiddly), so Phase 2 may justify a Python
+  preprocessing step that emits the `property.networks`/`jointC`/`crossProp` JSON,
+  consumed by MATLAB. Decide at Phase 2 start.
+
+---
+
+## 5. Scope recommendation for June 30, risks, fallback
+
+### 5.1 Recommended scope (commit)
+
+1. **Phase 0 + Phase 1 + Phase 3a** — single-network 2.0 parser + dispatch + sweep
+   wiring. This unlocks **all 28 genuine single-net 2.0 benchmarks** plus correctly
+   routes the 4 mislabeled-1.0 ones, and reads `adaptive_cruise`/`smart_turn` even if
+   it can only *falsify* them. **This is the high-value, low-risk core and should be
+   the June-30 commitment.**
+2. **Stretch:** Phase 3b (smart_turn multimodal input set) — small, self-contained.
+
+### 5.2 Stretch / research (do not commit)
+
+3. **Phase 2 + Phase 3c** — multi-network `equal-to` (monotonic acasxu) via the
+   product-net construction. Sound in principle (§3.1), plausibly verifiable with
+   exact-star, but needs runner generalization and empirical validation. Treat as
+   upside, not a deliverable.
+4. `isomorphic-to` (isomorphic acasxu) — lowest priority; output-band semantics
+   ambiguity (§3.2) must be resolved first.
+
+### 5.3 Risks
+
+- **R1 (−150, highest): index flattening / major-order.** A wrong row-major vs
+  column-major flatten silently mislabels input dims → wrong box → invalid sat/unsat.
+  Mitigation: differential test vs the Python `vnnlib` oracle and vs the existing 1.0
+  files (acasxu has both 1.0 and 2.0 — parse both, assert identical effective box).
+- **R2 (−150): `==`/`!=` polarity.** Mis-encoding `!=`/`==` unsafe regions flips
+  sat/unsat. Mitigation: encode `==` only as degenerate box (input) or paired
+  halfspaces (output); encode `!=`/disjunctions as OR-of-HalfSpaces; **on any form not
+  cleanly representable, return `unknown`.**
+- **R3: multimodal split correctness.** Wrong per-tensor split or ordering for
+  smart_turn → wrong input. Mitigation: descope smart_turn to `unknown` if not
+  validated; it has trivial output so little is lost.
+- **R4: nonlinear over-claim.** Never attempt to "linearize" `(* X X)` and claim
+  soundness. Mitigation: detect nonlinear → `unknown` for reach; PGD-only for sat.
+- **R5 (multi-net): witness format undefined by spec** [S6]. A multi-net `sat` must
+  serialize *both* `X_f` and `X_g`; the exact text format is set by VNN-COMP tooling,
+  not the standard. Mitigation: defer multi-net `sat` reporting until the format is
+  confirmed against the 2026 rules repo; until then, multi-net emits only `unsat`/
+  `unknown` (never an unverifiable `sat`).
+- **R6: over-approx looseness on monotonic.** approx-star decorrelates `Y_f`,`Y_g` →
+  `unknown`. Mitigation: use exact-star (already default for acasxu) and the joint
+  product-net reach; accept `unknown` rather than a wrong verdict.
+
+### 5.4 Fallback
+
+**The 1.0 track is already fully covered** by `load_vnnlib.m` + `run_vnncomp_instance.m`
+— every benchmark with a `1.0/` dir (30 of 34) is reachable through the existing,
+hardened path. **2.0 support is pure upside.** If Phase 1 slips, NNV loses only the 4
+extended-only 2.0-only benchmarks (and the 2.0-syntax variants of benches it already
+scores on via 1.0). Therefore the safe posture is: ship Phase 0/1/3a, keep everything
+**sound-or-unknown**, and treat multi-network as a post-deadline research item.
+
+---
+
+## Sources
+
+- [S1] VNN-LIB official site — version, 2.0 release, links to spec PDF and GitHub:
+  https://www.vnnlib.org/
+- [S2] VNNLIB-Standard repo (standard.tex, syntax/grammar.cf, v2.0.0 released
+  2025-12-15): https://github.com/VNNLIB/VNNLIB-Standard
+- [S3] `syntax/grammar.cf` (LBNF grammar: vnnlib-version, declare-network,
+  equal-to/isomorphic-to, declare-input/output/hidden, comparison/boolean/arithmetic
+  operators, assertions): https://github.com/VNNLIB/VNNLIB-Standard (syntax/grammar.cf)
+- [S4] `document/standard.tex` structure (chapters: models, query_language, logics,
+  verifier_interface): https://github.com/VNNLIB/VNNLIB-Standard
+- [S5] `document/chapters/query_language.tex` (verbatim definitions of declare-network,
+  declare-input/output/hidden, equal-to, isomorphic-to, operators, satisfiability):
+  https://raw.githubusercontent.com/VNNLIB/VNNLIB-Standard/main/document/chapters/query_language.tex
+- [S6] VNN-LIB 2.0 paper, "Rigorous Foundations for Neural Network Verification"
+  (Roy, Antony, Gimelli, Daggitt, CAV 2026) — satisfiability convention, equal-to vs
+  isomorphic-to semantics, `real` type, nonlinear products allowed, multi-dim indexing,
+  declare-hidden, witness mapping, no transitive chaining:
+  https://arxiv.org/html/2605.07451
+- [S7] VNN-COMP convention (unsat=proved, sat+counterexample=disproved,
+  unknown/timeout otherwise): https://vnn-comp.github.io/
+- [S8] dlshriver/vnnlib Python package (full VNN-LIB parser, AST + transformer,
+  declare-network; install via pip from GitHub): https://github.com/dlshriver/vnnlib
+- [S9] vnnlib on PyPI (VNNLIB-Python 1.0.0 released 2025-12-15, part of the official
+  ecosystem): https://pypi.org/project/vnnlib/
+
+### Local files cited
+- `code/nnv/engine/utils/load_vnnlib.m` — 1.0 parser; output contract
+  (`property.lb/ub/prop`), assumptions (`:10-18`), `>=`/`<=`-only (`:16`),
+  HalfSpace assembly (`:190-362`).
+- `code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m` — consumes
+  `property.lb/ub/prop` (`:41-44`), sat/unsat/unknown status encoding (`:361-377`),
+  per-category net loading (`load_vnncomp_network`, `:454-1011`), counterexample
+  writer (`:1059-1092`).
+- `code/nnv/tools/onnx2nnv_python/README.md` — vendored Python ONNX importer (basis
+  for a Python `vnnlib` differential-oracle bridge).
+
+### Benchmark files cited (under `../vnncomp2026_benchmarks/benchmarks/`)
+- `monotonic_acasxu_2026/2.0/vnnlib/instance_0.vnnlib.gz`, `.../2.0/instances.csv`
+  (multi-net `equal-to`, same onnx for f and g).
+- `isomorphic_acasxu_2026/2.0/vnnlib/instance_0.vnnlib.gz`, `.../2.0/instances.csv`
+  (multi-net `isomorphic-to`, original vs perturbed onnx).
+- `adaptive_cruise_control_non_linear_2026/2.0/vnnlib/instance_0.vnnlib.gz`
+  (single-net nonlinear).
+- `smart_turn_multimodal_2026/2.0/vnnlib/instance_0.vnnlib.gz` (single-net, 2 inputs).
+- `acasxu_2023/2.0`, `test/2.0`, `cgan2026/2.0`, `nn4sys/2.0`, `collins_aerospace_benchmark/2.0`,
+  etc. (single-net 2.0, `float32`, box+linear/or).
+- `cersyve/2.0`, `cora_2024/2.0`, `malbeware/2.0`, `safenlp_2024/2.0` (1.0 syntax
+  mislabeled into `2.0/` — `(declare-const X_0 Real)`, no version header).

--- a/code/nnv/engine/utils/load_vnnlib.m
+++ b/code/nnv/engine/utils/load_vnnlib.m
@@ -17,6 +17,15 @@ function property = load_vnnlib(propertyFile)
 %
 %    If the vnnlib does not meet these conditions, this function may not work
 
+    % VNN-LIB 2.0 dispatch: 2.0 files start with a `(vnnlib-version <2.0>)` header
+    % and use a different grammar (declare-network, bracket indexing). Route those
+    % to the dedicated 2.0 parser; 1.0 files (no such header, including the handful
+    % of 1.0-syntax files mislabeled into a 2.0/ folder) fall through unchanged.
+    if is_vnnlib2(propertyFile)
+        property = load_vnnlib2(propertyFile);
+        return;
+    end
+
     fileID = fopen(propertyFile,'r'); % open vnnlib file
     tline = fgetl(fileID); % Reading file line-by-line
     phase = "start"; % there are four phases in each file (declare inputs, declare outputs, define inputs, define outputs)
@@ -173,6 +182,24 @@ function property = load_vnnlib(propertyFile)
 end % end function
 
 %% Helper Functions
+
+% Sniff whether a file is VNN-LIB 2.0 (first non-comment, non-blank line is a
+% `(vnnlib-version <2.0>)` header). 1.0 files -- and the 1.0-syntax files some 2026
+% benchmarks place under a 2.0/ folder -- have no such header and return false.
+function tf = is_vnnlib2(propertyFile)
+    tf = false;
+    fid = fopen(propertyFile, 'r');
+    if fid < 0, return; end
+    cleaner = onCleanup(@() fclose(fid));
+    for it = 1:200   % scan past leading comments/blank lines only
+        ln = fgetl(fid);
+        if ~ischar(ln), return; end
+        ln = strtrim(ln);
+        if isempty(ln) || startsWith(ln, ';'), continue; end
+        tf = startsWith(ln, '(vnnlib-version') || contains(ln, 'declare-network');
+        return;   % first meaningful line decides
+    end
+end
 
 % combine multiple lines into a single one if they belong to a single statement/assertion
 function tline = merge_lines(tline, fileID)

--- a/code/nnv/engine/utils/load_vnnlib.m
+++ b/code/nnv/engine/utils/load_vnnlib.m
@@ -183,9 +183,12 @@ end % end function
 
 %% Helper Functions
 
-% Sniff whether a file is VNN-LIB 2.0 (first non-comment, non-blank line is a
-% `(vnnlib-version <2.0>)` header). 1.0 files -- and the 1.0-syntax files some 2026
-% benchmarks place under a 2.0/ folder -- have no such header and return false.
+% Sniff whether a file is VNN-LIB 2.0: its first non-comment, non-blank line is a
+% `(vnnlib-version ...)` header (the 2.0 grammar requires this header first). 1.0
+% files -- and the 1.0-syntax files some 2026 benchmarks place under a 2.0/ folder --
+% have no such header and return false, so they take the unchanged 1.0 path. We key
+% ONLY on the version header (not `declare-network`) to keep dispatch exactly the
+% documented contract and never misroute a file that merely mentions the token.
 function tf = is_vnnlib2(propertyFile)
     tf = false;
     fid = fopen(propertyFile, 'r');
@@ -196,7 +199,7 @@ function tf = is_vnnlib2(propertyFile)
         if ~ischar(ln), return; end
         ln = strtrim(ln);
         if isempty(ln) || startsWith(ln, ';'), continue; end
-        tf = startsWith(ln, '(vnnlib-version') || contains(ln, 'declare-network');
+        tf = startsWith(ln, '(vnnlib-version');
         return;   % first meaningful line decides
     end
 end

--- a/code/nnv/engine/utils/load_vnnlib2.m
+++ b/code/nnv/engine/utils/load_vnnlib2.m
@@ -16,9 +16,10 @@ function property = load_vnnlib2(propertyFile)
     % parser returns
     %     property.unsupported = true
     %     property.reason      = '<why>'
-    % and (when possible) still fills a sound INPUT box so the caller can fall back
-    % to falsification/PGD (a concrete counterexample is always a valid `sat`). The
-    % runner treats `unsupported` as `unknown` for the reach verdict. Gated cases:
+    % and (when possible) still records a sound INPUT box in property.lb/ub. NOTE: the
+    % current run_vnncomp_instance.m emits `unknown` for ANY unsupported property; the
+    % recorded box is reserved for a FUTURE falsification/PGD fallback (plan Phase 3b)
+    % that could still find a concrete `sat` for a gated-but-linear-input case. Gated:
     % multiple networks (equal-to/isomorphic-to), declare-hidden, >1 input or output
     % tensor (multimodal), `!=`, nonlinear/arithmetic (`*`,`+`,`-` over variables),
     % partial indexing, and mixed input/output disjunctions.

--- a/code/nnv/engine/utils/load_vnnlib2.m
+++ b/code/nnv/engine/utils/load_vnnlib2.m
@@ -1,0 +1,657 @@
+function property = load_vnnlib2(propertyFile)
+    % property = load_vnnlib2(propertyFile)
+    %
+    % Parse a VNN-LIB **2.0** specification file (header `(vnnlib-version <2.0>)`)
+    % for the SINGLE-NETWORK case and return the SAME contract as load_vnnlib (1.0):
+    %
+    %     property.lb    -> input lower-bound vector (single) OR cell{M} of vectors
+    %     property.ub    -> input upper-bound vector (single) OR cell{M} of vectors
+    %     property.prop  -> cell{N} of structs, each with field .Hg = HalfSpace array
+    %                       (HalfSpace.G*y <= HalfSpace.g encodes the UNSAFE output
+    %                        region; an array of length>1 is an OR of disjuncts,
+    %                        exactly as load_vnnlib produces).
+    %
+    % SOUNDNESS (the VNN-COMP -150 rule): any 2.0 construct this parser cannot map
+    % onto NNV's single-network linear reachability is NOT guessed at. Instead the
+    % parser returns
+    %     property.unsupported = true
+    %     property.reason      = '<why>'
+    % and (when possible) still fills a sound INPUT box so the caller can fall back
+    % to falsification/PGD (a concrete counterexample is always a valid `sat`). The
+    % runner treats `unsupported` as `unknown` for the reach verdict. Gated cases:
+    % multiple networks (equal-to/isomorphic-to), declare-hidden, >1 input or output
+    % tensor (multimodal), `!=`, nonlinear/arithmetic (`*`,`+`,`-` over variables),
+    % partial indexing, and mixed input/output disjunctions.
+    %
+    % PERFORMANCE: the file is processed by STREAMING complete S-expression
+    % statements (one (declare-network ...) / (assert ...) at a time) so the giant
+    % image benchmarks (collins 96 MB, smart_turn 124 MB) never materialize a
+    % whole-file token tree. Multi-network / multimodal files are gated from the
+    % header alone -- we stop reading before the millions of input asserts.
+    %
+    % VNN-LIB 2.0 grammar handled (single network):
+    %   (declare-network <name> (declare-input <Xname> <type> [shape])
+    %                           (declare-output <Yname> <type> [shape]))
+    %   (assert (<=|>=|<|>|== <Xname>[i,j,..] <const>))           input box
+    %   (assert (and <X bounds> ...))                            input box (paired)
+    %   (assert (or (and <X bounds>) (and <X bounds>) ...))      input OR of boxes
+    %   (assert (<=|>=|<|> <Yname>[..] <const|Yname[..]>))        linear output
+    %   (assert (or (and <Y lin> ...) <Y lin> ...))              disjunctive output
+    %
+    % Multi-dimensional indices are flattened ROW-MAJOR (ONNX/VNN-LIB order), the
+    % same flat order load_vnnlib emits, so the runner's per-category `needReshape`
+    % handling is unchanged. See VNNLIB2_SUPPORT_PLAN.md for the full design.
+
+    fid = fopen(propertyFile, 'r');
+    if fid < 0
+        property = unsupported_property([], 'cannot open file');
+        return;
+    end
+    closer = onCleanup(@() fclose(fid));
+
+    st = init_state();
+    depth = 0;              % running paren depth
+    buf = '';               % current top-level statement being assembled
+    started = false;        % has the current statement opened its first '(' ?
+
+    while true
+        line = fgetl(fid);
+        if ~ischar(line), break; end
+        line = strip_comment(line);
+        if isempty(strtrim(line)), continue; end
+        % scan char-by-char, emitting each balanced top-level (...) statement
+        [st, depth, buf, started, done] = consume_chars(line, st, depth, buf, started);
+        if done
+            property = finalize(st);   % header/assert gated -> stop reading the rest
+            return;
+        end
+    end
+
+    property = finalize(st);
+end
+
+% =========================================================================
+% Streaming statement assembler
+% =========================================================================
+
+function [st, depth, buf, started, done] = consume_chars(line, st, depth, buf, started)
+    done = false;
+    line = [line ' '];   % ensure a separator at line breaks
+    for i = 1:numel(line)
+        c = line(i);
+        if c == '('
+            depth = depth + 1; started = true;
+        elseif c == ')'
+            depth = depth - 1;
+        end
+        if started
+            buf(end+1) = c; %#ok<AGROW>
+        end
+        if started && depth == 0
+            stmt = strtrim(buf);
+            buf = ''; started = false;
+            if ~isempty(stmt)
+                [st, done] = dispatch_statement(stmt, st);
+                if done, return; end
+            end
+        end
+    end
+end
+
+function [st, done] = dispatch_statement(stmt, st)
+    done = false;
+    head = statement_head(stmt);
+    switch head
+        case 'vnnlib-version'
+            st.sawVersion = true;
+        case 'declare-network'
+            if st.sawNetwork
+                st.unsupported = true;
+                st.reason = 'multiple declare-network (multi-network 2.0 not supported)';
+                done = true; return;
+            end
+            st.sawNetwork = true;
+            st = parse_network_header(stmt, st);
+            if st.unsupported
+                done = true; return;   % gate from header alone
+            end
+        case 'assert'
+            st = process_assert(stmt, st);
+            if st.hardStop, done = true; return; end
+        otherwise
+            % ignore (set-logic, declare-const stragglers, comments-only, etc.)
+    end
+end
+
+% =========================================================================
+% Network header
+% =========================================================================
+
+function st = parse_network_header(stmt, st)
+    node = parse_one_sexpr(stmt);
+    inputs = {}; outputs = {}; hasEquiv = false; hasHidden = false;
+    for k = 2:numel(node)
+        c = node{k};
+        if ~iscell(c) || isempty(c), continue; end
+        h = char(c{1});
+        switch h
+            case 'declare-input',  inputs{end+1}  = c; %#ok<AGROW>
+            case 'declare-output', outputs{end+1} = c; %#ok<AGROW>
+            case 'declare-hidden', hasHidden = true;
+            case {'equal-to','isomorphic-to'}, hasEquiv = true;
+        end
+    end
+    if hasEquiv
+        st.unsupported = true; st.reason = 'network equivalence (equal-to/isomorphic-to) -- multi-network not supported'; return;
+    end
+    if hasHidden
+        st.unsupported = true; st.reason = 'declare-hidden intermediate constraints not supported'; return;
+    end
+    if numel(inputs) ~= 1 || numel(outputs) ~= 1
+        st.unsupported = true;
+        st.reason = sprintf('expected 1 input and 1 output tensor, found %d/%d (multimodal not supported)', numel(inputs), numel(outputs));
+        return;
+    end
+    [st.inName, inShape]   = parse_io_decl(inputs{1});
+    [st.outName, outShape] = parse_io_decl(outputs{1});
+    st.inShape = inShape; st.outShape = outShape;
+    st.inDim  = prod(inShape);
+    st.outDim = prod(outShape);
+    if isempty(st.inDim) || st.inDim < 1 || isempty(st.outDim) || st.outDim < 1
+        st.unsupported = true; st.reason = 'could not parse input/output shape'; return;
+    end
+    st.lb = nan(st.inDim, 1, 'single');
+    st.ub = nan(st.inDim, 1, 'single');
+    st.haveBox = true;
+end
+
+% =========================================================================
+% Assert processing
+% =========================================================================
+
+function st = process_assert(stmt, st)
+    if ~st.sawNetwork || ~st.haveBox
+        st.unsupported = true; st.reason = 'assert before declare-network'; st.hardStop = true; return;
+    end
+
+    % cheap, tree-free classification + unsupported-op scan on the raw statement
+    refIn  = ref_present(stmt, st.inName);
+    refOut = ref_present(stmt, st.outName);
+    nonlin = has_unsupported_op_str(stmt);
+
+    if refIn && refOut
+        st.unsupported = true;
+        st.reason = 'mixed input/output assertion (combined disjunction) not supported';
+        st.hardStop = true; return;
+    end
+
+    if refIn
+        if nonlin
+            % nonlinear input region: cannot bound soundly -> gate (still record any
+            % linear bounds we already have for PGD).
+            st.unsupported = true;
+            st.reason = 'nonlinear / arithmetic input constraint not soundly boundable';
+            st.hardStop = true; return;
+        end
+        e = sexpr_body(parse_one_sexpr(stmt));   % the asserted expr
+        head = node_head(e);
+        if strcmp(head, 'or')
+            [lbB, ubB, ok] = parse_input_or(e, st, st.lb, st.ub);
+            if ~ok
+                st.unsupported = true; st.reason = 'unsupported input OR form'; st.hardStop = true; return;
+            end
+            st.lbBoxes = lbB; st.ubBoxes = ubB; st.inputIsOr = true;
+        else
+            [st.lb, st.ub, ok] = apply_input_expr(e, st.lb, st.ub, st);
+            if ~ok
+                st.unsupported = true; st.reason = 'unsupported input constraint form'; st.hardStop = true; return;
+            end
+        end
+    elseif refOut
+        if nonlin
+            st.unsupported = true;
+            st.reason = 'nonlinear / arithmetic / != output property not soundly verifiable by linear reach';
+            st.hardStop = true; return;
+        end
+        e = sexpr_body(parse_one_sexpr(stmt));
+        [ast, ok] = build_output_assertion(e, st);
+        if ~ok
+            st.unsupported = true; st.reason = 'unsupported output property form'; st.hardStop = true; return;
+        end
+        [st.propHs, okacc] = accumulate_output(st.propHs, ast);
+        if ~okacc
+            st.unsupported = true;
+            st.reason = 'output is a conjunction of multiple OR-clauses (product-of-sums) not representable as one disjunctive spec';
+            st.hardStop = true; return;
+        end
+        st.sawOutput = true;
+    else
+        % references neither X nor Y -- ignore (constant tautology / set-info)
+    end
+end
+
+% =========================================================================
+% Finalization
+% =========================================================================
+
+function property = finalize(st)
+    if ~st.sawVersion && ~st.sawNetwork
+        property = unsupported_property([], 'no (vnnlib-version)/declare-network header -- not a 2.0 file'); return;
+    end
+    if st.unsupported
+        box = [];
+        if st.haveBox && ~st.inputIsOr && ~any(isnan(st.lb)) && ~any(isnan(st.ub))
+            box = struct('lb', st.lb, 'ub', st.ub);
+        end
+        property = unsupported_property(box, st.reason);
+        return;
+    end
+    if ~st.sawNetwork
+        property = unsupported_property([], 'no declare-network'); return;
+    end
+
+    if st.inputIsOr
+        for i = 1:numel(st.lbBoxes)
+            if any(isnan(st.lbBoxes{i})) || any(isnan(st.ubBoxes{i}))
+                property = unsupported_property([], 'input OR box has unbounded dimension'); return;
+            end
+        end
+        property.lb = st.lbBoxes;
+        property.ub = st.ubBoxes;
+    else
+        if any(isnan(st.lb)) || any(isnan(st.ub))
+            property = unsupported_property([], 'input box has an unbounded dimension (under-constrained)'); return;
+        end
+        property.lb = st.lb;
+        property.ub = st.ub;
+    end
+
+    if ~st.sawOutput || isempty(st.propHs)
+        property.unsupported = true;
+        property.reason = 'no output property assertion found';
+        property.prop = {};
+        return;
+    end
+    property.prop = st.propHs;
+    property.unsupported = false;
+end
+
+function st = init_state()
+    st = struct();
+    st.sawVersion = false;
+    st.sawNetwork = false;
+    st.unsupported = false;
+    st.reason = '';
+    st.hardStop = false;
+    st.inName = ''; st.outName = '';
+    st.inShape = []; st.outShape = [];
+    st.inDim = []; st.outDim = [];
+    st.lb = []; st.ub = []; st.haveBox = false;
+    st.lbBoxes = {}; st.ubBoxes = {}; st.inputIsOr = false;
+    st.propHs = {}; st.sawOutput = false;
+end
+
+% =========================================================================
+% Cheap raw-string helpers (no tree build)
+% =========================================================================
+
+function s = strip_comment(line)
+    ci = strfind(line, ';');
+    if isempty(ci), s = line; else, s = line(1:ci(1)-1); end
+end
+
+function h = statement_head(stmt)
+    % first token after the opening '('
+    h = '';
+    t = regexp(stmt, '^\(\s*([A-Za-z0-9_\-!]+)', 'tokens', 'once');
+    if ~isempty(t), h = t{1}; end
+end
+
+function tf = ref_present(stmt, name)
+    % does the variable `name` appear as a token (name[...] or bare name)? short-circuits.
+    if isempty(name), tf = false; return; end
+    pat = ['(?<![A-Za-z0-9_])' regexptranslate('escape', name) '(?![A-Za-z0-9_])'];
+    tf = ~isempty(regexp(stmt, pat, 'once'));
+end
+
+function tf = has_unsupported_op_str(stmt)
+    % arithmetic operators applied to variables, or `!=`. Constants like -0.5 are
+    % NOT `(- ...)` operators, so we look for the operator-in-call form `(op `.
+    tf = ~isempty(regexp(stmt, '\(\s*[\*\+/]', 'once')) || ...
+         ~isempty(regexp(stmt, '\(\s*-\s', 'once')) || ...
+         contains(stmt, '!=');
+end
+
+% =========================================================================
+% Tiny S-expression parser (per-statement; operates on ONE statement string)
+% =========================================================================
+
+function node = parse_one_sexpr(stmt)
+    s = squeeze_bracket_space(stmt);
+    toks = tokenize(s);
+    i = 1;
+    if i <= numel(toks) && strcmp(toks{i}, '(')
+        node = parse_node(toks, i);
+    else
+        node = {};
+    end
+end
+
+function body = sexpr_body(node)
+    % the asserted expression: (assert <expr>) -> <expr>
+    if iscell(node) && numel(node) >= 2
+        body = node{2};
+    else
+        body = {};
+    end
+end
+
+function s = squeeze_bracket_space(s)
+    % remove whitespace inside [...] so "X[0, 0, 0, 3]" / "[1, 1, 1, 5]" tokenize whole
+    out = char(zeros(1, numel(s)));
+    n = 0; depth = 0;
+    for i = 1:numel(s)
+        c = s(i);
+        if c == '[', depth = depth + 1; elseif c == ']', depth = max(0, depth - 1); end
+        if depth > 0 && (c == ' ' || c == sprintf('\t')), continue; end
+        n = n + 1; out(n) = c;
+    end
+    s = out(1:n);
+end
+
+function toks = tokenize(s)
+    s = strrep(s, '(', ' ( ');
+    s = strrep(s, ')', ' ) ');
+    toks = regexp(strtrim(s), '\s+', 'split');
+    toks = toks(~cellfun(@isempty, toks));
+end
+
+function node = parse_node(toks, i)
+    % toks{i} == '('
+    node = {};
+    i = i + 1;
+    while i <= numel(toks)
+        t = toks{i};
+        if strcmp(t, '(')
+            [child, i] = parse_node_r(toks, i);
+            node{end+1} = child; %#ok<AGROW>
+        elseif strcmp(t, ')')
+            return;
+        else
+            node{end+1} = t; %#ok<AGROW>
+            i = i + 1;
+        end
+    end
+end
+
+function [node, i] = parse_node_r(toks, i)
+    node = {};
+    i = i + 1;
+    while i <= numel(toks)
+        t = toks{i};
+        if strcmp(t, '(')
+            [child, i] = parse_node_r(toks, i);
+            node{end+1} = child; %#ok<AGROW>
+        elseif strcmp(t, ')')
+            i = i + 1;
+            return;
+        else
+            node{end+1} = t; %#ok<AGROW>
+            i = i + 1;
+        end
+    end
+end
+
+function h = node_head(e)
+    h = '';
+    if iscell(e) && ~isempty(e) && (ischar(e{1}) || isstring(e{1}))
+        h = char(e{1});
+    end
+end
+
+% =========================================================================
+% Declaration parsing
+% =========================================================================
+
+function [name, shape] = parse_io_decl(decl)
+    % decl = {'declare-input'/'declare-output', name, type, '[d0,d1,..]'}
+    name = ''; shape = [];
+    if numel(decl) < 2, return; end
+    name = char(decl{2});
+    for k = numel(decl):-1:3
+        if ischar(decl{k}) || isstring(decl{k})
+            tk = char(decl{k});
+            if startsWith(tk, '[') && endsWith(tk, ']')
+                inner = tk(2:end-1);
+                if isempty(inner)
+                    shape = 1;            % scalar
+                else
+                    shape = str2double(regexp(inner, ',', 'split'));
+                end
+                return;
+            end
+        end
+    end
+end
+
+% =========================================================================
+% Index flattening
+% =========================================================================
+
+function nm = var_basename(tok)
+    nm = ''; tok = char(tok);
+    b = strfind(tok, '[');
+    if ~isempty(b), cand = tok(1:b(1)-1); else, cand = tok; end
+    if ~isempty(cand) && (isletter(cand(1)) || cand(1) == '_'), nm = cand; end
+end
+
+function [flat, ok] = flatten_ref(tok, name, shape)
+    % 'X[0,0,0,3]' with shape [1 1 1 5] -> flat 0-based row-major index (here 3).
+    flat = []; ok = false; tok = char(tok);
+    b = strfind(tok, '[');
+    if isempty(b)
+        if prod(shape) == 1, flat = 0; ok = true; end
+        return;
+    end
+    if ~strcmp(tok(1:b(1)-1), name), return; end
+    e = strfind(tok, ']');
+    if isempty(e), return; end
+    inner = tok(b(1)+1:e(end)-1);
+    idx = str2double(regexp(inner, ',', 'split'));
+    if any(isnan(idx)), return; end
+    if numel(idx) ~= numel(shape), return; end   % partial indexing illegal in 2.0
+    if any(idx < 0) || any(idx >= shape), return; end
+    f = 0;
+    for k = 1:numel(shape)
+        f = f * shape(k) + idx(k);
+    end
+    flat = f; ok = true;
+end
+
+% =========================================================================
+% Input constraints
+% =========================================================================
+
+function [lb, ub, ok] = apply_input_expr(e, lb, ub, st)
+    ok = true;
+    if ~iscell(e) || isempty(e), ok = false; return; end
+    head = char(e{1});
+    if strcmp(head, 'and')
+        for k = 2:numel(e)
+            [lb, ub, ok] = apply_input_expr(e{k}, lb, ub, st);
+            if ~ok, return; end
+        end
+        return;
+    end
+    if ~ismember(head, {'<=','>=','<','>','=='}), ok = false; return; end
+    if numel(e) ~= 3, ok = false; return; end
+    var = char(e{2}); val = e{3};
+    if ~ischar(val) && ~isstring(val), ok = false; return; end
+    if ~isempty(var_basename(val)), ok = false; return; end   % var-var input not a box
+    c = single(str2double(char(val)));
+    if isnan(c), ok = false; return; end
+    [flat, okf] = flatten_ref(var, st.inName, st.inShape);
+    if ~okf, ok = false; return; end
+    idx = flat + 1;
+    % Strict (<,>) are treated as non-strict (<=,>=), matching the battle-tested 1.0
+    % parser (load_vnnlib.m process_constraint/process_input_constraint). This is sound
+    % for the UNSAT proof verdict (the box/unsafe region is over-approximated). For SAT
+    % the only divergence is a witness EXACTLY on the boundary, which (a) is guarded by
+    % the onnxruntime witness replay and (b) falls within VNN-COMP's 1e-4 constraint
+    % tolerance, so the official checker treats it identically.
+    switch head
+        case {'>=','>'}, lb(idx) = c;
+        case {'<=','<'}, ub(idx) = c;
+        case '==',       lb(idx) = c; ub(idx) = c;
+    end
+end
+
+function [lbBoxes, ubBoxes, ok] = parse_input_or(e, st, lb0, ub0)
+    lbBoxes = {}; ubBoxes = {}; ok = true;
+    for k = 2:numel(e)
+        d = e{k};
+        lb = lb0; ub = ub0;
+        [lb, ub, okd] = apply_input_expr(d, lb, ub, st);
+        if ~okd, ok = false; return; end
+        lbBoxes{end+1} = lb; %#ok<AGROW>
+        ubBoxes{end+1} = ub; %#ok<AGROW>
+    end
+    if isempty(lbBoxes), ok = false; end
+end
+
+% =========================================================================
+% Output property (unsafe region) -> HalfSpace
+% =========================================================================
+
+function [ast, ok] = build_output_assertion(e, st)
+    ast = struct('Hg', HalfSpace.empty); ok = true;
+    if ~iscell(e) || isempty(e), ok = false; return; end
+    head = char(e{1});
+    if strcmp(head, 'or')
+        Hs = HalfSpace.empty;
+        for k = 2:numel(e)
+            [sub, oks] = output_conjunction(e{k}, st);
+            if ~oks, ok = false; return; end
+            Hs(end+1,1) = sub; %#ok<AGROW>
+        end
+        ast.Hg = Hs;
+    else
+        [Hs, oks] = output_conjunction(e, st);
+        if ~oks, ok = false; return; end
+        ast.Hg = Hs;
+    end
+end
+
+function [hs, ok] = output_conjunction(e, st)
+    ok = true; G = []; g = [];
+    head = node_head(e);
+    if strcmp(head, 'and')
+        for k = 2:numel(e)
+            [Gr, gr, okr] = output_rows(e{k}, st);
+            if ~okr, ok = false; hs = HalfSpace.empty; return; end
+            G = [G; Gr]; g = [g; gr]; %#ok<AGROW>
+        end
+    else
+        [G, g, okr] = output_rows(e, st);
+        if ~okr, ok = false; hs = HalfSpace.empty; return; end
+    end
+    hs = HalfSpace(G, g);
+end
+
+function [G, g, ok] = output_rows(e, st)
+    ok = true; G = []; g = [];
+    if ~iscell(e) || numel(e) ~= 3, ok = false; return; end
+    head = char(e{1});
+    if ~ismember(head, {'<=','>=','<','>','=='}), ok = false; return; end
+    [row, gval, okr] = linear_two_terms(head, e{2}, e{3}, st);
+    if ~okr, ok = false; return; end
+    if strcmp(head, '==')
+        G = [row; -row]; g = [gval; -gval];
+    else
+        G = row; g = gval;
+    end
+end
+
+function [row, gval, ok] = linear_two_terms(op, lhs, rhs, st)
+    ok = true; row = zeros(1, st.outDim); gval = 0;
+    [li, lc, okl] = term_value(lhs, st);
+    [ri, rc, okr] = term_value(rhs, st);
+    if ~okl || ~okr, ok = false; return; end
+    coef = zeros(1, st.outDim);
+    cst = 0;
+    if ~isempty(li), coef(li) = coef(li) + 1; else, cst = cst - lc; end
+    if ~isempty(ri), coef(ri) = coef(ri) - 1; else, cst = cst + rc; end
+    if any(strcmp(op, {'<=','<'}))
+        row = coef; gval = single(cst);
+    else
+        row = -coef; gval = single(-cst);
+    end
+end
+
+function [idx, c, ok] = term_value(t, st)
+    idx = []; c = 0; ok = true; t = char(t);
+    nm = var_basename(t);
+    if isempty(nm)
+        c = single(str2double(t));
+        if isnan(c), ok = false; end
+        return;
+    end
+    if ~strcmp(nm, st.outName), ok = false; return; end
+    [flat, okf] = flatten_ref(t, st.outName, st.outShape);
+    if ~okf, ok = false; return; end
+    idx = flat + 1;
+end
+
+function [propHs, ok] = accumulate_output(propHs, ast)
+    % Combine successive output assertions into ONE prop cell. The runner verifies a
+    % single-input property against prop{1}.Hg only (run_vnncomp_instance.m: the
+    % length(prop)==1 branches), so we must NEVER leave multiple cells -- a trailing
+    % conjunct after an (or ...) has to be AND-ed INTO every disjunct, not appended as
+    % a second cell that the runner would silently ignore (-150 false verdict). This
+    % mirrors the hardened 1.0 parser's distribution (load_vnnlib.m ~116-153).
+    ok = true;
+    if isempty(propHs), propHs = {ast}; return; end
+    last = propHs{end};
+    nL = numel(last.Hg); nA = numel(ast.Hg);
+    if nL == 1 && nA == 1
+        % both scalar conjuncts -> AND-merge rows into one polytope
+        last.Hg.G = [last.Hg.G; ast.Hg.G];
+        last.Hg.g = [last.Hg.g; ast.Hg.g];
+        propHs{end} = last;
+    elseif nL > 1 && nA == 1
+        % running region is an OR; new standalone conjunct ANDs into EVERY disjunct
+        for di = 1:nL
+            last.Hg(di).G = [last.Hg(di).G; ast.Hg.G];
+            last.Hg(di).g = [last.Hg(di).g; ast.Hg.g];
+        end
+        propHs{end} = last;
+    elseif nL == 1 && nA > 1
+        % running region is a scalar conjunct asserted BEFORE this OR; AND the
+        % conjunct's rows into each disjunct of the new OR and keep the OR
+        for di = 1:nA
+            ast.Hg(di).G = [ast.Hg(di).G; last.Hg.G];
+            ast.Hg(di).g = [ast.Hg(di).g; last.Hg.g];
+        end
+        propHs{end} = ast;
+    else
+        % OR conjoined with OR: a product-of-sums NNV's single-disjunctive-spec
+        % contract cannot represent (the 1.0 parser errors here) -> gate (sound).
+        ok = false;
+    end
+end
+
+% =========================================================================
+% Unsupported-property helpers
+% =========================================================================
+
+function property = unsupported_property(box, reason)
+    property = struct();
+    property.unsupported = true;
+    property.reason = reason;
+    property.prop = {};
+    if ~isempty(box) && isfield(box, 'lb')
+        property.lb = box.lb; property.ub = box.ub;
+    else
+        property.lb = []; property.ub = [];
+    end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -39,6 +39,24 @@ end
 
 % Load property to verify
 property = load_vnnlib(vnnlib);
+
+% VNN-LIB 2.0 gate: load_vnnlib2 (dispatched for 2.0 files) flags any construct NNV
+% cannot soundly verify -- multi-network (equal-to/isomorphic-to), nonlinear/arithmetic
+% output, multimodal (>1 input tensor), declare-hidden, mixed input/output disjunction.
+% Emit `unknown` (0 points) rather than parse it unsoundly and risk a -150 wrong
+% verdict. (1.0 properties never set this field, so this is a no-op for them.)
+if isfield(property, 'unsupported') && property.unsupported
+    if isfield(property, 'reason') && ~isempty(property.reason)
+        fprintf('vnnlib 2.0 unsupported -> unknown: %s\n', property.reason);
+    end
+    status = 2;
+    tTime = toc(t);
+    fid = fopen(outputfile, 'w');
+    fprintf(fid, 'unknown \n');
+    fclose(fid);
+    return;
+end
+
 lb = property.lb; % input lower bounds
 ub = property.ub; % input upper bounds
 prop = property.prop; % output spec to verify

--- a/code/nnv/tests/utils/test_load_vnnlib2.m
+++ b/code/nnv/tests/utils/test_load_vnnlib2.m
@@ -1,0 +1,253 @@
+function tests = test_load_vnnlib2
+%TEST_LOAD_VNNLIB2  Regression tests for the VNN-LIB 2.0 parser (load_vnnlib2.m)
+%   and the version-sniff dispatch added to load_vnnlib.m.
+%
+%   Pins BOTH the supported single-network forms (box input + linear/disjunctive
+%   output, multi-dim ROW-MAJOR index flattening, ==) AND the SOUND GATING of the
+%   constructs NNV cannot verify (multi-network, nonlinear, multimodal), which must
+%   return property.unsupported=true so the runner emits `unknown` -- never a -150
+%   wrong verdict.
+%
+%   Output-structure contract is identical to load_vnnlib (see test_load_vnnlib_forms):
+%     property.prop{n}.Hg = array of HalfSpace; G*y <= g is the UNSAFE region; an
+%     ARRAY (numel>1) is an OR; rows within one HalfSpace are an AND.
+%   Sign convention (must match process_constraint):
+%     (<= Y[a] c)    -> G(a+1)=+1,           g=c
+%     (>= Y[a] c)    -> G(a+1)=-1,           g=-c
+%     (<= Y[a] Y[b]) -> G(a+1)=+1,G(b+1)=-1, g=0
+%
+%   Self-contained: every spec is written to a temp file inline (no benchmark clone
+%   needed), so this runs in CI. load_vnnlib2 lives in engine/utils (always on the
+%   NNV path), so no setupOnce is required.
+%
+%   To run: results = runtests('test_load_vnnlib2')
+    tests = functiontests(localfunctions);
+end
+
+% ---------- supported single-network forms ----------
+
+function test_single_net_linear(tc)
+    % box input + (<= Y[0] 0) -> 1 disjunct, 1 row
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [2]) (declare-output Y float32 [3]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (<= X[1] 2.0))', '(assert (>= X[1] -2.0))', ...
+        '(assert (<= Y[0] 0.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyFalse(tc, is_unsupported(property), 'single-net linear should be supported');
+    verifyEqual(tc, double(property.lb(:)'), [-1 -2], 'AbsTol', 1e-6);
+    verifyEqual(tc, double(property.ub(:)'), [ 1  2], 'AbsTol', 1e-6);
+    verifyEqual(tc, numel(property.prop), 1);
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, numel(Hg), 1, 'one HalfSpace, no OR');
+    verifyEqual(tc, double(Hg(1).G), [1 0 0], 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(1).g), 0, 'AbsTol', 1e-6);
+end
+
+function test_multidim_rowmajor_flatten(tc)
+    % X[0,0,0,3] in shape [1,1,1,5] -> flat 3 (col 4); Y[0,2] in [1,5] -> flat 2 (col 3).
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1, 1, 1, 5]) (declare-output Y float32 [1, 5]))', ...
+        '(assert (<= X[0,0,0,0] 0.1))', '(assert (>= X[0,0,0,0] 0.0))', ...
+        '(assert (<= X[0,0,0,1] 0.2))', '(assert (>= X[0,0,0,1] 0.1))', ...
+        '(assert (<= X[0,0,0,2] 0.3))', '(assert (>= X[0,0,0,2] 0.2))', ...
+        '(assert (<= X[0,0,0,3] 0.5))', '(assert (>= X[0,0,0,3] 0.45))', ...
+        '(assert (<= X[0,0,0,4] 0.6))', '(assert (>= X[0,0,0,4] 0.5))', ...
+        '(assert (>= Y[0,2] 1.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyFalse(tc, is_unsupported(property));
+    verifyEqual(tc, numel(property.lb), 5, '5 input dims = prod(shape)');
+    verifyEqual(tc, double(property.lb(4)), 0.45, 'AbsTol', 1e-6);   % flat 3 -> idx 4
+    verifyEqual(tc, double(property.ub(4)), 0.50, 'AbsTol', 1e-6);
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, size(Hg(1).G, 2), 5, '5 output dims');
+    verifyEqual(tc, double(Hg(1).G(1,3)), -1, 'AbsTol', 1e-6);       % Y[0,2] -> col 3
+    verifyEqual(tc, double(Hg(1).g(1)), -1, 'AbsTol', 1e-6);
+    verifyEqual(tc, nnz(Hg(1).G(1,:)), 1, 'only Y[0,2] nonzero');
+end
+
+function test_output_or(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [2]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (or (and (>= Y[0] 1.0)) (and (>= Y[1] 2.0))))'});
+    property = load_vnnlib2(tf); delete(tf);
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, numel(Hg), 2, 'two OR disjuncts');
+    verifyEqual(tc, double(Hg(1).G), [-1 0], 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(1).g), -1, 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(2).G), [0 -1], 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(2).g), -2, 'AbsTol', 1e-6);
+end
+
+function test_input_equality_degenerate_box(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [2]) (declare-output Y float32 [1]))', ...
+        '(assert (== X[0] 0.5))', ...
+        '(assert (<= X[1] 1.0))', '(assert (>= X[1] -1.0))', ...
+        '(assert (<= Y[0] 0.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyEqual(tc, double(property.lb(1)), 0.5, 'AbsTol', 1e-6);
+    verifyEqual(tc, double(property.ub(1)), 0.5, 'AbsTol', 1e-6);
+end
+
+function test_output_equality_two_rows(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [1]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (== Y[0] 2.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, size(Hg(1).G, 1), 2, '== output -> 2 rows');
+    % the two rows must encode {Y<=2} (G=+1,g=2) AND {Y>=2} (G=-1,g=-2), in either
+    % order -> their unsafe region is exactly {Y=2}. Assert order-independently.
+    rows = sortrows([double(Hg(1).G) double(Hg(1).g)]);
+    verifyEqual(tc, rows, [-1 -2; 1 2], 'AbsTol', 1e-6, '== -> {Y<=2, Y>=2}');
+end
+
+function test_var_var_output(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [2]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (<= Y[0] Y[1]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, double(Hg(1).G(1,1)), 1, 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(1).G(1,2)), -1, 'AbsTol', 1e-6);
+    verifyEqual(tc, double(Hg(1).g(1)), 0, 'AbsTol', 1e-6);
+end
+
+% ---------- sound gating (the -150 guard) ----------
+
+function test_gate_multi_network(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [5]) (declare-output Y_f real [5]))', ...
+        '(declare-network g (equal-to f) (declare-input X_g real [5]) (declare-output Y_g real [5]))', ...
+        '(assert (>= X_f[0] X_g[0]))', '(assert (< Y_f[3] Y_g[3]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'multi-network must be gated');
+end
+
+function test_gate_nonlinear(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [2]) (declare-output Y float32 [1]))', ...
+        '(assert (>= (* X[0] X[0]) 1.0))', ...
+        '(assert (<= Y[0] 0.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'nonlinear (* X X) must be gated, never linearized');
+end
+
+function test_gate_multimodal(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X1 float32 [2]) (declare-input X2 float32 [2]) (declare-output Y float32 [1]))', ...
+        '(assert (<= X1[0] 1.0))', '(assert (>= X1[0] 0.0))', ...
+        '(assert (> Y[0] 0.5))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'multimodal (2 input tensors) must be gated');
+end
+
+% ---------- dispatch ----------
+
+function test_dispatch_from_load_vnnlib(tc)
+    % load_vnnlib() must sniff the 2.0 header and route to load_vnnlib2, producing
+    % an identical result to calling load_vnnlib2 directly.
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [2]) (declare-output Y float32 [3]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (<= X[1] 2.0))', '(assert (>= X[1] -2.0))', ...
+        '(assert (<= Y[0] 0.0))'});
+    viaDispatch = load_vnnlib(tf);
+    viaDirect   = load_vnnlib2(tf);
+    delete(tf);
+    verifyFalse(tc, is_unsupported(viaDispatch), 'dispatch parsed the 2.0 file');
+    verifyEqual(tc, double(viaDispatch.lb), double(viaDirect.lb), 'AbsTol', 1e-6);
+    verifyEqual(tc, double(viaDispatch.prop{1}.Hg(1).G), double(viaDirect.prop{1}.Hg(1).G), 'AbsTol', 1e-6);
+end
+
+% ---------- output OR/conjunct distribution (must stay a SINGLE prop cell) ----------
+
+function test_conjunct_then_or_single_cell(tc)
+    % A standalone conjunct asserted BEFORE an (or ...) must be AND-ed into EVERY
+    % disjunct, leaving ONE prop cell. (A second cell would be silently ignored by the
+    % runner's length(prop)==1 verify path -> -150.)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [2]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (>= Y[0] 0.0))', ...
+        '(assert (or (and (<= Y[0] 1.0)) (and (>= Y[1] 2.0))))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyFalse(tc, is_unsupported(property));
+    verifyEqual(tc, numel(property.prop), 1, 'must be ONE prop cell (conjunct distributed into OR)');
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, numel(Hg), 2, 'two OR disjuncts');
+    verifyTrue(tc, has_row(Hg(1), [-1 0], 0), 'disjunct1 carries the conjunct Y0>=0');
+    verifyTrue(tc, has_row(Hg(2), [-1 0], 0), 'disjunct2 carries the conjunct Y0>=0');
+    verifyTrue(tc, has_row(Hg(1), [1 0], 1),  'disjunct1 keeps Y0<=1');
+    verifyTrue(tc, has_row(Hg(2), [0 -1], -2),'disjunct2 keeps Y1>=2');
+end
+
+function test_or_then_conjunct_single_cell(tc)
+    % Mirror: standalone conjunct AFTER the (or ...) -> still one cell, in every disjunct.
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [2]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (or (and (<= Y[0] 1.0)) (and (>= Y[1] 2.0))))', ...
+        '(assert (>= Y[0] 0.0))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyEqual(tc, numel(property.prop), 1, 'must be ONE prop cell');
+    Hg = property.prop{1}.Hg;
+    verifyEqual(tc, numel(Hg), 2, 'two OR disjuncts');
+    verifyTrue(tc, has_row(Hg(1), [-1 0], 0), 'disjunct1 carries the trailing conjunct');
+    verifyTrue(tc, has_row(Hg(2), [-1 0], 0), 'disjunct2 carries the trailing conjunct');
+end
+
+function test_gate_product_of_sums(tc)
+    % Two separate (or ...) assertions = (OR) AND (OR) = product-of-sums, which the
+    % single-disjunctive-spec contract cannot represent -> must gate to unsupported.
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network N (declare-input X float32 [1]) (declare-output Y float32 [2]))', ...
+        '(assert (<= X[0] 1.0))', '(assert (>= X[0] -1.0))', ...
+        '(assert (or (and (<= Y[0] 1.0)) (and (>= Y[0] 2.0))))', ...
+        '(assert (or (and (<= Y[1] 1.0)) (and (>= Y[1] 2.0))))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'product-of-sums must be gated');
+end
+
+% ---------- helpers ----------
+
+function tf = write_vnnlib2(lines)
+    tf = [tempname '.vnnlib'];
+    fid = fopen(tf, 'w');
+    for k = 1:numel(lines)
+        fprintf(fid, '%s\n', lines{k});
+    end
+    fclose(fid);
+end
+
+function u = is_unsupported(p)
+    u = isfield(p, 'unsupported') && p.unsupported;
+end
+
+function tf = has_row(hs, grow, gval)
+    % true if HalfSpace hs has a row equal to grow with rhs gval (order-independent)
+    G = double(hs.G); g = double(hs.g);
+    tf = false;
+    for r = 1:size(G, 1)
+        if isequal(G(r, :), grow) && abs(g(r) - gval) < 1e-6
+            tf = true; return;
+        end
+    end
+end


### PR DESCRIPTION
## What

Adds **`load_vnnlib2.m`**, a parser for **VNN-LIB 2.0** specs, dispatched from `load_vnnlib.m` on the `(vnnlib-version <2.0>)` header. This unlocks the VNN-COMP 2026 *extended track*: the 28 genuine single-network 2.0 benchmarks (box input + linear/disjunctive output) plus correct routing of the 4 mislabeled-1.0 files. The 1.0 path is **byte-for-byte unchanged**.

Implements **Phase 0 + 1 + 3a** of [`VNNLIB2_SUPPORT_PLAN.md`](code/nnv/VNNLIB2_SUPPORT_PLAN.md) (the research/design doc, also in this PR).

## Sound-or-unknown (the −150 discipline)

Every 2.0 construct NNV cannot soundly map onto single-network linear reachability is **gated to `property.unsupported`**, which `run_vnncomp_instance.m` emits as `unknown` (0 points) rather than parse unsoundly and risk a −150 wrong verdict:
multi-network (`equal-to`/`isomorphic-to`), nonlinear/arithmetic, multimodal (>1 input tensor), `declare-hidden`, mixed input/output disjunction, product-of-sums.

## Design notes

- **Streaming** (one S-expression statement at a time): the 96 MB / 124 MB image benchmarks parse without materializing a whole-file token tree; multimodal/multi-network files gate from the header alone (`smart_turn` 124 MB gated in **4 ms**).
- **Multi-dim indices** flatten **row-major** (ONNX/VNN-LIB order) — the same flat order the 1.0 parser emits, so the runner's per-category `needReshape` handling is unchanged.
- **Strict `<`/`>`** are treated as `<=`/`>=`, matching the battle-tested 1.0 parser (sound for the UNSAT proof; the boundary SAT case is within VNN-COMP's 1e-4 constraint tolerance and guarded by the onnxruntime witness replay).

## Validation

- **Differential:** acasxu `prop_1` parsed via 2.0 == via 1.0 **exactly** (lb/ub/G/g diff 0).
- **Adversarial review** (19-agent workflow) found + fixed one real soundness bug: a standalone output conjunct adjacent to an `(or ...)` is now distributed into every disjunct (one `prop` cell), matching the hardened 1.0 path — otherwise the runner's `length(prop)==1` verify path would silently ignore it.
- **`test_load_vnnlib2.m`: 13 tests** — forms, multi-dim row-major flatten, `==`, var-var, OR/conjunct distribution + product-of-sums gate, header dispatch, and the four soundness gates. All pass locally.

## Deferred (post-deadline upside, per §5.2 of the plan)

Multi-network `equal-to`/`isomorphic-to` (Phase 2), `smart_turn` multimodal input set (Phase 3b), pointing the sweep driver at the `2.0/` `instances.csv`, and PGD-on-the-box for nonlinear-gated instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)