### PR TITLE
fix(lstm): evaluate OutputMode='sequence' (#325) + fail-closed approx-zono (#326)

### DIFF
--- a/code/nnv/engine/nn/layers/LstmLayer.m
+++ b/code/nnv/engine/nn/layers/LstmLayer.m
@@ -157,9 +157,14 @@ classdef LstmLayer < handle
                 % only the final hidden state was returned regardless of
                 % OutputMode (see GitHub issue #325)
                 y = extractdata(Y);
-            else
-                % OutputMode='last': final hidden state (numHiddenUnits x 1)
+            elseif isempty(obj.outputMode) || strcmp(obj.outputMode, 'last')
+                % OutputMode='last' (or unset): final hidden state (numHiddenUnits x 1)
                 y = extractdata(hiddenState);
+            else
+                % fail loud on an invalid OutputMode rather than silently
+                % treating it as 'last' (consistent with the reach path)
+                error('NNV:LstmLayer:invalidOutputMode', ...
+                    'Invalid OutputMode ''%s''; expected ''last'' or ''sequence''.', string(obj.outputMode));
             end
         end 
         
@@ -477,7 +482,7 @@ classdef LstmLayer < handle
                 'LstmLayer approx-zono reachability is not supported; use approx-star');
         end
 
-        % handle mulitples inputs - NOT SUPPORTED (see GitHub issue #326)
+        % handle multiple inputs - NOT SUPPORTED (see GitHub issue #326)
         function S = reach_zono_multipleInputs(obj, inputs, option) %#ok<STOUT,INUSD>
             error('NNV:LstmLayer:zonoUnsupported', ...
                 'LstmLayer approx-zono reachability is not supported; use approx-star');

--- a/code/nnv/engine/nn/layers/LstmLayer.m
+++ b/code/nnv/engine/nn/layers/LstmLayer.m
@@ -147,8 +147,20 @@ classdef LstmLayer < handle
             % initial cell state
             c0 = dlarray(obj.cellState);
             
-            [~,hiddenState,~] = lstm(x,h0,c0,obj.inputWeights,obj.recurrentWeights,obj.bias,"DataFormat","ST");
-            y = extractdata(hiddenState);
+            [Y,hiddenState,~] = lstm(x,h0,c0,obj.inputWeights,obj.recurrentWeights,obj.bias,"DataFormat","ST");
+            if strcmp(obj.outputMode, 'sequence')
+                % full hidden-state sequence (numHiddenUnits x seqLength),
+                % matching MATLAB's lstmLayer OutputMode='sequence'
+                % semantics and the star reachability path
+                % (reach_star_single_input, outputMode == "sequence");
+                % previously the first output of lstm() was discarded and
+                % only the final hidden state was returned regardless of
+                % OutputMode (see GitHub issue #325)
+                y = extractdata(Y);
+            else
+                % OutputMode='last': final hidden state (numHiddenUnits x 1)
+                y = extractdata(hiddenState);
+            end
         end 
         
         function y = evaluateSequence(obj, input)
@@ -218,7 +230,11 @@ classdef LstmLayer < handle
             elseif strcmp(method, 'approx-star') || strcmp(method, 'abs-dom') || contains(method, "relax-star")
                 IS = obj.reach_star_multipleInputs(in_images, option);
             elseif strcmp(method, 'approx-zono')
-                IS = obj.reach_zono_multipleInputs(in_images, option);
+                % the zonotope path (reach_zono) was non-functional and
+                % had no sound semantics (see GitHub issue #326); fail
+                % closed rather than risk returning a wrong set
+                error('NNV:LstmLayer:zonoUnsupported', ...
+                    'LstmLayer approx-zono reachability is not supported; use approx-star');
             else
                 error('Unknown reachability method');
             end
@@ -286,7 +302,11 @@ classdef LstmLayer < handle
             if strcmp(method, 'approx-star') || strcmp(method, 'exact-star') || strcmp(method, 'abs-dom') || contains(method, "relax-star")
                 IS = obj.reach_star_multipleInputs_Sequence(in_images, option);
             elseif strcmp(method, 'approx-zono')
-                IS = obj.reach_zono_multipleInputs(in_images, option);
+                % the zonotope path (reach_zono) was non-functional and
+                % had no sound semantics (see GitHub issue #326); fail
+                % closed rather than risk returning a wrong set
+                error('NNV:LstmLayer:zonoUnsupported', ...
+                    'LstmLayer approx-zono reachability is not supported; use approx-star');
             else
                 error('Unknown reachability method');
             end
@@ -441,68 +461,26 @@ classdef LstmLayer < handle
             S = obj.reach_star_single_input(inputs);
         end
 
-        %(reachability analysis using imagezono)
-        function image = reach_zono(obj, in_image)
-            % @in_image: input imagezono
-            % @image: output set
-            
-            if ~isa(in_image, 'ImageZono') && ~isa(in_image, 'Zono')
-                error('Input set is not an ImageZono or Zono');
-            end
-
-            if isa(in_image, 'ImageZono')
-            
-                N = in_image.height*in_image.width*in_image.numChannels;
-                if N~= obj.InputSize
-                    error('Inconsistency between the size of the input image and the InputSize of the network');
-                end
-                           
-                n = in_image.numPreds;
-                V(1, 1, :, in_image.numPreds + 1) = zeros(obj.OutputSize, 1);        
-                for i=1:n+1
-                    I = in_image.V(:,:,:,i);
-                    I = reshape(I,N,1);
-                    if i==1
-                        V(1, 1,:,i) = double(obj.Weights)*I + double(obj.Bias);
-                    else
-                        V(1, 1,:,i) = double(obj.Weights)*I;
-                    end
-                end
-                
-                image = ImageZono(V);
-            else
-                image = in_image.affineMap(obj.Weights, obj.Bias);
-            end
-            
+        % (reachability analysis using imagezono) - NOT SUPPORTED
+        % The previous reach_zono implementation was non-functional (see
+        % GitHub issue #326): it referenced properties that do not exist
+        % on LstmLayer (obj.Weights, obj.Bias, obj.OutputSize - the body
+        % was copied from a fully-connected layer), its input-size check
+        % flattened the whole sequence and compared against InputSize
+        % (features per step), and even with the plumbing fixed a single
+        % affine map cannot soundly enclose an LSTM. The dead code has
+        % been removed and the method fails closed; a sound zonotope LSTM
+        % step would need affine gate maps on zonotopes, sigmoid/tanh
+        % abstractions, and a sound bilinear product enclosure.
+        function image = reach_zono(obj, in_image) %#ok<STOUT,INUSD>
+            error('NNV:LstmLayer:zonoUnsupported', ...
+                'LstmLayer approx-zono reachability is not supported; use approx-star');
         end
-        
-        % handle mulitples inputs
-        function S = reach_zono_multipleInputs(obj, inputs, option)
-            % @inputs: an array of ImageZonos
-            % @option: = 'parallel' or 'single'
-            % @S: output ImageZono
-            
-            n = length(inputs);
-            if isa(inputs, 'ImageZono')
-                S(n) = ImageZono;
-            elseif isa(inputs, 'Zono')
-                S(n) = Zono;
-            else
-                error('Wrong input set. It must be ImageZono or Zono')
-            end
 
-            if strcmp(option, 'parallel')
-                parfor i=1:n
-                    S(i) = obj.reach_zono(inputs(i));
-                end
-            elseif strcmp(option, 'single') || isempty(option)
-                for i=1:n
-                    S(i) = obj.reach_zono(inputs(i));
-                end
-            else
-                error('Unknown computation option, should be parallel or single');
-            end
-            
+        % handle mulitples inputs - NOT SUPPORTED (see GitHub issue #326)
+        function S = reach_zono_multipleInputs(obj, inputs, option) %#ok<STOUT,INUSD>
+            error('NNV:LstmLayer:zonoUnsupported', ...
+                'LstmLayer approx-zono reachability is not supported; use approx-star');
         end
         
     end

--- a/code/nnv/tests/soundness/test_LstmLayer_evaluate_outputMode.m
+++ b/code/nnv/tests/soundness/test_LstmLayer_evaluate_outputMode.m
@@ -1,0 +1,174 @@
+function tests = test_LstmLayer_evaluate_outputMode
+%TEST_LSTMLAYER_EVALUATE_OUTPUTMODE  Regression tests for GitHub issues #325 and #326.
+%
+%   #325: LstmLayer.evaluate (and evaluateSequence, which delegates to it)
+%   discarded the first output of lstm() and returned only the final hidden
+%   state regardless of OutputMode. With OutputMode='sequence' they must
+%   return the full hidden-state sequence (numHiddenUnits x seqLength),
+%   matching MATLAB's lstmLayer semantics and the layer's own star
+%   reachability path (reach_star_single_input, outputMode == "sequence",
+%   fixed in PR #322). OutputMode='last' behavior is unchanged.
+%
+%   #326: LstmLayer.reach_zono was non-functional (referenced nonexistent
+%   properties obj.Weights/obj.Bias/obj.OutputSize, wrong input-size
+%   semantics) and a single affine map has no sound LSTM semantics, so the
+%   'approx-zono' dispatch in reach()/reachSequence() must fail closed with
+%   error id NNV:LstmLayer:zonoUnsupported (an error is safe; a wrong set
+%   is catastrophic).
+%
+%   To run: results = runtests('test_LstmLayer_evaluate_outputMode')
+    tests = functiontests(localfunctions);
+end
+
+% ---------- #325: evaluate/evaluateSequence OutputMode handling ----------
+
+function test_sequence_mode_shape_and_last_column(tc)
+    % OutputMode='sequence' must return numHiddenUnits x seqLength, and its
+    % last column must equal the OutputMode='last' result on the same input
+    [Lseq, Llast, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(42);
+
+    x = randn(inputSize, seqLength);
+    yseq = Lseq.evaluateSequence(x);
+    ylast = Llast.evaluateSequence(x);
+
+    verifyEqual(tc, size(yseq), [numHiddenUnits, seqLength], ...
+        "OutputMode='sequence' must return the full hidden-state sequence (features x time)");
+    verifyEqual(tc, size(ylast), [numHiddenUnits, 1], ...
+        "OutputMode='last' must return only the final hidden state");
+    verifyEqual(tc, double(yseq(:, end)), double(ylast), 'AbsTol', 1e-12, ...
+        "last column of the sequence must equal the OutputMode='last' result");
+
+    % evaluate and evaluateSequence must agree (the latter delegates)
+    verifyEqual(tc, double(Lseq.evaluate(x)), double(yseq), 'AbsTol', 1e-12, ...
+        'evaluate and evaluateSequence must agree');
+    verifyEqual(tc, double(Llast.evaluate(x)), double(ylast), 'AbsTol', 1e-12, ...
+        'evaluate and evaluateSequence must agree');
+end
+
+function test_sequence_mode_prefix_consistency(tc)
+    % column t of the sequence output equals the 'last' output on the
+    % prefix x(:, 1:t) (the initial hidden/cell states are fixed), pinning
+    % the values of every column, not just the final one
+    [Lseq, Llast, inputSize, ~, seqLength] = make_lstm_pair(43);
+
+    x = randn(inputSize, seqLength);
+    yseq = Lseq.evaluateSequence(x);
+    for t = 1:seqLength
+        ht = Llast.evaluateSequence(x(:, 1:t));
+        verifyEqual(tc, double(yseq(:, t)), double(ht), 'AbsTol', 1e-9, ...
+            sprintf('column %d must equal the final hidden state of the prefix x(:,1:%d)', t, t));
+    end
+end
+
+% ---------- #325: evaluate-vs-reach consistency (the core divergence) ----------
+
+function test_reach_consistency_sequence_mode(tc)
+    % for a degenerate (zero-width) ImageStar input, the center of the
+    % reachSequence output must equal the concrete evaluation; this catches
+    % evaluate-vs-reach divergence (pre-fix, evaluateSequence returned
+    % numHiddenUnits x 1 while the reach path returned one column per step)
+    [Lseq, ~, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(44);
+
+    x = randn(inputSize, seqLength);
+    R = Lseq.reachSequence(ImageStar(x, x), 'approx-star');
+    verifyClass(tc, R, 'ImageStar');
+    verifyEqual(tc, R.height, numHiddenUnits, 'output must have numHiddenUnits rows');
+    verifyEqual(tc, R.width, seqLength, ...
+        'sequence-mode output must have one column per time step');
+
+    [lb, ub] = R.getRanges;
+    c = reshape((lb + ub)/2, numHiddenUnits, seqLength);
+    y = Lseq.evaluateSequence(x);
+    verifyEqual(tc, size(y), size(c), ...
+        'evaluateSequence output shape must match the reach output shape');
+    verifyEqual(tc, double(c), double(y), 'AbsTol', 1e-6, ...
+        'reach center must equal the concrete evaluation for a point input');
+    verifyLessThan(tc, max(abs(ub(:) - lb(:))), 1e-6, ...
+        'reach output for a point input must be (numerically) a point');
+end
+
+function test_reach_consistency_last_mode(tc)
+    % same degenerate-input consistency for OutputMode='last' (guards the
+    % byte-identical 'last' behavior against regressions)
+    [~, Llast, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(45);
+
+    x = randn(inputSize, seqLength);
+    R = Llast.reachSequence(ImageStar(x, x), 'approx-star');
+    verifyClass(tc, R, 'ImageStar');
+    verifyEqual(tc, R.height, numHiddenUnits, 'output must have numHiddenUnits rows');
+
+    [lb, ub] = R.getRanges;
+    c = reshape((lb + ub)/2, numHiddenUnits, 1);
+    y = Llast.evaluateSequence(x);
+    verifyEqual(tc, size(y), size(c), ...
+        'evaluateSequence output shape must match the reach output shape');
+    verifyEqual(tc, double(c), double(y), 'AbsTol', 1e-6, ...
+        'reach center must equal the concrete evaluation for a point input');
+end
+
+% ---------- #326: approx-zono must fail closed ----------
+
+function test_reach_zono_fails_closed(tc)
+    % the zonotope path is non-functional and has no sound semantics; both
+    % dispatch entry points must raise a clear, identifiable error instead
+    % of returning a wrong set (VNN-COMP: an error is safe, a wrong set is
+    % a -150 catastrophe)
+    [Lseq, Llast, inputSize, ~, seqLength] = make_lstm_pair(46);
+
+    x = randn(inputSize, seqLength);
+    IZ = ImageZono(x - 0.1, x + 0.1);
+
+    verifyError(tc, @() Llast.reach(IZ, 'approx-zono', []), ...
+        'NNV:LstmLayer:zonoUnsupported');
+    verifyError(tc, @() Llast.reachSequence(IZ, 'approx-zono', []), ...
+        'NNV:LstmLayer:zonoUnsupported');
+    verifyError(tc, @() Lseq.reach(IZ, 'approx-zono', []), ...
+        'NNV:LstmLayer:zonoUnsupported');
+    verifyError(tc, @() Lseq.reachSequence(IZ, 'approx-zono', []), ...
+        'NNV:LstmLayer:zonoUnsupported');
+
+    % direct calls to the stubbed methods fail closed as well
+    verifyError(tc, @() Llast.reach_zono(IZ), ...
+        'NNV:LstmLayer:zonoUnsupported');
+    verifyError(tc, @() Llast.reach_zono_multipleInputs(IZ, []), ...
+        'NNV:LstmLayer:zonoUnsupported');
+end
+
+% ---------- helpers ----------
+
+function [Lseq, Llast, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(seed)
+    % two small deterministic LstmLayers sharing identical fixed-rng
+    % weights, differing only in OutputMode (constructor pattern mirrors
+    % test_soundness_LstmLayer_reachSequence.m)
+    rng(seed);
+
+    inputSize = 3;
+    numHiddenUnits = 4;
+    seqLength = 5;
+
+    inputWeights = 0.5*randn(4*numHiddenUnits, inputSize);
+    recurrentWeights = 0.5*randn(4*numHiddenUnits, numHiddenUnits);
+    bias = 0.1*randn(4*numHiddenUnits, 1);
+    cellState = zeros(numHiddenUnits, 1);
+    hiddenState = zeros(numHiddenUnits, 1);
+
+    Lseq = LstmLayer('Name', 'lstm_eval_seq', ...
+        'InputSize', inputSize, ...
+        'NumHiddenUnits', numHiddenUnits, ...
+        'InputWeights', inputWeights, ...
+        'RecurrentWeights', recurrentWeights, ...
+        'Bias', bias, ...
+        'CellState', cellState, ...
+        'HiddenState', hiddenState, ...
+        'OutputMode', 'sequence');
+
+    Llast = LstmLayer('Name', 'lstm_eval_last', ...
+        'InputSize', inputSize, ...
+        'NumHiddenUnits', numHiddenUnits, ...
+        'InputWeights', inputWeights, ...
+        'RecurrentWeights', recurrentWeights, ...
+        'Bias', bias, ...
+        'CellState', cellState, ...
+        'HiddenState', hiddenState, ...
+        'OutputMode', 'last');
+end

--- a/code/nnv/tests/soundness/test_LstmLayer_evaluate_outputMode.m
+++ b/code/nnv/tests/soundness/test_LstmLayer_evaluate_outputMode.m
@@ -70,7 +70,8 @@ function test_reach_consistency_sequence_mode(tc)
     [Lseq, ~, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(44);
 
     x = randn(inputSize, seqLength);
-    R = Lseq.reachSequence(ImageStar(x, x), 'approx-star');
+    ep = 1e-3;
+    R = Lseq.reachSequence(ImageStar(x - ep, x + ep), 'approx-star');
     verifyClass(tc, R, 'ImageStar');
     verifyEqual(tc, R.height, numHiddenUnits, 'output must have numHiddenUnits rows');
     verifyEqual(tc, R.width, seqLength, ...
@@ -81,10 +82,11 @@ function test_reach_consistency_sequence_mode(tc)
     y = Lseq.evaluateSequence(x);
     verifyEqual(tc, size(y), size(c), ...
         'evaluateSequence output shape must match the reach output shape');
-    verifyEqual(tc, double(c), double(y), 'AbsTol', 1e-6, ...
-        'reach center must equal the concrete evaluation for a point input');
-    verifyLessThan(tc, max(abs(ub(:) - lb(:))), 1e-6, ...
-        'reach output for a point input must be (numerically) a point');
+    % containment (not equality): a small real box avoids the pre-existing
+    % degenerate-set 'imagestar is empty' guard in ImageStar.getRange; the
+    % SHAPE asserts above are what catch the #325 evaluate-vs-reach divergence
+    verifyTrue(tc, all(y(:) >= lb(:) - 1e-6) && all(y(:) <= ub(:) + 1e-6), ...
+        'concrete evaluation must be enclosed by the reach output');
 end
 
 function test_reach_consistency_last_mode(tc)
@@ -93,17 +95,19 @@ function test_reach_consistency_last_mode(tc)
     [~, Llast, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(45);
 
     x = randn(inputSize, seqLength);
-    R = Llast.reachSequence(ImageStar(x, x), 'approx-star');
+    ep = 1e-3;
+    R = Llast.reachSequence(ImageStar(x - ep, x + ep), 'approx-star');
     verifyClass(tc, R, 'ImageStar');
     verifyEqual(tc, R.height, numHiddenUnits, 'output must have numHiddenUnits rows');
 
     [lb, ub] = R.getRanges;
-    c = reshape((lb + ub)/2, numHiddenUnits, 1);
     y = Llast.evaluateSequence(x);
-    verifyEqual(tc, size(y), size(c), ...
-        'evaluateSequence output shape must match the reach output shape');
-    verifyEqual(tc, double(c), double(y), 'AbsTol', 1e-6, ...
-        'reach center must equal the concrete evaluation for a point input');
+    verifyEqual(tc, size(y), [numHiddenUnits, 1], ...
+        'last-mode evaluateSequence output must be numHiddenUnits x 1');
+    % containment, not center-equality: with a real epsilon box the reach center
+    % is not exactly the concrete evaluation (over-approximation skew ~1e-6)
+    verifyTrue(tc, all(y(:) >= lb(:) - 1e-6) && all(y(:) <= ub(:) + 1e-6), ...
+        'concrete evaluation must be enclosed by the reach output');
 end
 
 % ---------- #326: approx-zono must fail closed ----------
@@ -171,4 +175,14 @@ function [Lseq, Llast, inputSize, numHiddenUnits, seqLength] = make_lstm_pair(se
         'CellState', cellState, ...
         'HiddenState', hiddenState, ...
         'OutputMode', 'last');
+end
+
+function IS = point_image_star(x)
+    % point set as an explicit 1-predicate ImageStar with a ZERO generator:
+    % ImageStar(x, x) (im_lb==im_ub) yields a 0-predicate set that trips the
+    % pre-existing "imagestar is empty" guard in ImageStar.getRange during the
+    % reach path's splitSet; this form is the same point semantically but
+    % keeps one (inert) predicate so every range/LP path is well-defined.
+    V = cat(4, x, zeros(size(x)));
+    IS = ImageStar(V, [1; -1], [1; 1], -1, 1);
 end

--- a/code/nnv/tests/soundness/test_soundness_LstmLayer_reachSequence.m
+++ b/code/nnv/tests/soundness/test_soundness_LstmLayer_reachSequence.m
@@ -166,6 +166,9 @@ for k = 1:10
     xs = (x - ep) + 2*ep.*rand(inputSize, seqLength);
     for t = 1:seqLength
         ht = L.evaluateSequence(xs(:, 1:t));
+        ht = ht(:, end);   % #325 fix: 'sequence' mode now returns H x t; the final
+                           % hidden state of the prefix is the LAST column (under the
+                           % old H x 1 semantics this indexing is a no-op)
         assert(all(ht(:) >= lb(:, t) - tol) && all(ht(:) <= ub(:, t) + tol), ...
             sprintf('sample %d, step %d must be enclosed by column %d', k, t, t));
     end


### PR DESCRIPTION
## What

- **#325**: `LstmLayer.evaluate`/`evaluateSequence` now honors `OutputMode='sequence'` — returns the full hidden-state sequence (numHiddenUnits × seqLength) via the first output of `lstm(...)`; `'last'` behavior byte-identical. This aligns evaluate with the reach path fixed in #322.
- **#326**: the `approx-zono` path **fails closed** (`NNV:LstmLayer:zonoUnsupported`) in `reach()`/`reachSequence()`, and the dead `reach_zono`/`reach_zono_multipleInputs` bodies (referencing nonexistent `obj.Weights`/`obj.Bias`/`obj.OutputSize`) are replaced with fail-loud stubs. Given −150 stakes, an explicit error beats a silently wrong set.

## Validation (MATLAB, local)

- New `test_LstmLayer_evaluate_outputMode.m`: **5/5 pass** — sequence shape + last-column equality, per-prefix column consistency, evaluate-vs-reach containment for both output modes (epsilon-box; catches the #325 divergence), and `verifyError` on every zono entry point.
- Existing LSTM suites against the new layer: `test_soundness_LstmLayer_reachSequence` **4/4** (one test updated backward-compatibly: prefix check takes the last column, a no-op under old semantics), `test_LstmLayer_reach_dispatch` 4/4, `test_LstmLayer_sequence_outputMode` 1/1, `test_star_HadamardProduct` 1/1.

Note: the evaluate-vs-reach consistency tests use a small epsilon-box rather than a degenerate `ImageStar(x,x)` point set — zero-width sets trip a pre-existing `ImageStar.getRange` "empty" guard in the reach path's `splitSet` (a separate latent issue, unchanged here).

Closes #325. Closes #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)