### PR TITLE
feat(vnncomp): cctsdb_yolo complete-enumeration verifier (sound + complete)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/cctsdb_enumerate.py
+++ b/code/nnv/examples/Submission/VNN_COMP2025/cctsdb_enumerate.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Complete-enumeration verifier for the VNN-COMP cctsdb_yolo_2023 benchmark.
+
+Usage:
+    python cctsdb_enumerate.py <model.onnx[.gz]> <spec.vnnlib[.gz]> <out_witness.csv>
+                               [--timeout S] [--margin M]
+
+Why enumeration is SOUND AND COMPLETE for this benchmark (and ONLY under the
+structural guards below, all re-verified per instance):
+
+  * Every cctsdb_yolo_2023 spec fixes ALL inputs (lb == ub) except the two patch
+    position coordinates X_12288 and X_12289, each ranging over [0, 62].
+  * In the ONNX graph the ONLY consumers of those two inputs are Gather(idx 12288)
+    and Gather(idx 12289), each feeding directly into Cast(to=int64) -- i.e. the
+    network sees only trunc(x). The output is therefore PIECEWISE CONSTANT on the
+    unit cells [p, p+1) x [q, q+1), and evaluating one representative point per
+    cell (the integer points trunc(lb)..trunc(ub) per axis, clamped into the box)
+    covers the ENTIRE input set exactly. 63 x 63 = 3969 onnxruntime evaluations.
+  * The output spec is a single half-space on Y_0 (e.g. "(assert (<= Y_0 0.5))",
+    the UNSAFE region). Any cell with Y_0 in the unsafe region => SAT with that
+    cell's representative point as witness; every cell outside it => UNSAT, a
+    complete proof.
+
+Any deviation from this structure (different free variables, non-Cast consumers,
+complex asserts, subgraphs, borderline margins, timeout, any error at all) prints
+UNKNOWN and exits 2 -- never a guessed verdict. VNN-COMP scores a wrong verdict
+at -150; this script is sound-or-unknown by construction.
+
+Output protocol (stdout last line / exit code):
+    SAT p q y       exit 10   witness CSV written: the FULL input vector, one
+                              value per line, in FLAT vnnlib order X_0..X_{N-1},
+                              with (X_12288, X_12289) = the violating cell point;
+                              y is the onnxruntime output Y_0 at that point.
+    UNSAT ymin ymax exit 11   complete proof; ymin/ymax = grid output range.
+    UNKNOWN <why>   exit 2    guard violation / borderline / timeout / error.
+
+Margin: verdicts within --margin (default 1e-4) of the threshold are reported
+UNKNOWN. onnxruntime results can differ across versions/CPUs in the last ulps;
+the margin keeps a borderline instance from flipping verdict on another machine.
+"""
+
+import argparse
+import gzip
+import math
+import re
+import sys
+import time
+
+import numpy as np
+
+EXIT_SAT = 10
+EXIT_UNSAT = 11
+EXIT_UNKNOWN = 2
+
+# The only free-input structure this verifier understands (guard (a)).
+EXPECTED_FREE = frozenset({12288, 12289})
+MAX_GRID = 100_000  # refuse absurd enumeration sizes (future-proofing guard)
+
+
+def unknown(why):
+    print(f"UNKNOWN {why}")
+    sys.exit(EXIT_UNKNOWN)
+
+
+def read_maybe_gz(path):
+    """Return file bytes, transparently gunzipping *.gz."""
+    if str(path).endswith(".gz"):
+        with gzip.open(path, "rb") as f:
+            return f.read()
+    with open(path, "rb") as f:
+        return f.read()
+
+
+# ---------------------------------------------------------------------------
+# vnnlib parsing (simple regex parse; ANY unrecognized assert => UNKNOWN)
+# ---------------------------------------------------------------------------
+
+_NUM = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+_ASSERT_RE = re.compile(
+    r"\(\s*assert\s+\(\s*(<=|>=)\s+([XY])_(\d+)\s+(" + _NUM + r")\s*\)\s*\)"
+)
+
+
+def parse_vnnlib(text):
+    """Parse the simple cctsdb vnnlib form.
+
+    Returns (lb, ub, out_op, out_thr) where lb/ub are dicts {index: float} and
+    the single output constraint is "out_op" in {'<=', '>='} applied to Y_0
+    (the asserted = UNSAFE region). UNKNOWN on any non-simple construct.
+    """
+    text = re.sub(r";[^\n]*", "", text)  # strip comments
+    n_asserts = text.count("(assert")
+    matches = list(_ASSERT_RE.finditer(text))
+    if len(matches) != n_asserts:
+        unknown(
+            f"vnnlib has {n_asserts} asserts but only {len(matches)} match the "
+            "simple (assert (<=|>= V_i const)) form"
+        )
+    lb, ub, ycons = {}, {}, []
+    for m in matches:
+        op, var, idx, val = m.group(1), m.group(2), int(m.group(3)), float(m.group(4))
+        if var == "X":
+            if op == ">=":  # X_i >= v  -> lower bound
+                lb[idx] = max(lb.get(idx, -math.inf), val)
+            else:           # X_i <= v  -> upper bound
+                ub[idx] = min(ub.get(idx, math.inf), val)
+        else:
+            ycons.append((op, idx, val))
+
+    # guard (c): EXACTLY one output constraint, on Y_0, <= or >= a constant
+    if len(ycons) != 1 or ycons[0][1] != 0:
+        unknown(f"output spec is not exactly one <=/>= threshold on Y_0: {ycons}")
+    out_op, _, out_thr = ycons[0]
+
+    if not lb:
+        unknown("no input bounds parsed")
+    n = max(max(lb), max(ub)) + 1
+    if set(lb) != set(range(n)) or set(ub) != set(range(n)):
+        unknown("input box is not a complete X_0..X_{N-1} bound set")
+    for i in range(n):
+        if not (math.isfinite(lb[i]) and math.isfinite(ub[i]) and lb[i] <= ub[i]):
+            unknown(f"invalid bounds on X_{i}: [{lb[i]}, {ub[i]}]")
+    return lb, ub, out_op, out_thr
+
+
+# ---------------------------------------------------------------------------
+# ONNX structural guard (guard (b)): the free inputs may ONLY flow through
+# Gather -> Cast(int64) (at most one intermediate Gather, i.e. 2 hops).
+# ---------------------------------------------------------------------------
+
+def _attr_i(node, name, default=None):
+    for a in node.attribute:
+        if a.name == name:
+            return a.i
+    return default
+
+
+def _build_const_map(graph):
+    from onnx import numpy_helper
+
+    cmap = {t.name: numpy_helper.to_array(t) for t in graph.initializer}
+    for nd in graph.node:
+        if nd.op_type == "Constant":
+            for a in nd.attribute:
+                if a.name == "value":
+                    cmap[nd.output[0]] = numpy_helper.to_array(a.t)
+    return cmap
+
+
+def _slice_read_set(node, cmap, dim):
+    """Indices (axis-0) a 1-D Slice reads, or None if not statically resolvable.
+
+    ONNX Slice clamping/negative-index semantics match Python slicing, so we
+    evaluate via range(dim)[start:end:step]. Handles both the input form
+    (opset >= 10) and the attribute form (opset < 10).
+    """
+    if len(node.input) >= 3:  # input form: data, starts, ends[, axes[, steps]]
+        vals = []
+        for k in range(1, len(node.input)):
+            name = node.input[k]
+            if name == "":
+                vals.append(None)
+                continue
+            if name not in cmap:
+                return None
+            vals.append(cmap[name].flatten().astype(np.int64))
+        while len(vals) < 4:
+            vals.append(None)
+        starts, ends, axes, steps = vals[0], vals[1], vals[2], vals[3]
+    else:  # attribute form
+        starts = ends = axes = steps = None
+        for a in node.attribute:
+            arr = np.array(a.ints, dtype=np.int64)
+            if a.name == "starts":
+                starts = arr
+            elif a.name == "ends":
+                ends = arr
+            elif a.name == "axes":
+                axes = arr
+    if starts is None or ends is None or starts.size != 1 or ends.size != 1:
+        return None
+    if axes is not None and (axes.size != 1 or int(axes[0]) not in (0, -1)):
+        return None  # data is 1-D; only axis 0 is meaningful
+    step = 1
+    if steps is not None:
+        if steps.size != 1 or int(steps[0]) == 0:
+            return None
+        step = int(steps[0])
+    return set(range(dim)[int(starts[0]):int(ends[0]):step])
+
+
+def _paths_hit_int_cast(tname, consumers, out_names, hops):
+    """True iff EVERY consumer path of tensor `tname` reaches Cast(to=int64)
+    within `hops` hops, with only Gather permitted as an intermediate node."""
+    from onnx import TensorProto
+
+    if tname in out_names:
+        return False  # free value would flow to a graph output un-truncated
+    for c in consumers.get(tname, []):
+        if c.op_type == "Cast" and _attr_i(c, "to") == TensorProto.INT64:
+            continue  # this path is truncated: OK
+        if (
+            c.op_type == "Gather"
+            and hops > 1
+            and c.input[0] == tname
+            and tname not in list(c.input)[1:]
+        ):
+            if all(
+                _paths_hit_int_cast(o, consumers, out_names, hops - 1)
+                for o in c.output
+            ):
+                continue
+        return False
+    return True  # all paths truncated (no consumers = dead value: also safe)
+
+
+def check_onnx_structure(model, n_inputs, free_set):
+    """UNKNOWN unless the graph provably consumes the free inputs only through
+    Cast(int64) truncation. Returns (input_name, input_shape)."""
+    import onnx
+    from onnx import TensorProto
+
+    g = model.graph
+
+    # no control-flow subgraphs: outer-scope capture could smuggle the input past
+    # this walk, so refuse them outright
+    for nd in g.node:
+        for a in nd.attribute:
+            if a.type in (onnx.AttributeProto.GRAPH, onnx.AttributeProto.GRAPHS):
+                unknown(f"graph contains a subgraph node ({nd.op_type})")
+
+    init_names = {t.name for t in g.initializer}
+    real_inputs = [i for i in g.input if i.name not in init_names]
+    if len(real_inputs) != 1:
+        unknown(f"expected exactly 1 graph input, found {len(real_inputs)}")
+    inp = real_inputs[0]
+    if inp.type.tensor_type.elem_type != TensorProto.FLOAT:
+        unknown(f"input is not float32 (elem_type={inp.type.tensor_type.elem_type})")
+    dims = [d.dim_value for d in inp.type.tensor_type.shape.dim]
+    if any(d <= 0 for d in dims) or int(np.prod(dims)) != n_inputs:
+        unknown(f"input shape {dims} does not match the {n_inputs} vnnlib inputs")
+
+    cmap = _build_const_map(g)
+    consumers = {}
+    for nd in g.node:
+        for i in nd.input:
+            consumers.setdefault(i, []).append(nd)
+    out_names = {o.name for o in g.output}
+
+    for nd in g.node:
+        if inp.name not in nd.input:
+            continue
+        if (
+            nd.op_type == "Gather"
+            and nd.input[0] == inp.name
+            and inp.name not in list(nd.input)[1:]
+        ):
+            if _attr_i(nd, "axis", 0) != 0:
+                unknown(f"Gather {nd.name} on input has axis != 0")
+            idx = cmap.get(nd.input[1])
+            if idx is None:
+                unknown(f"Gather {nd.name} on input has non-constant indices")
+            idxs = {int(v) + (n_inputs if int(v) < 0 else 0) for v in idx.flatten()}
+            if idxs & free_set:
+                # 2 hops: Gather -> Cast(int64), or Gather -> Gather -> Cast(int64)
+                if not _paths_hit_int_cast(nd.output[0], consumers, out_names, 2):
+                    unknown(
+                        f"free input flows through Gather {nd.name} without "
+                        "hitting Cast(int64) within 2 hops"
+                    )
+        elif (
+            nd.op_type == "Slice"
+            and nd.input[0] == inp.name
+            and inp.name not in list(nd.input)[1:]
+        ):
+            read = _slice_read_set(nd, cmap, n_inputs)
+            if read is None:
+                unknown(f"Slice {nd.name} on input is not statically resolvable")
+            if read & free_set:
+                unknown(f"Slice {nd.name} reads the free inputs {sorted(read & free_set)}")
+        else:
+            unknown(f"unexpected consumer of the input tensor: {nd.op_type} {nd.name}")
+
+    return inp.name, dims
+
+
+# ---------------------------------------------------------------------------
+# enumeration
+# ---------------------------------------------------------------------------
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("onnx_path")
+    ap.add_argument("vnnlib_path")
+    ap.add_argument("out_witness_csv")
+    ap.add_argument("--timeout", type=float, default=300.0,
+                    help="wall-clock budget in seconds (default 300)")
+    ap.add_argument("--margin", type=float, default=1e-4,
+                    help="threshold margin below which the verdict is UNKNOWN")
+    args = ap.parse_args()
+    t0 = time.monotonic()
+    deadline = t0 + args.timeout
+
+    import onnx
+    import onnxruntime as ort
+
+    # ---- parse spec --------------------------------------------------------
+    try:
+        spec_text = read_maybe_gz(args.vnnlib_path).decode("utf-8", errors="replace")
+    except OSError as e:
+        unknown(f"cannot read vnnlib: {e}")
+    lb, ub, out_op, out_thr = parse_vnnlib(spec_text)
+    n = len(lb)
+
+    # guard (a): the free variables are EXACTLY {X_12288, X_12289}
+    free = {i for i in range(n) if ub[i] > lb[i]}
+    if free != set(EXPECTED_FREE):
+        unknown(f"free variables {sorted(free)[:10]}... != {sorted(EXPECTED_FREE)}")
+    i0, i1 = sorted(free)
+    # the unit-cell argument below uses trunc-toward-zero == floor, which needs
+    # the free range to be nonnegative
+    if lb[i0] < 0 or lb[i1] < 0:
+        unknown("free-input lower bound is negative; truncation cells differ")
+
+    # ---- guard (b): structural check on the graph --------------------------
+    try:
+        model_bytes = read_maybe_gz(args.onnx_path)
+    except OSError as e:
+        unknown(f"cannot read onnx: {e}")
+    model = onnx.load_model_from_string(model_bytes)
+    in_name, in_shape = check_onnx_structure(model, n, free)
+
+    # ---- enumerate the integer grid (one cell representative each) ---------
+    p_lo, p_hi = int(math.trunc(lb[i0])), int(math.trunc(ub[i0]))
+    q_lo, q_hi = int(math.trunc(lb[i1])), int(math.trunc(ub[i1]))
+    n_evals = (p_hi - p_lo + 1) * (q_hi - q_lo + 1)
+    if n_evals > MAX_GRID:
+        unknown(f"grid of {n_evals} cells exceeds the {MAX_GRID} safety cap")
+    print(f"enumerating {n_evals} cells: X_{i0} in [{p_lo},{p_hi}], "
+          f"X_{i1} in [{q_lo},{q_hi}]", file=sys.stderr)
+
+    so = ort.SessionOptions()
+    so.log_severity_level = 3
+    sess = ort.InferenceSession(model_bytes, sess_options=so,
+                                providers=["CPUExecutionProvider"])
+
+    base = np.array([lb[i] for i in range(n)], dtype=np.float64)
+
+    def eval_point(session, xp, xq):
+        x = base.copy()
+        x[i0], x[i1] = xp, xq
+        out = session.run(None, {in_name: x.astype(np.float32).reshape(in_shape)})[0]
+        arr = np.asarray(out).flatten()
+        if arr.size < 1:
+            unknown("model produced an empty output")
+        y = float(arr[0])  # Y_0 = first element in flat order
+        if not math.isfinite(y):
+            unknown(f"non-finite output {y} at ({xp},{xq})")
+        return y
+
+    ymin = math.inf
+    ymax = -math.inf
+    argmin = argmax = None  # (p, q, xp, xq)
+    for p in range(p_lo, p_hi + 1):
+        # cell [p, p+1) representative INSIDE the box: max(lb, p); for p > trunc(lb)
+        # this is p itself, and for p == trunc(lb) it is lb (which truncates to p)
+        xp = max(lb[i0], float(p))
+        for q in range(q_lo, q_hi + 1):
+            if time.monotonic() > deadline:
+                unknown(f"timeout after {time.monotonic() - t0:.1f}s "
+                        f"({(p - p_lo) * (q_hi - q_lo + 1) + (q - q_lo)}/{n_evals} cells)")
+            xq = max(lb[i1], float(q))
+            y = eval_point(sess, xp, xq)
+            if y < ymin:
+                ymin, argmin = y, (p, q, xp, xq)
+            if y > ymax:
+                ymax, argmax = y, (p, q, xp, xq)
+
+    print(f"grid done in {time.monotonic() - t0:.2f}s: "
+          f"Y_0 in [{ymin:.17g}, {ymax:.17g}], unsafe region Y_0 {out_op} {out_thr:g}",
+          file=sys.stderr)
+
+    # ---- verdict (asserted region = UNSAFE; entering it = SAT) -------------
+    m = args.margin
+    if out_op == "<=":
+        viol = argmin
+        clearly_sat = ymin <= out_thr - m
+        clearly_unsat = ymin > out_thr + m
+    else:  # '>='
+        viol = argmax
+        clearly_sat = ymax >= out_thr + m
+        clearly_unsat = ymax < out_thr - m
+
+    if clearly_sat:
+        p, q, xp, xq = viol
+        # double-check the single witness point through a FRESH session
+        sess2 = ort.InferenceSession(model_bytes, sess_options=so,
+                                     providers=["CPUExecutionProvider"])
+        y2 = eval_point(sess2, xp, xq)
+        recheck = (y2 <= out_thr - m) if out_op == "<=" else (y2 >= out_thr + m)
+        if not recheck:
+            unknown(f"witness re-evaluation disagreed (y={y2:.17g} at ({p},{q}))")
+        x = base.copy()
+        x[i0], x[i1] = xp, xq
+        with open(args.out_witness_csv, "w") as f:
+            for v in x:
+                f.write(f"{v:.17g}\n")
+        print(f"SAT {p} {q} {y2:.17g}")
+        sys.exit(EXIT_SAT)
+    elif clearly_unsat:
+        print(f"UNSAT {ymin:.17g} {ymax:.17g}")
+        sys.exit(EXIT_UNSAT)
+    else:
+        unknown(f"verdict within margin {m:g} of threshold {out_thr:g} "
+                f"(Y_0 range [{ymin:.17g}, {ymax:.17g}])")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except SystemExit:
+        raise
+    except BaseException as e:  # any unexpected failure must stay sound
+        unknown(f"{type(e).__name__}: {e}")

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -7,7 +7,38 @@ status = 2; % unknown (to start with)
 
 % disp("We are running...")
 
-
+%% 0) cctsdb_yolo: complete-enumeration path (bypasses net import + reach)
+%
+% Every cctsdb_yolo_2023 spec fixes ALL inputs (lb == ub) except the two patch
+% position coordinates X_12288/X_12289 in [0,62], and the ONNX graph consumes
+% those two ONLY through Cast(int64) truncation (Gather(12288/12289) -> Cast),
+% so the network output is PIECEWISE CONSTANT on unit cells and enumerating the
+% <= 3969 integer points is SOUND AND COMPLETE. cctsdb_enumerate.py re-verifies
+% all of that structurally per instance (any deviation -> unknown), runs the
+% enumeration through onnxruntime, and returns SAT-with-witness / UNSAT /
+% UNKNOWN. MATLAB's importNetworkFromONNX cannot handle this model (the old
+% stub errored "Working on supporting this one"), so this branch must route
+% AROUND load_vnncomp_network / falsify / reach entirely and write the result
+% file in the same format as section 4 below.
+if contains(category, "cctsdb_yolo")
+    [status, counterEx] = verify_cctsdb_enumeration(onnx, vnnlib);
+    tTime = toc(t);
+    disp("Verification result: " + string(status));
+    disp("Total Time: " + string(tTime));
+    fid = fopen(outputfile, 'w');
+    if status == 0
+        fprintf(fid, 'sat \n');
+        fclose(fid);
+        write_counterexample(outputfile, counterEx);
+    elseif status == 1
+        fprintf(fid, 'unsat \n');
+        fclose(fid);
+    else
+        fprintf(fid, 'unknown \n');
+        fclose(fid);
+    end
+    return;
+end
 
 %% 1) Load components
 
@@ -470,12 +501,11 @@ function ok = is_nnvnet_valid(nnvnet)
 end
 
 function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,falsifyOpts] = load_vnncomp_network(category, onnx, vnnlib)
-% load participating vnncomp 2025 benchmark NNs 
+% load participating vnncomp 2025 benchmark NNs
 % Not yet supported:
-% - cctsdb (some errrors when forward propagating)
-% - lsnc_relu
-% - traffic_signs_recognition (last year all instances were sat, maybe we are not wrong?)
 % - collins aerospace (unsure of what is wrong, but we get invalid SAT instances)
+% Handled OUTSIDE this dispatcher:
+% - cctsdb_yolo (complete-enumeration path at the top of run_vnncomp_instance)
 
 
     needReshape = 0; % default is to use MATLAB reshape, otherwise use the python reshape
@@ -511,17 +541,12 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         
 
     elseif contains(category, "cctsdb_yolo")
-        % net = importNetworkFromONNX(onnx);
-        % nnvnet = "";
-        % inputSize = [12296, 1];
-        % inputFormat = "UU";
-        % X = dlarray(rand(12296, 1), inputFormat);
-        % net = initialize(net, X);
-        % reachOptions = struct;
-        % reachOptions.reachMethod = 'cp-star';
-        % reachOptions.inputFormat = inputFormat;
-        % reachOptionsList{1} = reachOptions;
-        error("Working on supporting this one");
+        % Handled by the complete-enumeration path at the TOP of
+        % run_vnncomp_instance (verify_cctsdb_enumeration -> cctsdb_enumerate.py);
+        % control never reaches this dispatcher for cctsdb_yolo. Fail loud if it
+        % somehow does: MATLAB's importer mis-handles this model (Cast/Gather
+        % truncation on a flat 12296 input).
+        error("cctsdb_yolo is handled by the enumeration path in run_vnncomp_instance; load_vnncomp_network should not be reached for it");
 
     elseif contains(category, "cersyve")
         net = importNetworkFromONNX(onnx, "InputDataFormats", "BC");
@@ -1125,6 +1150,76 @@ function write_counterexample(outputfile, counterEx)
     % close and save file
     fclose(fid);
 
+end
+
+% cctsdb_yolo complete-enumeration verifier: shell out to cctsdb_enumerate.py
+% (same folder as this runner). The script is sound-or-unknown by construction:
+% it structurally re-verifies, per instance, that (a) the only free inputs are
+% X_12288/X_12289, (b) the ONNX consumes them only through Cast(int64)
+% truncation (=> output piecewise-constant on unit cells), (c) the output spec
+% is a single half-space on Y_0 -- and enumerates all <= 3969 cells through
+% onnxruntime. Exit protocol: 10 = SAT (witness CSV written + "SAT p q y" on
+% stdout), 11 = UNSAT, anything else = unknown. ANY parse/replay irregularity
+% on the MATLAB side also degrades to unknown -- never an unsound verdict.
+function [status, counterEx] = verify_cctsdb_enumeration(onnx, vnnlib)
+    status = 2; counterEx = nan;
+    here = fileparts(mfilename('fullpath'));
+    script = fullfile(here, 'cctsdb_enumerate.py');
+    if ~isfile(script)
+        fprintf('cctsdb_enumerate.py not found next to the runner -> unknown\n');
+        return;
+    end
+    witness_csv = [tempname '.csv'];
+    cleanup = onCleanup(@() delete_if_exists(witness_csv)); %#ok<NASGU>
+    py = python_exe();
+    % The script self-limits via --timeout: 300 s leaves margin inside the 350 s
+    % per-instance benchmark budget (the enumeration itself measures 2-25 s).
+    cmd = sprintf('%s "%s" "%s" "%s" "%s" --timeout 300', ...
+        py, script, char(onnx), char(vnnlib), witness_csv);
+    [st, out] = system(cmd);
+    disp(strtrim(out));
+    if st == 10                  % SAT with witness
+        % stdout carries "SAT p q y"; the CSV carries the FULL input vector in
+        % FLAT vnnlib order X_0..X_{N-1} (one value per line).
+        tok = regexp(out, '\<SAT\s+(-?\d+)\s+(-?\d+)\s+([-+0-9.eE]+)', 'tokens', 'once');
+        try
+            x = readmatrix(witness_csv);
+        catch
+            x = [];
+        end
+        if isempty(tok) || isempty(x) || ~all(isfinite(x(:)))
+            fprintf('malformed SAT report from cctsdb_enumerate.py -> unknown\n');
+            return;
+        end
+        y = str2double(tok{3});
+        if ~isfinite(y)
+            fprintf('non-finite witness output from cctsdb_enumerate.py -> unknown\n');
+            return;
+        end
+        % {flat input; output} -- the exact cell write_counterexample expects
+        % (same shape falsify_single produces).
+        counterEx = {reshape(x, [], 1); y};
+        status = 0;
+    elseif st == 11              % UNSAT: complete enumeration, all cells safe
+        status = 1;
+    end                          % anything else: guard violation/timeout -> unknown
+end
+
+function delete_if_exists(f)
+    if exist(f, 'file'), delete(f); end
+end
+
+% Resolve the Python interpreter the SAME way validate_witness_onnx does:
+% prefer MATLAB's configured pyenv executable, else fall back to PATH 'python'.
+function py = python_exe()
+    py = 'python';
+    try
+        pe = pyenv;
+        if ~isempty(pe.Executable) && isfile(pe.Executable)
+            py = ['"' char(pe.Executable) '"'];
+        end
+    catch
+    end
 end
 
 % Load an NNV net from the Python-importer manifest written alongside the ONNX

--- a/code/nnv/tests/vnncomp25/test_cctsdb_enumerate.m
+++ b/code/nnv/tests/vnncomp25/test_cctsdb_enumerate.m
@@ -137,6 +137,10 @@ function [onnx, vnnlib] = locate_instance(tc, model, spec)
         root = fullfile(here, '..', '..', '..', '..', '..', ...
             'vnncomp2026_benchmarks', 'benchmarks');
     end
+    % accept the env var pointing at either the repo root or its benchmarks/ dir
+    if ~isfolder(fullfile(root, 'cctsdb_yolo_2023')) && isfolder(fullfile(root, 'benchmarks', 'cctsdb_yolo_2023'))
+        root = fullfile(root, 'benchmarks');
+    end
     bench = fullfile(root, 'cctsdb_yolo_2023', '1.0');
     onnx = fullfile(bench, 'onnx', [model '.onnx.gz']);
     vnnlib = fullfile(bench, 'vnnlib', [spec '.vnnlib.gz']);

--- a/code/nnv/tests/vnncomp25/test_cctsdb_enumerate.m
+++ b/code/nnv/tests/vnncomp25/test_cctsdb_enumerate.m
@@ -1,0 +1,162 @@
+function tests = test_cctsdb_enumerate
+%TEST_CCTSDB_ENUMERATE  Tests for the cctsdb_yolo complete-enumeration verifier.
+%   cctsdb_enumerate.py exploits the cctsdb_yolo_2023 structure (only
+%   X_12288/X_12289 free in [0,62]; the ONNX consumes them ONLY through
+%   Cast(int64) truncation, so the output is piecewise-constant on unit cells)
+%   to decide instances by enumerating the <= 3969 integer points through
+%   onnxruntime: SOUND AND COMPLETE for this benchmark, UNKNOWN on any
+%   structural deviation. Exit protocol: 10 = SAT (+witness CSV), 11 = UNSAT,
+%   2 = UNKNOWN.
+%
+%   Three groups of tests:
+%     * the python script exists next to the runner (always runs);
+%     * known-instance replays (run only if python+onnxruntime are importable
+%       AND the local vnncomp2026_benchmarks clone exists): patch-1 idx_00559
+%       -> UNSAT (min Y_0 ~ 0.8128), patch-3 idx_00055 -> SAT at (0,23);
+%     * the run_vnncomp_instance dispatcher no longer rejects cctsdb_yolo with
+%       the old stub error "Working on supporting this one".
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(tc)
+    % The runner + script live in examples/Submission/VNN_COMP2025. The matrix CI
+    % splits tests into shards and nothing guarantees that dir is on the path, so
+    % add it here to be self-sufficient.
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+    tc.TestData.subdir = sub;
+    tc.TestData.addedPath = '';
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub);
+        tc.TestData.addedPath = sub;
+    end
+end
+
+function teardownOnce(tc)
+    if isfield(tc.TestData, 'addedPath') && ~isempty(tc.TestData.addedPath)
+        rmpath(tc.TestData.addedPath);
+    end
+end
+
+% ---------- (a) script presence (environment-independent) ----------
+
+function test_script_exists(tc)
+    verifyTrue(tc, isfile(fullfile(tc.TestData.subdir, 'cctsdb_enumerate.py')), ...
+        'cctsdb_enumerate.py must live next to run_vnncomp_instance.m');
+end
+
+% ---------- (b) known-instance replays (needs python+onnxruntime+benchmarks) ----------
+
+function test_known_unsat_instance(tc)
+    % patch-1 idx_00559: the full 63x63 grid stays strictly ABOVE the unsafe
+    % region Y_0 <= 0.5 (min Y_0 ~ 0.8128) -> a COMPLETE unsat proof, exit 11.
+    [onnx, vnnlib] = locate_instance(tc, 'patch-1', 'spec_onnx_patch-1_idx_00559_0');
+    witness = [tempname '.csv'];
+    c = onCleanup(@() cleanup_file(witness));
+    [st, out] = run_enumerate(tc, onnx, vnnlib, witness);
+    verifyEqual(tc, st, 11, sprintf('expected UNSAT exit 11, got %d: %s', st, out));
+    tok = regexp(out, 'UNSAT\s+([-+0-9.eE]+)\s+([-+0-9.eE]+)', 'tokens', 'once');
+    verifyNotEmpty(tc, tok, 'stdout must carry "UNSAT ymin ymax"');
+    ymin = str2double(tok{1});
+    verifyEqual(tc, ymin, 0.8128, 'AbsTol', 1e-3, ...
+        'min Y_0 over the grid must reproduce the known 0.8128');
+    verifyFalse(tc, isfile(witness), 'no witness CSV may be written for UNSAT');
+end
+
+function test_known_sat_instance(tc)
+    % patch-3 idx_00055: cell (0,23) lands in the unsafe region (Y_0 = 0) ->
+    % SAT with that point as witness, exit 10, full input vector CSV written.
+    [onnx, vnnlib] = locate_instance(tc, 'patch-3', 'spec_onnx_patch-3_idx_00055_0');
+    witness = [tempname '.csv'];
+    c = onCleanup(@() cleanup_file(witness));
+    [st, out] = run_enumerate(tc, onnx, vnnlib, witness);
+    verifyEqual(tc, st, 10, sprintf('expected SAT exit 10, got %d: %s', st, out));
+    tok = regexp(out, '\<SAT\s+(-?\d+)\s+(-?\d+)\s+([-+0-9.eE]+)', 'tokens', 'once');
+    verifyNotEmpty(tc, tok, 'stdout must carry "SAT p q y"');
+    p = str2double(tok{1}); q = str2double(tok{2}); y = str2double(tok{3});
+    verifyEqual(tc, [p q], [0 23], 'witness cell must reproduce the known (0,23)');
+    verifyLessThanOrEqual(tc, y, 0.5, 'witness output must be in the unsafe region');
+    % witness CSV: FULL input vector, flat vnnlib order, free coords = (p,q)
+    verifyTrue(tc, isfile(witness), 'SAT must write the witness CSV');
+    x = readmatrix(witness);
+    verifyEqual(tc, numel(x), 12296, 'witness must be the full 12296 input vector');
+    verifyTrue(tc, all(isfinite(x)), 'witness values must all be finite');
+    verifyEqual(tc, x(12288 + 1), p, 'X_12288 must equal the reported p'); % 1-based
+    verifyEqual(tc, x(12289 + 1), q, 'X_12289 must equal the reported q');
+end
+
+% ---------- (c) dispatcher routing (mirrors classify_dispatch in the smoke test) ----------
+
+function test_dispatcher_no_longer_stub_errors(tc)
+    % run_vnncomp_instance must neither raise the old cctsdb stub error
+    % ("Working on supporting this one") nor reject the category as
+    % unsupported: it routes to the enumeration path, which degrades bogus
+    % inputs to a sound 'unknown' WITHOUT raising.
+    tc.assumeTrue(exist('run_vnncomp_instance', 'file') == 2, ...
+        'run_vnncomp_instance not on path; add examples/Submission/VNN_COMP2025');
+    onnx = [tempname '.onnx'];          % does not exist
+    vnnlib = [tempname '.vnnlib'];      % does not exist
+    outf = [tempname '.txt'];
+    c = onCleanup(@() cleanup_file(outf));
+    msg = '';
+    try
+        run_vnncomp_instance('cctsdb_yolo', onnx, vnnlib, outf);
+    catch ME
+        msg = ME.message;
+    end
+    verifyFalse(tc, contains(msg, 'Working on supporting this one'), ...
+        'the cctsdb_yolo stub error must be gone');
+    verifyFalse(tc, contains(msg, 'ONNX model not supported'), ...
+        'cctsdb_yolo must not be rejected as an unsupported category');
+    verifyEmpty(tc, msg, sprintf('dispatch must not raise at all; got: %s', msg));
+    verifyTrue(tc, isfile(outf), 'runner must write the output file');
+    verifyEqual(tc, strtrim(fileread(outf)), 'unknown', ...
+        'bogus inputs must degrade to a sound ''unknown''');
+end
+
+% ---------- helpers ----------
+
+function [st, out] = run_enumerate(tc, onnx, vnnlib, witness)
+    % Invoke the script the same way verify_cctsdb_enumeration does. It accepts
+    % .gz transparently, so the benchmark files need no decompression here.
+    script = fullfile(tc.TestData.subdir, 'cctsdb_enumerate.py');
+    cmd = sprintf('%s "%s" "%s" "%s" "%s" --timeout 300', ...
+        resolve_python(), script, onnx, vnnlib, witness);
+    [st, out] = system(cmd);
+end
+
+function [onnx, vnnlib] = locate_instance(tc, model, spec)
+    % Skip (not fail) when python/onnxruntime or the local benchmark clone is
+    % unavailable, so CI machines without them stay green.
+    [pyok, ~] = system([resolve_python() ' -c "import onnx, onnxruntime, numpy"']);
+    assumeEqual(tc, pyok, 0, 'python/onnx/onnxruntime unavailable -- skipping replay tests');
+    here = fileparts(mfilename('fullpath'));
+    root = getenv('NNV_VNNCOMP2026_BENCHMARKS');   % points at .../benchmarks
+    if isempty(root)
+        % default: sibling clone of the repo, <repo>/../vnncomp2026_benchmarks
+        root = fullfile(here, '..', '..', '..', '..', '..', ...
+            'vnncomp2026_benchmarks', 'benchmarks');
+    end
+    bench = fullfile(root, 'cctsdb_yolo_2023', '1.0');
+    onnx = fullfile(bench, 'onnx', [model '.onnx.gz']);
+    vnnlib = fullfile(bench, 'vnnlib', [spec '.vnnlib.gz']);
+    assumeTrue(tc, isfile(onnx) && isfile(vnnlib), ...
+        sprintf('benchmark clone not found under %s -- skipping replay tests', bench));
+end
+
+function py = resolve_python()
+    % Same resolution idiom as validate_witness_onnx / verify_cctsdb_enumeration:
+    % prefer MATLAB's configured pyenv executable, else PATH 'python'.
+    py = 'python';
+    try
+        pe = pyenv;
+        if ~isempty(pe.Executable) && isfile(pe.Executable)
+            py = ['"' char(pe.Executable) '"'];
+        end
+    catch
+    end
+end
+
+function cleanup_file(f)
+    if exist(f, 'file'), delete(f); end
+end

--- a/code/nnv/tests/vnncomp25/test_pgd_falsify.m
+++ b/code/nnv/tests/vnncomp25/test_pgd_falsify.m
@@ -3,6 +3,33 @@ classdef test_pgd_falsify < matlab.unittest.TestCase
     % validator (validate_witness) -- VNN-COMP 2026 strategy Pillars 1 & 2 -- across
     % feature, non-permuted image, and PERMUTED image (needReshape) inputs.
 
+    properties (Access = private)
+        AddedPath = ''   % runner dir added by TestClassSetup (removed in teardown)
+    end
+
+    methods (TestClassSetup)
+        function addRunnerPath(tc)
+            % pgd_falsify/validate_witness live in examples/Submission/VNN_COMP2025.
+            % The matrix CI splits tests into shards and nothing guarantees that dir
+            % is on the path (same latent flake test_validate_witness_onnx had), so
+            % add it here to be self-sufficient.
+            here = fileparts(mfilename('fullpath'));
+            sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2025');
+            if isfolder(sub) && ~contains(path, sub)
+                addpath(sub);
+                tc.AddedPath = sub;
+            end
+        end
+    end
+
+    methods (TestClassTeardown)
+        function removeRunnerPath(tc)
+            if ~isempty(tc.AddedPath)
+                rmpath(tc.AddedPath);
+            end
+        end
+    end
+
     methods (Static)
         function net = linsum_net()                  % y = x1 + x2 (feature, 2->1)
             layers = [ featureInputLayer(2, 'Name', 'in')

--- a/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
+++ b/code/nnv/tests/vnncomp25/test_run_vnncomp_dispatch_smoke.m
@@ -74,14 +74,28 @@ function test_supported_categories_reach_import(testCase)
 end
 
 % --------------------------------------------------------------------------
-% Known-unsupported-at-dispatch categories: they deliberately error in the
-% if/elseif BEFORE importing. Pin the stable messages so a future change that
-% silently starts/stops handling them is caught.
+% cctsdb_yolo: no longer errors at dispatch ("Working on supporting this one").
+% It now routes to the complete-enumeration python path (cctsdb_enumerate.py)
+% BEFORE load_vnncomp_network. With bogus inputs the script (or a missing
+% python) yields UNKNOWN, so the runner must return WITHOUT error and write
+% 'unknown' -- a sound degradation, never a crash.
 % --------------------------------------------------------------------------
-function test_cctsdb_yolo_errors_at_dispatch(testCase)
-    msg = dispatch_error_message(testCase, 'cctsdb_yolo');
-    verifyTrue(testCase, contains(msg, 'Working on supporting this one'), ...
-        sprintf('cctsdb_yolo should error at dispatch; got: %s', msg));
+function test_cctsdb_yolo_routes_to_enumeration(testCase)
+    onnx = [tempname '.onnx'];          % does not exist
+    vnnlib = [tempname '.vnnlib'];      % does not exist
+    outf = [tempname '.txt'];
+    c = onCleanup(@() cleanup_file(outf));
+    try
+        run_vnncomp_instance('cctsdb_yolo', onnx, vnnlib, outf);
+    catch ME
+        verifyFail(testCase, sprintf( ...
+            'cctsdb_yolo must not error at dispatch anymore; got: %s', ME.message));
+        return
+    end
+    verifyTrue(testCase, isfile(outf), 'runner must write the output file');
+    txt = strtrim(fileread(outf));
+    verifyEqual(testCase, txt, 'unknown', ...
+        'bogus inputs must degrade to a sound ''unknown''');
 end
 
 function test_unknown_category_is_rejected(testCase)


### PR DESCRIPTION
## What

Replaces the cctsdb_yolo stub (`error("Working on supporting this one")` — all 39 instances forfeited) with a **sound AND complete enumeration verifier**, recovering up to **+390 points**.

## Why enumeration is sound + complete here

Every cctsdb_yolo_2023 spec has exactly **two free inputs** (X_12288, X_12289 ∈ [0,62], the patch position); all 12,294 other inputs are fixed. The ONNX graph consumes those two inputs **only through Cast(int64)** (truncation), so the network is piecewise-constant on unit cells — enumerating the 63×63 integer grid covers the entire continuous input box **exactly**. UNSAT from enumeration is a complete proof; SAT witnesses are concrete points re-validated through a fresh onnxruntime session.

`cctsdb_enumerate.py` **re-verifies this structure per instance** before trusting it (free-var set, graph-walk to Cast within 2 hops, single-threshold output spec, disjoint slices); any deviation → UNKNOWN (sound). Float-jitter guard: verdicts within ±1e-4 of the threshold → UNKNOWN.

## Validation (MATLAB + python, real instances)

- patch-1 `idx_00559` → **UNSAT** (min Y₀ = 0.81277, matches the independent investigation's 0.8128), 3969 evals.
- patch-3 `idx_00055` → **SAT at (0,23)**, Y₀ = 0, witness replayed + confirmed in-box.
- **Full dispatcher E2E in MATLAB**: `run_vnncomp_instance('cctsdb_yolo', patch-3.onnx.gz, idx_00055.vnnlib.gz)` → `sat` + **12,296-value witness in exact `write_counterexample` format**, 39 s (budget 350 s).
- `test_cctsdb_enumerate.m`: **4/4 pass** (script presence, both replays behind assume-guards, dispatch-no-longer-stub).
- Guard paths (extra free var, compound asserts, Cast retargeted, timeout, missing files) all → UNKNOWN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)