### PR TITLE
fix(vnnlib): input-box leak across disjuncts in combined input/output (or ...)

### DIFF
--- a/code/nnv/engine/utils/load_vnnlib.m
+++ b/code/nnv/engine/utils/load_vnnlib.m
@@ -418,7 +418,14 @@ function [lb_array, ub_array, prop_array] = process_combined_input_output(tline,
     lb_array = cell(n,1);
     ub_array = cell(n,1);
     prop_array = cell(n,1);
+    lb_global = lb_input;   % the globally-declared input box; each disjunct of the OR
+    ub_global = ub_input;   % starts fresh from it so an input bound set in one disjunct
+                            % cannot LEAK into the next (mirrors the process_multiple_inputs
+                            % fix). Without this reset, disjunct i accumulates every prior
+                            % disjunct's X bounds -> wrong (too-narrow) box -> -150 risk.
     for i = 1:length(all_cons)
+        lb_input = lb_global;
+        ub_input = ub_global;
         combo = all_cons{i};
         combo = combo + ")";
         single_cons = extractBetween(combo, "(", ")");

--- a/code/nnv/tests/utils/test_load_vnnlib_audit_fixes.m
+++ b/code/nnv/tests/utils/test_load_vnnlib_audit_fixes.m
@@ -85,3 +85,36 @@ function test_multiinput_no_bound_leak(testCase)
     verifyEqual(testCase, double(P.lb{2}(1)), 4.0, 'AbsTol', 1e-6, 'region 2 X_0 lb as specified');
     verifyEqual(testCase, double(P.ub{2}(1)), 5.0, 'AbsTol', 1e-6, 'region 2 X_0 ub as specified');
 end
+
+% ---------------------------------------------------------------------------
+% Finding 1b: the SAME no-leak rule for the COMBINED input/output (or ...) form
+% [load_vnnlib "option 3", process_combined_input_output]. Each disjunct pairs an
+% input region with an output halfspace; its input box must start from the GLOBAL
+% declared bounds, not inherit the previous disjunct's. Pre-fix:
+% process_combined_input_output never reset lb_input/ub_input between disjuncts, so
+% an X dimension constrained in disjunct 1 LEAKED into disjunct 2 -> wrong (too
+% narrow) box -> false sat/unsat (-150). Mirrors the process_multiple_inputs fix.
+% ---------------------------------------------------------------------------
+function test_combined_input_output_no_bound_leak(testCase)
+    tf = [tempname '.vnnlib']; c = onCleanup(@() delete(tf));
+    fid = fopen(tf, 'w');
+    fprintf(fid, '(declare-const X_0 Real)\n(declare-const X_1 Real)\n(declare-const Y_0 Real)\n');
+    fprintf(fid, '(assert (<= X_0 10.0))\n(assert (>= X_0 -10.0))\n');   % global box
+    fprintf(fid, '(assert (<= X_1 10.0))\n(assert (>= X_1 -10.0))\n');
+    % disjunct 1 constrains X_0 (+ a Y -> option 3); disjunct 2 constrains ONLY X_1.
+    fprintf(fid, ['(assert (or (and (>= X_0 1.0) (<= X_0 2.0) (>= Y_0 0.0)) ' ...
+                  '(and (>= X_1 3.0) (<= X_1 4.0) (>= Y_0 0.0))))\n']);
+    fclose(fid);
+    P = load_vnnlib(tf);
+    verifyTrue(testCase, iscell(P.lb) && numel(P.lb) == 2, 'two input regions (option 3)');
+    % disjunct 1: X_0 in [1,2] as specified
+    verifyEqual(testCase, double(P.lb{1}(1)), 1.0, 'AbsTol', 1e-6, 'disjunct1 X_0 lb');
+    verifyEqual(testCase, double(P.ub{1}(1)), 2.0, 'AbsTol', 1e-6, 'disjunct1 X_0 ub');
+    % disjunct 2: X_0 must NOT have leaked [1,2]; it stays at the GLOBAL [-10,10].
+    verifyEqual(testCase, double(P.lb{2}(1)), -10.0, 'AbsTol', 1e-6, ...
+        'disjunct2 X_0 must NOT inherit disjunct1''s lower bound (no leak)');
+    verifyEqual(testCase, double(P.ub{2}(1)), 10.0, 'AbsTol', 1e-6, ...
+        'disjunct2 X_0 must NOT inherit disjunct1''s upper bound (no leak)');
+    verifyEqual(testCase, double(P.lb{2}(2)), 3.0, 'AbsTol', 1e-6, 'disjunct2 X_1 lb as specified');
+    verifyEqual(testCase, double(P.ub{2}(2)), 4.0, 'AbsTol', 1e-6, 'disjunct2 X_1 ub as specified');
+end


### PR DESCRIPTION
## Bug

`process_combined_input_output` — the `load_vnnlib` **"option 3"** path, an `(assert (or (and <X+Y constraints>) (and <X+Y constraints>) ...))` whose disjuncts each pair an **input region** with an **output halfspace** — never reset `lb_input`/`ub_input` between disjuncts. So an `X` dimension constrained in disjunct 1 **leaked** into disjunct 2 when disjunct 2 omitted it, giving disjunct 2 a wrong (too-narrow) input box → **false sat/unsat (−150)**.

This is the *same* latent leak already fixed in `process_multiple_inputs` (the pure-input `(or ...)` path); this PR applies the identical fix to the combined input/output path: snapshot the global declared box, reset each disjunct from it.

## Validation

A 2-disjunct option-3 spec where disjunct 1 sets `X_0 ∈ [1,2]` and disjunct 2 sets only `X_1`:

| | pre-fix (leak) | post-fix |
|---|---|---|
| disjunct 2 `X_0` | `[1,2]` ❌ (leaked) | `[-10,10]` ✅ (global) |
| disjunct 2 `X_1` | `[3,4]` | `[3,4]` |

Regression test added as **Finding 1b** in `test_load_vnnlib_audit_fixes.m`, right next to the existing `process_multiple_inputs` no-leak test. All 4 audit-fix tests pass.

## Scope

Behavior is **unchanged for single-disjunct** properties (the snapshot equals the entry box, so the reset is a no-op) and for all non-option-3 forms. Latent on the 2025 set; would flip verdicts on any 2026 benchmark using the combined input/output disjunction form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)