### PR TITLE
feat(vnnlib2): multi-network equal-to parsing + product-net verifier (Phase 2 foundation)

### DIFF
--- a/code/nnv/engine/utils/load_vnnlib2.m
+++ b/code/nnv/engine/utils/load_vnnlib2.m
@@ -20,9 +20,36 @@ function property = load_vnnlib2(propertyFile)
     % current run_vnncomp_instance.m emits `unknown` for ANY unsupported property; the
     % recorded box is reserved for a FUTURE falsification/PGD fallback (plan Phase 3b)
     % that could still find a concrete `sat` for a gated-but-linear-input case. Gated:
-    % multiple networks (equal-to/isomorphic-to), declare-hidden, >1 input or output
+    % three-or-more networks, isomorphic-to, declare-hidden, >1 input or output
     % tensor (multimodal), `!=`, nonlinear/arithmetic (`*`,`+`,`-` over variables),
     % partial indexing, and mixed input/output disjunctions.
+    %
+    % PHASE 2 (multi-network, `equal-to` ONLY -- plan section 3.1): when the file
+    % declares exactly TWO networks and the second is `(equal-to <first>)` (the
+    % monotonic_acasxu_2026 shape: the SAME onnx evaluated on two coupled inputs),
+    % the file is PARSED instead of gated. The result keeps the single-network
+    % contract fields EMPTY (property.lb/ub = [], property.prop = {}) so legacy
+    % consumers cannot misuse them, and adds
+    %     property.multinet.names     -> {name_f, name_g}            (cell 1x2)
+    %     property.multinet.inShapes  -> {inShape_f, inShape_g}      (must match)
+    %     property.multinet.outShapes -> {outShape_f, outShape_g}    (must match)
+    %     property.multinet.equivKind -> 'equal'
+    %     property.multinet.jointLb   -> box over the STACKED input [X_f; X_g] (2n x 1)
+    %     property.multinet.jointUb      (g-block bounds that only follow from the
+    %                                     coupling rows are closed by sound interval
+    %                                     propagation; see propagate_joint_bounds)
+    %     property.multinet.jointC    -> cross/within-network input coupling rows
+    %     property.multinet.jointd       jointC * x <= jointd over the CONCRETE
+    %                                     stacked input x = [X_f; X_g] (NOT over star
+    %                                     predicates -- verify_multinet maps x to the
+    %                                     Star predicate alpha; `==` couplings are
+    %                                     emitted as two-row inequality pairs)
+    %     property.multinet.crossProp -> HalfSpace array over the STACKED output
+    %                                     [Y_f; Y_g]: G*y <= g is the UNSAFE region,
+    %                                     same polarity convention as .prop{n}.Hg
+    % property.unsupported stays true (the default) unless EVERY assert parsed
+    % cleanly into the joint box / jointC / crossProp AND the joint box closed.
+    % Verification of this structure lives in engine/utils/verify_multinet.m.
     %
     % PERFORMANCE: the file is processed by STREAMING complete S-expression
     % statements (one (declare-network ...) / (assert ...) at a time) so the giant
@@ -107,16 +134,22 @@ function [st, done] = dispatch_statement(stmt, st)
             st.sawVersion = true;
         case 'declare-network'
             if st.sawNetwork
-                st.unsupported = true;
-                st.reason = 'multiple declare-network (multi-network 2.0 not supported)';
-                done = true; return;
-            end
-            st.sawNetwork = true;
-            st = parse_network_header(stmt, st);
-            if st.unsupported
-                done = true; return;   % gate from header alone
+                % Phase 2: a SECOND declare-network is parsed (not gated) iff it
+                % is `(equal-to <first>)` with matching shapes; anything else
+                % (third network, isomorphic-to, multimodal, ...) stays gated.
+                st = parse_second_network(stmt, st);
+                if st.unsupported
+                    done = true; return;
+                end
+            else
+                st.sawNetwork = true;
+                st = parse_network_header(stmt, st);
+                if st.unsupported
+                    done = true; return;   % gate from header alone
+                end
             end
         case 'assert'
+            st.sawAssert = true;
             st = process_assert(stmt, st);
             if st.hardStop, done = true; return; end
         otherwise
@@ -130,6 +163,9 @@ end
 
 function st = parse_network_header(stmt, st)
     node = parse_one_sexpr(stmt);
+    if numel(node) >= 2 && (ischar(node{2}) || isstring(node{2}))
+        st.netName = char(node{2});   % needed to validate `(equal-to <name>)` (Phase 2)
+    end
     inputs = {}; outputs = {}; hasEquiv = false; hasHidden = false;
     for k = 2:numel(node)
         c = node{k};
@@ -166,11 +202,96 @@ function st = parse_network_header(stmt, st)
     st.haveBox = true;
 end
 
+function st = parse_second_network(stmt, st)
+    % Phase 2 (multi-network `equal-to` ONLY, plan section 3.1): accept a SECOND
+    % declare-network iff it is `(equal-to <first-network-name>)` with exactly one
+    % input and one output tensor whose shapes MATCH the first network (the 2.0
+    % standard requires matching element types and shapes for equal-to). On
+    % success the parser switches to multinet mode: subsequent asserts fill the
+    % joint stacked box/coupling rows/cross output property instead of the
+    % single-network fields. EVERY other shape of file stays gated (sound).
+    if st.multinet
+        st.unsupported = true;
+        st.reason = 'more than two declare-network (only an equal-to pair is supported)';
+        return;
+    end
+    if st.sawAssert
+        % The 2.0 grammar puts all asserts AFTER the network declarations. An
+        % assert seen BEFORE the second declare-network was processed (or
+        % silently ignored, if it referenced the then-undeclared network) in
+        % single-network mode, so continuing could DROP constraints -- a sat
+        % witness ignoring a dropped input constraint fails the official
+        % witness replay (-150). Gate instead.
+        st.unsupported = true;
+        st.reason = 'assert appears before the second declare-network';
+        return;
+    end
+    node = parse_one_sexpr(stmt);
+    name2 = '';
+    if numel(node) >= 2 && (ischar(node{2}) || isstring(node{2}))
+        name2 = char(node{2});
+    end
+    inputs = {}; outputs = {}; equivs = {}; hasHidden = false;
+    for k = 2:numel(node)
+        c = node{k};
+        if ~iscell(c) || isempty(c), continue; end
+        h = node_head(c);
+        switch h
+            case 'declare-input',  inputs{end+1}  = c; %#ok<AGROW>
+            case 'declare-output', outputs{end+1} = c; %#ok<AGROW>
+            case 'declare-hidden', hasHidden = true;
+            case {'equal-to','isomorphic-to'}, equivs{end+1} = c; %#ok<AGROW>
+        end
+    end
+    if hasHidden
+        st.unsupported = true; st.reason = 'declare-hidden intermediate constraints not supported'; return;
+    end
+    if numel(equivs) ~= 1
+        st.unsupported = true; st.reason = 'second declare-network must carry exactly one equivalence relation (equal-to)'; return;
+    end
+    eq = equivs{1};
+    if ~strcmp(node_head(eq), 'equal-to')
+        st.unsupported = true; st.reason = 'isomorphic-to (different weights) not supported -- only equal-to'; return;
+    end
+    if numel(eq) < 2 || ~(ischar(eq{2}) || isstring(eq{2})) || isempty(st.netName) || ~strcmp(char(eq{2}), st.netName)
+        st.unsupported = true; st.reason = 'equal-to must reference the first declared network'; return;
+    end
+    if numel(inputs) ~= 1 || numel(outputs) ~= 1
+        st.unsupported = true;
+        st.reason = sprintf('expected 1 input and 1 output tensor per network, found %d/%d (multimodal not supported)', numel(inputs), numel(outputs));
+        return;
+    end
+    [st.inName2, inShape2]   = parse_io_decl(inputs{1});
+    [st.outName2, outShape2] = parse_io_decl(outputs{1});
+    st.inShape2 = inShape2; st.outShape2 = outShape2;
+    if ~isequal(inShape2, st.inShape) || ~isequal(outShape2, st.outShape)
+        st.unsupported = true; st.reason = 'equal-to networks must have identical input/output shapes'; return;
+    end
+    % the four tensor names (and the two net names) must be distinct, otherwise
+    % the raw-string assert classification (ref_present) is ambiguous
+    nm = {st.inName, st.outName, st.inName2, st.outName2};
+    if any(cellfun(@isempty, nm)) || numel(unique(nm)) ~= 4 || isempty(name2) || strcmp(name2, st.netName)
+        st.unsupported = true; st.reason = 'ambiguous / duplicate tensor names across the two networks'; return;
+    end
+    % switch to multinet mode: stacked order is [X_f; X_g] / [Y_f; Y_g]
+    st.multinet = true;
+    st.netName2 = name2;
+    st.jointLb = nan(2*st.inDim, 1, 'single');
+    st.jointUb = nan(2*st.inDim, 1, 'single');
+    st.jointC = zeros(0, 2*st.inDim, 'single');
+    st.jointd = zeros(0, 1, 'single');
+    st.crossCells = {};
+end
+
 % =========================================================================
 % Assert processing
 % =========================================================================
 
 function st = process_assert(stmt, st)
+    if st.multinet
+        st = process_assert_multinet(stmt, st);
+        return;
+    end
     if ~st.sawNetwork || ~st.haveBox
         st.unsupported = true; st.reason = 'assert before declare-network'; st.hardStop = true; return;
     end
@@ -232,6 +353,260 @@ function st = process_assert(stmt, st)
 end
 
 % =========================================================================
+% Assert processing -- multi-network (equal-to) mode (Phase 2)
+% =========================================================================
+
+function st = process_assert_multinet(stmt, st)
+    % Multinet twin of process_assert. Stacked variable order is fixed as
+    % [X_f; X_g] for inputs and [Y_f; Y_g] for outputs (f = first declared
+    % network). Any form that does not map EXACTLY onto
+    %   - a var-const bound on the joint box,
+    %   - a two-term linear coupling row jointC*x <= jointd, or
+    %   - a linear (possibly disjunctive) HalfSpace over [Y_f; Y_g]
+    % gates the whole property (unsupported -> runner says `unknown`).
+    refIn  = ref_present(stmt, st.inName)  || ref_present(stmt, st.inName2);
+    refOut = ref_present(stmt, st.outName) || ref_present(stmt, st.outName2);
+    nonlin = has_unsupported_op_str(stmt);
+
+    if refIn && refOut
+        st.unsupported = true;
+        st.reason = 'mixed input/output assertion in multi-network property not supported';
+        st.hardStop = true; return;
+    end
+
+    if refIn
+        if nonlin
+            st.unsupported = true;
+            st.reason = 'nonlinear / arithmetic multi-network input constraint not soundly representable';
+            st.hardStop = true; return;
+        end
+        e = sexpr_body(parse_one_sexpr(stmt));
+        [st, ok] = apply_mn_input_expr(e, st);
+        if ~ok
+            st.unsupported = true; st.reason = 'unsupported multi-network input constraint form'; st.hardStop = true; return;
+        end
+    elseif refOut
+        if nonlin
+            st.unsupported = true;
+            st.reason = 'nonlinear / arithmetic / != multi-network output property not soundly verifiable by linear reach';
+            st.hardStop = true; return;
+        end
+        e = sexpr_body(parse_one_sexpr(stmt));
+        [ast, ok] = mn_build_output_assertion(e, st);
+        if ~ok
+            st.unsupported = true; st.reason = 'unsupported multi-network output property form'; st.hardStop = true; return;
+        end
+        [st.crossCells, okacc] = accumulate_output(st.crossCells, ast);
+        if ~okacc
+            st.unsupported = true;
+            st.reason = 'multi-network output is a product-of-sums not representable as one disjunctive spec';
+            st.hardStop = true; return;
+        end
+        st.sawCrossOutput = true;
+    else
+        % references neither network's tensors -- ignore (constant tautology)
+    end
+end
+
+function [st, ok] = apply_mn_input_expr(e, st)
+    % Multinet twin of apply_input_expr. Handles
+    %   (and ...)                          recursion
+    %   (op  <inVar> <const>)              joint box bound (strict -> non-strict,
+    %                                      same soundness note as apply_input_expr)
+    %   (op  <inVar> <inVar>)              linear coupling row(s) over the CONCRETE
+    %                                      stacked input x = [X_f; X_g]:
+    %       (<= A B), (< A B)   ->  x(A) - x(B) <= 0      (one row:  +1@A, -1@B)
+    %       (>= A B), (> A B)   -> -x(A) + x(B) <= 0      (one row:  -1@A, +1@B)
+    %       (== A B)            ->  both rows above        (two-row inequality pair)
+    % NOTE: jointC/jointd constrain x DIRECTLY (concrete input space), NOT the
+    % Star predicate alpha. verify_multinet performs the x -> alpha substitution
+    % (x = c + G*alpha) when building the joint input Star; the falsifier checks
+    % jointC*x <= jointd on concrete samples. Parser and verifier MUST stay
+    % consistent on this convention.
+    ok = true;
+    if ~iscell(e) || isempty(e), ok = false; return; end
+    head = char(e{1});
+    if strcmp(head, 'and')
+        for k = 2:numel(e)
+            [st, ok] = apply_mn_input_expr(e{k}, st);
+            if ~ok, return; end
+        end
+        return;
+    end
+    if ~ismember(head, {'<=','>=','<','>','=='}), ok = false; return; end
+    if numel(e) ~= 3, ok = false; return; end
+    lhs = e{2}; rhs = e{3};
+    if ~(ischar(lhs) || isstring(lhs)) || ~(ischar(rhs) || isstring(rhs))
+        ok = false; return;   % nested expression -- not a plain bound/coupling
+    end
+    [li, lok] = mn_input_index(lhs, st);
+    if ~lok, ok = false; return; end   % lhs must be an input ref (mirrors 1-net path)
+    if isempty(var_basename(rhs))
+        % var-const -> joint box (strict <,> treated as <=,>= like apply_input_expr)
+        c = single(str2double(char(rhs)));
+        if isnan(c), ok = false; return; end
+        switch head
+            case {'>=','>'}, st.jointLb(li) = c;
+            case {'<=','<'}, st.jointUb(li) = c;
+            case '==',       st.jointLb(li) = c; st.jointUb(li) = c;
+        end
+    else
+        % var-var -> coupling row(s); both sides must resolve to input dims
+        [ri, rok] = mn_input_index(rhs, st);
+        if ~rok, ok = false; return; end
+        row = zeros(1, 2*st.inDim, 'single');
+        switch head
+            case {'<=','<'}
+                row(li) = row(li) + 1; row(ri) = row(ri) - 1;       % x(li) - x(ri) <= 0
+                st.jointC = [st.jointC; row];
+                st.jointd = [st.jointd; single(0)];
+            case {'>=','>'}
+                row(li) = row(li) - 1; row(ri) = row(ri) + 1;       % x(ri) - x(li) <= 0
+                st.jointC = [st.jointC; row];
+                st.jointd = [st.jointd; single(0)];
+            case '=='
+                row(li) = row(li) + 1; row(ri) = row(ri) - 1;
+                st.jointC = [st.jointC; row; -row];                 % == as two-row pair
+                st.jointd = [st.jointd; single(0); single(0)];
+        end
+    end
+end
+
+function [idx, ok] = mn_input_index(tok, st)
+    % resolve an input variable reference to its 1-based STACKED index in
+    % x = [X_f; X_g] (f-block first, then the g-block offset by inDim)
+    idx = []; ok = false; tok = char(tok);
+    nm = var_basename(tok);
+    if isempty(nm), return; end
+    if strcmp(nm, st.inName)
+        [flat, okf] = flatten_ref(tok, st.inName, st.inShape);
+        if ~okf, return; end
+        idx = flat + 1; ok = true;
+    elseif strcmp(nm, st.inName2)
+        [flat, okf] = flatten_ref(tok, st.inName2, st.inShape2);
+        if ~okf, return; end
+        idx = st.inDim + flat + 1; ok = true;
+    end
+end
+
+function [ast, ok] = mn_build_output_assertion(e, st)
+    % multinet twin of build_output_assertion (same or/and shapes)
+    ast = struct('Hg', HalfSpace.empty); ok = true;
+    if ~iscell(e) || isempty(e), ok = false; return; end
+    head = char(e{1});
+    if strcmp(head, 'or')
+        Hs = HalfSpace.empty;
+        for k = 2:numel(e)
+            [sub, oks] = mn_output_conjunction(e{k}, st);
+            if ~oks, ok = false; return; end
+            Hs(end+1,1) = sub; %#ok<AGROW>
+        end
+        ast.Hg = Hs;
+    else
+        [Hs, oks] = mn_output_conjunction(e, st);
+        if ~oks, ok = false; return; end
+        ast.Hg = Hs;
+    end
+end
+
+function [hs, ok] = mn_output_conjunction(e, st)
+    % multinet twin of output_conjunction
+    ok = true; G = []; g = [];
+    head = node_head(e);
+    if strcmp(head, 'and')
+        for k = 2:numel(e)
+            [Gr, gr, okr] = mn_output_rows(e{k}, st);
+            if ~okr, ok = false; hs = HalfSpace.empty; return; end
+            G = [G; Gr]; g = [g; gr]; %#ok<AGROW>
+        end
+    else
+        [G, g, okr] = mn_output_rows(e, st);
+        if ~okr, ok = false; hs = HalfSpace.empty; return; end
+    end
+    hs = HalfSpace(G, g);
+end
+
+function [G, g, ok] = mn_output_rows(e, st)
+    % multinet twin of output_rows (== expands to a two-row pair)
+    ok = true; G = []; g = [];
+    if ~iscell(e) || numel(e) ~= 3, ok = false; return; end
+    head = char(e{1});
+    if ~ismember(head, {'<=','>=','<','>','=='}), ok = false; return; end
+    [row, gval, okr] = mn_linear_two_terms(head, e{2}, e{3}, st);
+    if ~okr, ok = false; return; end
+    if strcmp(head, '==')
+        G = [row; -row]; g = [gval; -gval];
+    else
+        G = row; g = gval;
+    end
+end
+
+function [row, gval, ok] = mn_linear_two_terms(op, lhs, rhs, st)
+    % Multinet twin of linear_two_terms over the STACKED output y = [Y_f; Y_g]
+    % (width 2*outDim). POLARITY DERIVATION (the -150-critical part), mirroring
+    % linear_two_terms exactly:
+    %
+    %   VNN-LIB asserts encode the SAT/counterexample (= unsafe) region ITSELF:
+    %   a `sat` witness must make every assert TRUE, and the official checker
+    %   REPLAYS the asserts on the witness. So the asserted comparison maps
+    %   DIRECTLY into HalfSpace G*y <= g -- no negation. (Negating here, i.e.
+    %   encoding the complement, would flip sat/unsat: a "witness" would be
+    %   rejected by the replay and a -150 wrong verdict would follow.)
+    %
+    %   (op lhs rhs) is first normalized to  coef*y ? cst  with lhs terms +1,
+    %   rhs terms -1 (constants folded into cst with opposite signs):
+    %     op in {<=,<}:  lhs - rhs <= 0  ->  row =  coef, g =  cst
+    %     op in {>=,>}:  lhs - rhs >= 0  ->  row = -coef, g = -cst
+    %   Strict <,> are relaxed to <=,>= (superset of the true unsafe region:
+    %   sound for the UNSAT proof; the boundary-witness caveat is the same as
+    %   in the single-network parser and is guarded by strict-interior checks
+    %   in verify_multinet's falsifier).
+    %
+    %   Worked example (monotonic_acasxu): assert (< Y_f[3] Y_g[3]) ->
+    %   unsafe = { Y_f[3] - Y_g[3] <= 0 }, i.e. row has +1 at the Y_f[3] column
+    %   (stacked col 4) and -1 at the Y_g[3] column (stacked col outDim+4),
+    %   g = 0. An `unsat` verdict then proves NO coupled input pair reaches
+    %   Y_f[3] <= Y_g[3], hence none reaches the strict Y_f[3] < Y_g[3] either
+    %   (the asserted region is unreachable -> property proved).
+    ok = true; row = zeros(1, 2*st.outDim); gval = 0;
+    [li, lc, okl] = mn_term_value(lhs, st);
+    [ri, rc, okr] = mn_term_value(rhs, st);
+    if ~okl || ~okr, ok = false; return; end
+    coef = zeros(1, 2*st.outDim);
+    cst = 0;
+    if ~isempty(li), coef(li) = coef(li) + 1; else, cst = cst - lc; end
+    if ~isempty(ri), coef(ri) = coef(ri) - 1; else, cst = cst + rc; end
+    if any(strcmp(op, {'<=','<'}))
+        row = coef; gval = single(cst);
+    else
+        row = -coef; gval = single(-cst);
+    end
+end
+
+function [idx, c, ok] = mn_term_value(t, st)
+    % multinet twin of term_value: resolve an output ref into the STACKED
+    % [Y_f; Y_g] order (g-block offset by outDim), or a numeric constant
+    idx = []; c = 0; ok = true; t = char(t);
+    nm = var_basename(t);
+    if isempty(nm)
+        c = single(str2double(t));
+        if isnan(c), ok = false; end
+        return;
+    end
+    if strcmp(nm, st.outName)
+        [flat, okf] = flatten_ref(t, st.outName, st.outShape);
+        if ~okf, ok = false; return; end
+        idx = flat + 1;
+    elseif strcmp(nm, st.outName2)
+        [flat, okf] = flatten_ref(t, st.outName2, st.outShape2);
+        if ~okf, ok = false; return; end
+        idx = st.outDim + flat + 1;
+    else
+        ok = false;
+    end
+end
+
+% =========================================================================
 % Finalization
 % =========================================================================
 
@@ -241,7 +616,9 @@ function property = finalize(st)
     end
     if st.unsupported
         box = [];
-        if st.haveBox && ~st.inputIsOr && ~any(isnan(st.lb)) && ~any(isnan(st.ub))
+        % never record a single-net box for a multinet file: it would describe
+        % only the first network's input and could mislead a future PGD fallback
+        if ~st.multinet && st.haveBox && ~st.inputIsOr && ~any(isnan(st.lb)) && ~any(isnan(st.ub))
             box = struct('lb', st.lb, 'ub', st.ub);
         end
         property = unsupported_property(box, st.reason);
@@ -249,6 +626,10 @@ function property = finalize(st)
     end
     if ~st.sawNetwork
         property = unsupported_property([], 'no declare-network'); return;
+    end
+    if st.multinet
+        property = finalize_multinet(st);
+        return;
     end
 
     if st.inputIsOr
@@ -281,15 +662,120 @@ function st = init_state()
     st = struct();
     st.sawVersion = false;
     st.sawNetwork = false;
+    st.sawAssert = false;
     st.unsupported = false;
     st.reason = '';
     st.hardStop = false;
+    st.netName = '';
     st.inName = ''; st.outName = '';
     st.inShape = []; st.outShape = [];
     st.inDim = []; st.outDim = [];
     st.lb = []; st.ub = []; st.haveBox = false;
     st.lbBoxes = {}; st.ubBoxes = {}; st.inputIsOr = false;
     st.propHs = {}; st.sawOutput = false;
+    % --- Phase 2: multi-network (equal-to) state ---
+    st.multinet = false;
+    st.netName2 = '';
+    st.inName2 = ''; st.outName2 = '';
+    st.inShape2 = []; st.outShape2 = [];
+    st.jointLb = []; st.jointUb = [];
+    st.jointC = []; st.jointd = [];
+    st.crossCells = {}; st.sawCrossOutput = false;
+end
+
+function property = finalize_multinet(st)
+    % Phase 2 finalization. UNSUPPORTED-BY-DEFAULT discipline: every gating
+    % assert already set st.unsupported (handled by the caller before we get
+    % here), so at this point all asserts parsed cleanly; what remains is to
+    % (a) require a cross-network output property,
+    % (b) CLOSE the joint box -- the g-block is typically bounded only THROUGH
+    %     the coupling rows (X_g == X_f componentwise, X_g[0] <= X_f[0], ...),
+    %     so propagate interval bounds through jointC*x <= jointd, and
+    % (c) refuse anything still unbounded / infeasible.
+    if ~st.sawCrossOutput || isempty(st.crossCells)
+        property = unsupported_property([], 'multi-network: no output property assertion found');
+        return;
+    end
+    if numel(st.crossCells) ~= 1
+        % accumulate_output keeps exactly one cell on success; defensive only
+        property = unsupported_property([], 'multi-network: output property is not a single disjunctive spec');
+        return;
+    end
+    [jlb, jub] = propagate_joint_bounds(st.jointLb, st.jointUb, st.jointC, st.jointd);
+    if any(isnan(jlb)) || any(isnan(jub))
+        property = unsupported_property([], 'multi-network: joint input box has an unbounded dimension (under-constrained)');
+        return;
+    end
+    if any(jlb > jub)
+        % constraints are infeasible; technically vacuously unsat, but we gate
+        % conservatively instead of emitting a verdict from an empty region
+        property = unsupported_property([], 'multi-network: joint input constraints are infeasible (empty box)');
+        return;
+    end
+    property = struct();
+    property.lb = [];     % single-network contract fields left EMPTY on purpose:
+    property.ub = [];     % legacy single-net consumers must not see a usable box
+    property.prop = {};
+    mn = struct();
+    mn.names = {st.netName, st.netName2};
+    mn.inShapes = {st.inShape, st.inShape2};
+    mn.outShapes = {st.outShape, st.outShape2};
+    mn.equivKind = 'equal';
+    mn.jointLb = jlb;
+    mn.jointUb = jub;
+    mn.jointC = st.jointC;
+    mn.jointd = st.jointd;
+    mn.crossProp = st.crossCells{1}.Hg;
+    property.multinet = mn;
+    property.unsupported = false;
+    property.reason = '';
+end
+
+function [lb, ub] = propagate_joint_bounds(lb, ub, C, d)
+    % Sound interval tightening of the joint box through the two-term coupling
+    % rows of C*x <= d (the parser only emits rows with exactly two +/-1
+    % entries; the algebra below is generic anyway). For a row
+    %       a_i*x_i + a_j*x_j <= d_r
+    % every feasible point satisfies a_i*x_i <= d_r - a_j*x_j, hence
+    %       a_i*x_i <= d_r - min_{x_j in [lb_j,ub_j]}(a_j*x_j)
+    % with min(a_j*x_j) = a_j*lb_j if a_j>0, else a_j*ub_j. Dividing by a_i:
+    %       a_i > 0  ->  x_i <= (d_r - min(a_j*x_j))/a_i   (an UPPER bound)
+    %       a_i < 0  ->  x_i >= (d_r - min(a_j*x_j))/a_i   (a  LOWER bound)
+    % NaN (unknown) bounds on x_j simply produce no tightening. Every derived
+    % bound is IMPLIED by box+rows, so the result still encloses the true
+    % constrained joint region (this can only shrink the box -- sound). Two-row
+    % `==` pairs propagate both directions, which is what closes the g-block.
+    % Monotone (bounds only shrink), so the fixed point exists; iteration is
+    % capped defensively and an early stop just leaves looser (still sound)
+    % bounds.
+    if isempty(C), return; end
+    maxIter = 8 + 2*size(C, 1);
+    iter = 0;
+    changed = true;
+    while changed && iter < maxIter
+        iter = iter + 1;
+        changed = false;
+        for r = 1:size(C, 1)
+            nz = find(C(r, :));
+            if numel(nz) ~= 2, continue; end   % only two-term rows are propagated
+            for s = 1:2
+                i = nz(s); j = nz(3-s);
+                ai = C(r, i); aj = C(r, j);
+                if aj > 0, mj = aj*lb(j); else, mj = aj*ub(j); end
+                if isnan(mj), continue; end
+                bnd = (d(r) - mj)/ai;
+                if ai > 0
+                    if isnan(ub(i)) || bnd < ub(i)
+                        ub(i) = bnd; changed = true;
+                    end
+                else
+                    if isnan(lb(i)) || bnd > lb(i)
+                        lb(i) = bnd; changed = true;
+                    end
+                end
+            end
+        end
+    end
 end
 
 % =========================================================================

--- a/code/nnv/engine/utils/multinet_product_net.m
+++ b/code/nnv/engine/utils/multinet_product_net.m
@@ -1,0 +1,71 @@
+function [prodNet, ok, reason] = multinet_product_net(nnvnet)
+    % [prodNet, ok, reason] = multinet_product_net(nnvnet)
+    %
+    % Build the weight-shared PRODUCT network for the VNN-LIB 2.0 multi-network
+    % `equal-to` case (both declare-network map to the SAME onnx, hence the same
+    % NNV net f):
+    %
+    %       h([x_f; x_g]) = [f(x_f); f(x_g)]
+    %
+    % so a SINGLE NNV reach over the stacked input Star keeps the f/g output
+    % correlation (shared predicates) that two independent reaches would lose
+    % (VNNLIB2_SUPPORT_PLAN.md section 3.1).
+    %
+    % LAYER WHITELIST (soundness, -150 rule): only layer types whose product
+    % construction is EXACTLY equivalent to running f on each half are accepted:
+    %
+    %   - FullyConnectedLayer (W [m x n], b [m x 1]): the stacked affine map is
+    %     the block diagonal
+    %         [W 0; 0 W] * [x1; x2] + [b; b] = [W*x1 + b; W*x2 + b]
+    %     i.e. blkdiag(W, W) with bias [b; b] -- exact, no approximation.
+    %   - ReluLayer: ReLU is ELEMENTWISE, so relu([x1; x2]) = [relu(x1); relu(x2)]
+    %     and the layer passes through unchanged (a fresh ReluLayer with the same
+    %     name is used to avoid sharing handle objects between two NN objects).
+    %
+    % Anything else (conv/pooling with spatial structure, normalization across
+    % features, softmax, attention, ...) is NOT stack-equivariant in this flat
+    % encoding -> ok = false, the caller must emit `unknown`.
+    %
+    % NOTE: the product net is assembled WITHOUT a Connections table (plain
+    % sequential execution of nnvnet.Layers in order). If the source network's
+    % Layers order were not its execution order, the product would diverge from
+    % f-applied-twice; verify_multinet guards this with a concrete
+    % evaluate-consistency cross-check before trusting any reach result.
+
+    prodNet = []; ok = false; reason = '';
+
+    if ~isa(nnvnet, 'NN')
+        reason = 'input is not an NN object'; return;
+    end
+    L = nnvnet.Layers;
+    if isempty(L) || ~iscell(L)
+        reason = 'network has no layer cell array'; return;
+    end
+
+    pL = cell(1, numel(L));
+    for i = 1:numel(L)
+        Li = L{i};
+        if isa(Li, 'FullyConnectedLayer')
+            if ~isempty(Li.weightPerturb)
+                reason = 'FullyConnectedLayer with weightPerturb is not supported in the product construction';
+                return;
+            end
+            W = double(Li.Weights);
+            b = double(Li.Bias); b = b(:);
+            if isempty(W) || size(W, 1) ~= numel(b)
+                reason = 'malformed FullyConnectedLayer (empty weights or bias mismatch)';
+                return;
+            end
+            pL{i} = FullyConnectedLayer([char(Li.Name) '_x2'], blkdiag(W, W), [b; b]);
+        elseif isa(Li, 'ReluLayer')
+            pL{i} = ReluLayer(char(Li.Name));
+        else
+            reason = ['unsupported layer for the product construction: ' class(Li)];
+            return;
+        end
+    end
+
+    prodNet = NN(pL);
+    prodNet.Name = [char(nnvnet.Name) '_product_x2'];
+    ok = true;
+end

--- a/code/nnv/engine/utils/verify_multinet.m
+++ b/code/nnv/engine/utils/verify_multinet.m
@@ -1,0 +1,237 @@
+function [status, counterEx] = verify_multinet(nnvnet, property, reachOptions)
+    % [status, counterEx] = verify_multinet(nnvnet, property, reachOptions)
+    %
+    % Verify a VNN-LIB 2.0 multi-network `equal-to` property (property.multinet
+    % as produced by load_vnnlib2, Phase 2) on ONE shared network: `equal-to`
+    % means both declared networks are the SAME model, evaluated on two inputs
+    % coupled by property.multinet.jointC/jointd.
+    %
+    % Inputs:
+    %   nnvnet       - the (single, shared) NN object
+    %   property     - load_vnnlib2 output with property.multinet present
+    %   reachOptions - NNV reach options struct; defaults to
+    %                  struct('reachMethod','exact-star') (plan section 3.1:
+    %                  approx-star decorrelates Y_f/Y_g and typically yields
+    %                  unknown; exact-star keeps the joint correlation)
+    %
+    % Outputs (VNN-COMP convention, mirrors run_vnncomp_instance):
+    %   status    = 0 -> sat: counterexample found AND validated by evaluating
+    %                    the ORIGINAL network on both halves + replaying ALL
+    %                    parsed input constraints on the concrete pair
+    %             = 1 -> unsat: the joint product-net reach set is provably
+    %                    disjoint from the unsafe cross-network region
+    %             = 2 -> unknown: anything else (non-whitelisted layer, shape
+    %                    mismatch, any thrown error, any doubt)
+    %   counterEx = {x_f, x_g} (flat column vectors, parser row-major ONNX
+    %               order) when status == 0; [] otherwise.
+    %
+    % SOUNDNESS (-150 rule): every path defaults to unknown. The whole body is
+    % wrapped in try/catch; a verdict is only emitted from the two defensible
+    % paths above. Reach returning "intersection nonempty" is NOT promoted to
+    % sat (even under exact-star) because that would require extracting and
+    % replay-validating a concrete witness from the intersecting star.
+
+    status = 2; counterEx = [];
+    if nargin < 3 || isempty(reachOptions) || ~isstruct(reachOptions)
+        reachOptions = struct('reachMethod', 'exact-star');
+    end
+    if ~isfield(reachOptions, 'reachMethod') || isempty(reachOptions.reachMethod)
+        % NN.validate_reach_options reads reachMethod unconditionally
+        reachOptions.reachMethod = 'exact-star';
+    end
+    try
+        [status, counterEx] = verify_multinet_impl(nnvnet, property, reachOptions);
+    catch
+        % ANY error -> unknown (never let an exception escape into the runner)
+        status = 2; counterEx = [];
+    end
+end
+
+% =========================================================================
+
+function [status, counterEx] = verify_multinet_impl(nnvnet, property, reachOptions)
+    status = 2; counterEx = [];
+
+    % ---- 1) layer whitelist FIRST (and product-net assembly) ---------------
+    % every layer must be FullyConnectedLayer or ReluLayer; anything else
+    % cannot be soundly stacked -> unknown immediately
+    [prodNet, okp] = multinet_product_net(nnvnet);
+    if ~okp
+        return;
+    end
+
+    % ---- 2) property validation (anything off -> unknown) ------------------
+    if ~isstruct(property) || ~isfield(property, 'multinet'), return; end
+    if isfield(property, 'unsupported') && property.unsupported, return; end
+    mn = property.multinet;
+    req = {'names', 'inShapes', 'outShapes', 'equivKind', 'jointLb', 'jointUb', ...
+           'jointC', 'jointd', 'crossProp'};
+    for k = 1:numel(req)
+        if ~isfield(mn, req{k}), return; end
+    end
+    if ~strcmp(mn.equivKind, 'equal')
+        % isomorphic-to (different weights) must NEVER fall through to the
+        % equal-to falsifier/product: g is a DIFFERENT network there
+        return;
+    end
+    jlb = double(mn.jointLb(:)); jub = double(mn.jointUb(:));
+    twoN = numel(jlb);
+    if twoN == 0 || numel(jub) ~= twoN || mod(twoN, 2) ~= 0, return; end
+    if any(~isfinite(jlb)) || any(~isfinite(jub)) || any(jlb > jub), return; end
+    n = twoN/2;
+    if prod(mn.inShapes{1}) ~= n || prod(mn.inShapes{2}) ~= n, return; end
+    outDim = prod(mn.outShapes{1});
+    if outDim < 1 || prod(mn.outShapes{2}) ~= outDim, return; end
+    Cj = double(mn.jointC); dj = double(mn.jointd(:));
+    if isempty(Cj)
+        Cj = zeros(0, twoN); dj = zeros(0, 1);
+    end
+    if size(Cj, 2) ~= twoN || size(Cj, 1) ~= numel(dj), return; end
+    hs = mn.crossProp;
+    if isempty(hs) || ~isa(hs, 'HalfSpace'), return; end
+    for h = 1:numel(hs)
+        if size(hs(h).G, 2) ~= 2*outDim || size(hs(h).G, 1) ~= numel(hs(h).g)
+            return;
+        end
+    end
+    % network I/O widths must match the spec (first FC consumes the input,
+    % last FC produces the output -- whitelist guarantees both exist)
+    fcIdx = find(cellfun(@(L) isa(L, 'FullyConnectedLayer'), nnvnet.Layers));
+    if isempty(fcIdx), return; end
+    if nnvnet.Layers{fcIdx(1)}.InputSize ~= n, return; end
+    if nnvnet.Layers{fcIdx(end)}.OutputSize ~= outDim, return; end
+
+    % ---- 3) falsification FIRST (sound, validated sat witness) -------------
+    % rejection-sample the joint box; jointC/jointd constrain the CONCRETE
+    % stacked x = [x_f; x_g] DIRECTLY (parser convention -- see
+    % apply_mn_input_expr in load_vnnlib2.m), so feasibility is checked on x
+    % itself, NOT on star predicates. `==` couplings are measure-zero under
+    % box sampling, so detected equality pairs are REPAIRED algebraically
+    % before the feasibility check (the repaired x satisfies them exactly).
+    nSamples = 1000;
+    if isfield(reachOptions, 'falsifySamples') && ~isempty(reachOptions.falsifySamples)
+        nSamples = reachOptions.falsifySamples;
+    end
+    [eqP, eqQ, eqCP, eqCQ, eqD] = detect_equality_pairs(Cj, dj);
+    for s = 1:nSamples
+        x = jlb + rand(twoN, 1).*(jub - jlb);
+        % repair two-term equality couplings: a_p*x_p + a_q*x_q = d
+        %   -> x_q = (d - a_p*x_p)/a_q  (exact for the parser's +/-1 rows)
+        for k = 1:numel(eqP)
+            x(eqQ(k)) = (eqD(k) - eqCP(k)*x(eqP(k)))/eqCQ(k);
+        end
+        if any(x < jlb) || any(x > jub), continue; end      % repair left the box
+        if ~isempty(Cj) && any(Cj*x > dj), continue; end    % infeasible -> reject
+        xf = x(1:n); xg = x(n+1:end);
+        yf = double(nnvnet.evaluate(xf)); yf = yf(:);
+        yg = double(nnvnet.evaluate(xg)); yg = yg(:);
+        if numel(yf) ~= outDim || numel(yg) ~= outDim
+            return;   % network output does not match the declared shape -> unknown
+        end
+        y = [yf; yg];
+        for h = 1:numel(hs)
+            % STRICT interior check (G*y < g componentwise): crossProp stores
+            % the <=-relaxation of possibly-STRICT asserts, so a boundary point
+            % (G*y == g) could fail the original strict assert on the official
+            % witness replay. Requiring strict interiority is sound (at most we
+            % miss boundary witnesses -> fall through to reach/unknown).
+            if all(double(hs(h).G)*y - double(hs(h).g) < 0)
+                status = 0;
+                counterEx = {xf, xg};
+                return;
+            end
+        end
+    end
+
+    % ---- 4) product-net consistency cross-check ----------------------------
+    % the unsat path trusts h([xf;xg]) == [f(xf); f(xg)]; verify it CONCRETELY
+    % on a few box samples (no feasibility needed -- evaluation equivalence
+    % must hold pointwise everywhere). Guards layer-order/Connections quirks.
+    for t = 1:3
+        x = jlb + rand(twoN, 1).*(jub - jlb);
+        y1 = double(nnvnet.evaluate(x(1:n)));
+        y2 = double(nnvnet.evaluate(x(n+1:end)));
+        yref = [y1(:); y2(:)];
+        yprod = double(prodNet.evaluate(x)); yprod = yprod(:);
+        if numel(yprod) ~= numel(yref) || norm(yprod - yref) > 1e-4*max(1, norm(yref))
+            return;   % product does not replicate f twice -> unknown
+        end
+    end
+
+    % ---- 5) joint input Star ------------------------------------------------
+    % Star(lb, ub) (via Box.toStar) builds  x = c + G*alpha  with
+    %     c = (lb+ub)/2 = V(:,1),
+    %     G = V(:,2:end) = diag((ub-lb)/2) with all-zero (PINNED, lb==ub)
+    %         columns REMOVED,
+    %     alpha in [-1, 1]^m  (m = number of non-degenerate dims).
+    % So alpha is NOT the raw input offset: it is scaled by the half-width and
+    % pinned dims have no predicate at all. The parser's jointC/jointd
+    % constrain the CONCRETE x; substituting x = c + G*alpha gives the
+    % predicate-space constraints to append:
+    %     jointC*x <= jointd  <=>  (jointC*G)*alpha <= jointd - jointC*c
+    % Composing through S0.V (instead of assuming x = c + I*alpha) keeps the
+    % algebra correct regardless of which columns Box dropped.
+    S0 = Star(jlb, jub);
+    c0 = double(S0.V(:, 1));
+    G0 = double(S0.V(:, 2:end));
+    Ca = Cj*G0;
+    da = dj - Cj*c0;
+    % rows whose variables are all pinned map to all-zero alpha rows
+    % (0*alpha <= da(r)):
+    %   da(r) >= 0 -> trivially true, drop the row;
+    %   da(r) <  0 -> the input region is empty; technically a vacuous unsat
+    %                 but we refuse to claim a verdict from an empty region
+    zr = ~any(Ca, 2);
+    if any(da(zr) < 0)
+        return;
+    end
+    Ca = Ca(~zr, :); da = da(~zr);
+    S = Star(double(S0.V), [double(S0.C); Ca], [double(S0.d); da], ...
+             double(S0.predicate_lb), double(S0.predicate_ub));
+
+    % ---- 6) joint reach + spec check ----------------------------------------
+    R = prodNet.reach(S, reachOptions);
+    spec = struct();
+    spec.Hg = hs;   % field assignment (struct('Hg', hs) would explode an hs array)
+    res = verify_specification(R, {spec});
+    if res == 1
+        % reach set (exact or over-approximate -- both sound for this
+        % direction) does not intersect the unsafe cross region -> unsat
+        status = 1;
+    else
+        % res == 2 is NOT promoted to sat even under exact-star: that would
+        % require extracting a concrete witness from the intersecting star and
+        % replay-validating it. Stay unknown.
+        status = 2;
+    end
+end
+
+% =========================================================================
+
+function [eqP, eqQ, eqCP, eqCQ, eqD] = detect_equality_pairs(Cj, dj)
+    % find two-row inequality pairs encoding equalities: rows (i, j) with
+    % Cj(j,:) == -Cj(i,:) and dj(j) == -dj(i) represent  Cj(i,:)*x == dj(i).
+    % Only two-term rows are returned (the parser emits exactly those); the
+    % falsifier uses them to repair sampled points onto the equality manifold.
+    eqP = zeros(0, 1); eqQ = zeros(0, 1);
+    eqCP = zeros(0, 1); eqCQ = zeros(0, 1); eqD = zeros(0, 1);
+    m = size(Cj, 1);
+    used = false(m, 1);
+    for i = 1:m
+        if used(i), continue; end
+        nzi = find(Cj(i, :));
+        if numel(nzi) ~= 2, continue; end
+        for j = i+1:m
+            if used(j), continue; end
+            if isequal(Cj(j, :), -Cj(i, :)) && dj(j) == -dj(i)
+                used(i) = true; used(j) = true;
+                eqP(end+1, 1) = nzi(1);          %#ok<AGROW>
+                eqQ(end+1, 1) = nzi(2);          %#ok<AGROW>
+                eqCP(end+1, 1) = Cj(i, nzi(1));  %#ok<AGROW>
+                eqCQ(end+1, 1) = Cj(i, nzi(2));  %#ok<AGROW>
+                eqD(end+1, 1) = dj(i);           %#ok<AGROW>
+                break;
+            end
+        end
+    end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -41,7 +41,7 @@ end
 property = load_vnnlib(vnnlib);
 
 % VNN-LIB 2.0 gate: load_vnnlib2 (dispatched for 2.0 files) flags any construct NNV
-% cannot soundly verify -- multi-network (equal-to/isomorphic-to), nonlinear/arithmetic
+% cannot soundly verify -- 3+ networks / isomorphic-to, nonlinear/arithmetic
 % output, multimodal (>1 input tensor), declare-hidden, mixed input/output disjunction.
 % Emit `unknown` (0 points) rather than parse it unsoundly and risk a -150 wrong
 % verdict. (1.0 properties never set this field, so this is a no-op for them.)
@@ -49,6 +49,22 @@ if isfield(property, 'unsupported') && property.unsupported
     if isfield(property, 'reason') && ~isempty(property.reason)
         fprintf('vnnlib 2.0 unsupported -> unknown: %s\n', property.reason);
     end
+    status = 2;
+    tTime = toc(t);
+    fid = fopen(outputfile, 'w');
+    fprintf(fid, 'unknown \n');
+    fclose(fid);
+    return;
+end
+
+% Phase 2 guard: a clean multi-network `equal-to` pair parses into
+% property.multinet (unsupported = false) with the single-network fields
+% lb/ub/prop intentionally EMPTY. The runner plumbing for it (python-tuple onnx
+% list in instances.csv, product-net dispatch -- plan Phase 3c) is not wired
+% yet, so emit `unknown` rather than fall through to the single-network path.
+% Verification entry point for these properties: engine/utils/verify_multinet.m.
+if isfield(property, 'multinet')
+    fprintf('vnnlib 2.0 multi-network (equal-to) property parsed -> unknown: runner wiring is Phase 3c (see verify_multinet.m)\n');
     status = 2;
     tTime = toc(t);
     fid = fopen(outputfile, 'w');

--- a/code/nnv/tests/utils/test_vnnlib2_multinet.m
+++ b/code/nnv/tests/utils/test_vnnlib2_multinet.m
@@ -1,0 +1,259 @@
+function tests = test_vnnlib2_multinet
+%TEST_VNNLIB2_MULTINET  Phase 2 (VNN-LIB 2.0 multi-network `equal-to`) tests:
+%   (a) load_vnnlib2 parses a monotonic_acasxu-style two-network spec into
+%       property.multinet: joint stacked box (g-block bounds CLOSED by interval
+%       propagation through the coupling rows), jointC/jointd coupling rows over
+%       the CONCRETE stacked input, and the cross-network unsafe HalfSpace with
+%       the single-net polarity convention (asserted comparison maps DIRECTLY
+%       into G*y <= g -- no negation; see mn_linear_two_terms);
+%   (b) multinet_product_net builds the weight-shared product net (blkdiag
+%       weights, stacked bias, pass-through ReLU) and the product evaluates
+%       EXACTLY like running f on each half;
+%   (c) verify_multinet soundly refuses (status 2) non-whitelisted layers and
+%       non-`equal` equivalence kinds -- the -150 guard.
+%
+%   Gating discipline: property.unsupported stays true unless EVERY assert
+%   parsed cleanly AND the joint box closed, so under-constrained / 3-network /
+%   isomorphic-to / shape-mismatched files all stay `unknown`.
+%
+%   Self-contained (inline temp specs, hand-built tiny nets); no reach / LP
+%   solver is exercised, so this runs fast in CI.
+%
+%   To run: results = runtests('test_vnnlib2_multinet')
+    tests = functiontests(localfunctions);
+end
+
+% ---------- (a) parser: monotonic_acasxu-style equal-to pair ----------
+
+function test_multinet_parse_monotonic_style(tc)
+    % two 5-d networks, equal-to; box on X_f; == couplings X_f[i]=X_g[i] for
+    % i~=0; X_f[0] >= X_g[0] (+ lower bound on X_g[0]); output (< Y_f[3] Y_g[3])
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [5]) (declare-output Y_f real [5]))', ...
+        '(declare-network g (equal-to f) (declare-input X_g real [5]) (declare-output Y_g real [5]))', ...
+        '(assert (and (<= X_f[0] 0.6) (>= X_f[0] -0.1)))', ...
+        '(assert (and (<= X_f[1] 0.0) (>= X_f[1] -0.25)))', ...
+        '(assert (and (<= X_f[2] 0.5) (>= X_f[2] 0.25)))', ...
+        '(assert (== X_f[3] 0.2))', ...
+        '(assert (== X_f[4] 0.25))', ...
+        '(assert (and (>= X_f[0] X_g[0]) (>= X_g[0] -0.1)))', ...
+        '(assert (== X_f[1] X_g[1]))', ...
+        '(assert (== X_f[2] X_g[2]))', ...
+        '(assert (== X_f[3] X_g[3]))', ...
+        '(assert (== X_f[4] X_g[4]))', ...
+        '(assert (< Y_f[3] Y_g[3]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyFalse(tc, is_unsupported(property), 'clean equal-to pair must parse as supported');
+    verifyTrue(tc, isfield(property, 'multinet'));
+    mn = property.multinet;
+    verifyEqual(tc, mn.names, {'f', 'g'});
+    verifyEqual(tc, mn.equivKind, 'equal');
+    verifyEqual(tc, mn.inShapes{1}, 5);
+    verifyEqual(tc, mn.inShapes{2}, 5);
+    verifyEqual(tc, mn.outShapes{1}, 5);
+    verifyEqual(tc, mn.outShapes{2}, 5);
+
+    % joint box (10x1, f-block then g-block). The g-block has NO direct bounds
+    % except lb(X_g[0]); everything else must be PROPAGATED through the
+    % couplings: X_g[0] <= X_f[0] <= 0.6 and X_g[i] == X_f[i] for i = 1..4.
+    expLb = [-0.1; -0.25; 0.25; 0.2; 0.25; -0.1; -0.25; 0.25; 0.2; 0.25];
+    expUb = [ 0.6;  0.0;  0.5; 0.2; 0.25;  0.6;  0.0;  0.5; 0.2; 0.25];
+    verifyEqual(tc, size(mn.jointLb), [10 1]);
+    verifyEqual(tc, size(mn.jointUb), [10 1]);
+    verifyEqual(tc, double(mn.jointLb), expLb, 'AbsTol', 1e-6);
+    verifyEqual(tc, double(mn.jointUb), expUb, 'AbsTol', 1e-6);
+
+    % coupling rows over the CONCRETE stacked x = [X_f; X_g]:
+    % 1 row from (>= X_f[0] X_g[0]) + 2 rows per == coupling (4 of them) = 9
+    verifyEqual(tc, size(mn.jointC), [9 10]);
+    verifyEqual(tc, double(mn.jointd), zeros(9, 1), 'AbsTol', 1e-12);
+    % (>= X_f[0] X_g[0])  ->  -x_f0 + x_g0 <= 0  (ONE row)
+    verifyEqual(tc, double(mn.jointC(1, :)), [-1 0 0 0 0 1 0 0 0 0], 'AbsTol', 1e-12);
+    % (== X_f[1] X_g[1])  ->  TWO-row inequality pair (x_f1 - x_g1 <= 0, and its negation)
+    verifyEqual(tc, double(mn.jointC(2, :)), [0 1 0 0 0 0 -1 0 0 0], 'AbsTol', 1e-12);
+    verifyEqual(tc, double(mn.jointC(3, :)), [0 -1 0 0 0 0 1 0 0 0], 'AbsTol', 1e-12);
+    % remaining pairs follow the same two-row pattern for dims 2, 3, 4
+    verifyEqual(tc, double(mn.jointC(4, :)), [0 0 1 0 0 0 0 -1 0 0], 'AbsTol', 1e-12);
+    verifyEqual(tc, double(mn.jointC(8, :)), [0 0 0 0 1 0 0 0 0 -1], 'AbsTol', 1e-12);
+
+    % cross-network UNSAFE region over the stacked [Y_f; Y_g]: VNN-LIB asserts
+    % encode the sat/counterexample region ITSELF, so (< Y_f[3] Y_g[3]) maps
+    % DIRECTLY (strict relaxed to <=) to  Y_f[3] - Y_g[3] <= 0:
+    %   +1 at stacked col 4 (Y_f[3]), -1 at stacked col 9 (Y_g[3]), g = 0.
+    % (Same convention as the single-net (<= Y[a] Y[b]) -> G(a+1)=+1,G(b+1)=-1.)
+    verifyEqual(tc, numel(mn.crossProp), 1);
+    expG = zeros(1, 10); expG(4) = 1; expG(9) = -1;
+    verifyEqual(tc, double(mn.crossProp(1).G), expG, 'AbsTol', 1e-12, ...
+        'polarity must mirror the single-net direct-mapping convention');
+    verifyEqual(tc, double(mn.crossProp(1).g), 0, 'AbsTol', 1e-12);
+
+    % legacy single-network contract fields must be unusable (runner wiring for
+    % multinet is Phase 3c; nothing may mistake this for a single-net box)
+    verifyTrue(tc, isempty(property.lb) && isempty(property.ub) && isempty(property.prop));
+end
+
+% ---------- (a) parser: sound gating ----------
+
+function test_multinet_gate_isomorphic(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [2]) (declare-output Y_f real [2]))', ...
+        '(declare-network g (isomorphic-to f) (declare-input X_g real [2]) (declare-output Y_g real [2]))', ...
+        '(assert (and (<= X_f[0] 1.0) (>= X_f[0] -1.0)))', ...
+        '(assert (== X_f[0] X_g[0]))', ...
+        '(assert (< Y_f[0] Y_g[0]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'isomorphic-to (different weights) must stay gated');
+end
+
+function test_multinet_gate_three_networks(tc)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [2]) (declare-output Y_f real [2]))', ...
+        '(declare-network g (equal-to f) (declare-input X_g real [2]) (declare-output Y_g real [2]))', ...
+        '(declare-network h (equal-to f) (declare-input X_h real [2]) (declare-output Y_h real [2]))', ...
+        '(assert (< Y_f[0] Y_g[0]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'three declare-network must stay gated');
+end
+
+function test_multinet_gate_unbounded_joint_box(tc)
+    % couplings + output only, NO box on X_f: propagation cannot close the
+    % joint box -> unsupported stays true (the unsupported-by-default rule)
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [5]) (declare-output Y_f real [5]))', ...
+        '(declare-network g (equal-to f) (declare-input X_g real [5]) (declare-output Y_g real [5]))', ...
+        '(assert (>= X_f[0] X_g[0]))', ...
+        '(assert (< Y_f[3] Y_g[3]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'unbounded joint box must stay gated');
+end
+
+function test_multinet_gate_shape_mismatch(tc)
+    % equal-to requires identical shapes (2.0 standard); [5] vs [4] must gate
+    tf = write_vnnlib2({ ...
+        '(vnnlib-version <2.0>)', ...
+        '(declare-network f (declare-input X_f real [5]) (declare-output Y_f real [5]))', ...
+        '(declare-network g (equal-to f) (declare-input X_g real [4]) (declare-output Y_g real [5]))', ...
+        '(assert (< Y_f[3] Y_g[3]))'});
+    property = load_vnnlib2(tf); delete(tf);
+    verifyTrue(tc, is_unsupported(property), 'equal-to with mismatched shapes must stay gated');
+end
+
+% ---------- (b) product net: blkdiag construction + evaluate consistency ----------
+
+function test_product_net_blkdiag(tc)
+    [f, W1, b1, W2, b2] = tiny_fc_relu_net();
+    [h, ok] = multinet_product_net(f);
+    verifyTrue(tc, ok, 'FC+ReLU net must be whitelisted');
+    verifyEqual(tc, numel(h.Layers), 4);
+    % each FC becomes blkdiag(W, W) with stacked bias [b; b]
+    verifyEqual(tc, h.Layers{1}.Weights, blkdiag(W1, W1));
+    verifyEqual(tc, h.Layers{1}.Bias, [b1; b1]);
+    verifyEqual(tc, h.Layers{3}.Weights, blkdiag(W2, W2));
+    verifyEqual(tc, h.Layers{3}.Bias, [b2; b2]);
+    % ReLU passes through unchanged (elementwise on the stacked vector)
+    verifyTrue(tc, isa(h.Layers{2}, 'ReluLayer'));
+    verifyTrue(tc, isa(h.Layers{4}, 'ReluLayer'));
+end
+
+function test_product_net_evaluate_consistency(tc)
+    % h([x1; x2]) must equal [f(x1); f(x2)] -- the product is EXACT, not an
+    % approximation (fixed deterministic probe points, incl. ReLU sign flips)
+    f = tiny_fc_relu_net();
+    h = multinet_product_net(f);
+    probes = { [ 1.0; -1.0], [ 0.3;  2.0]; ...
+               [-0.5; -0.25], [ 2.0;  0.1]; ...
+               [ 0.0;  0.0], [-1.5;  1.5]; ...
+               [ 0.7;  0.7], [ 0.7;  0.7] };
+    for p = 1:size(probes, 1)
+        x1 = probes{p, 1}; x2 = probes{p, 2};
+        y = h.evaluate([x1; x2]);
+        yref = [f.evaluate(x1); f.evaluate(x2)];
+        verifyEqual(tc, y, yref, 'AbsTol', 1e-12, ...
+            'product net must replicate f on each half of the stacked input');
+    end
+end
+
+function test_product_net_rejects_non_whitelisted(tc)
+    net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), TanhLayer()});
+    [~, ok, reason] = multinet_product_net(net);
+    verifyFalse(tc, ok, 'TanhLayer must not be whitelisted');
+    verifyTrue(tc, contains(reason, 'TanhLayer'));
+end
+
+% ---------- (c) verify_multinet: sound refusals ----------
+
+function test_verify_multinet_whitelist_gate(tc)
+    % a net with a non-whitelisted layer must return unknown (2) IMMEDIATELY
+    % (whitelist runs before falsification and reach)
+    net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), TanhLayer()});
+    property = hand_built_multinet_property('equal');
+    [status, counterEx] = verify_multinet(net, property, struct('reachMethod', 'approx-star'));
+    verifyEqual(tc, status, 2, 'non-whitelisted layer (TanhLayer) must yield unknown');
+    verifyTrue(tc, isempty(counterEx));
+end
+
+function test_verify_multinet_equivkind_gate(tc)
+    % equivKind ~= 'equal' (e.g. isomorphic-to) must NEVER reach the equal-to
+    % falsifier/product path (g would be a DIFFERENT network) -> unknown
+    net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), ReluLayer('relu1')});
+    property = hand_built_multinet_property('isomorphic');
+    [status, counterEx] = verify_multinet(net, property, struct('reachMethod', 'approx-star'));
+    verifyEqual(tc, status, 2, 'equivKind isomorphic must yield unknown');
+    verifyTrue(tc, isempty(counterEx));
+end
+
+function test_verify_multinet_missing_multinet_gate(tc)
+    % a property without the .multinet payload (e.g. single-net or gated parse)
+    % must yield unknown, never a verdict
+    net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), ReluLayer('relu1')});
+    property = struct('unsupported', false, 'lb', [], 'ub', [], 'prop', {{}});
+    [status, counterEx] = verify_multinet(net, property, struct('reachMethod', 'approx-star'));
+    verifyEqual(tc, status, 2);
+    verifyTrue(tc, isempty(counterEx));
+end
+
+% ---------- helpers ----------
+
+function [f, W1, b1, W2, b2] = tiny_fc_relu_net()
+    % tiny 2-2-2 FC+ReLU network built by hand
+    W1 = [1 -2; 0.5 1]; b1 = [0.1; -0.2];
+    W2 = [1 1; -1 2];   b2 = [0; 0.3];
+    f = NN({FullyConnectedLayer('fc1', W1, b1), ReluLayer('relu1'), ...
+            FullyConnectedLayer('fc2', W2, b2), ReluLayer('relu2')});
+end
+
+function property = hand_built_multinet_property(equivKind)
+    % minimal well-formed property.multinet for two 2-d nets (joint dim 4)
+    mn = struct();
+    mn.names = {'f', 'g'};
+    mn.inShapes = {2, 2};
+    mn.outShapes = {2, 2};
+    mn.equivKind = equivKind;
+    mn.jointLb = -ones(4, 1);
+    mn.jointUb = ones(4, 1);
+    mn.jointC = zeros(0, 4);
+    mn.jointd = zeros(0, 1);
+    mn.crossProp = HalfSpace([1 0 -1 0], 0);
+    property = struct();
+    property.lb = []; property.ub = []; property.prop = {};
+    property.unsupported = false;
+    property.reason = '';
+    property.multinet = mn;
+end
+
+function tf = write_vnnlib2(lines)
+    tf = [tempname '.vnnlib'];
+    fid = fopen(tf, 'w');
+    for k = 1:numel(lines)
+        fprintf(fid, '%s\n', lines{k});
+    end
+    fclose(fid);
+end
+
+function u = is_unsupported(p)
+    u = isfield(p, 'unsupported') && p.unsupported;
+end


### PR DESCRIPTION
## What

VNN-LIB 2.0 **Phase 2 foundation** (per `VNNLIB2_SUPPORT_PLAN.md` §3.1): parse `equal-to` two-network specs (monotonic_acasxu_2026 shape) into a structured `property.multinet` instead of a blanket gate, plus a **sound product-net verifier**.

- `load_vnnlib2.m`: two `declare-network` with `(equal-to)` + matching shapes → `property.multinet` = {names, shapes, jointLb/jointUb (stacked box, closed by a sound interval-propagation fixed point through the coupling rows), jointC/jointd (cross-input constraints; `==` → row pairs), crossProp (HalfSpace over stacked [Y_f;Y_g])}. Everything else still gates (3+ nets, isomorphic-to, mismatch, nonlinear, unclosed box → `unsupported`).
- `multinet_product_net.m`: weight-shared product via `blkdiag(W,W)`/[b;b] for FC, ReLU pass-through — **whitelist-gated**, refuses anything else.
- `verify_multinet.m`: falsification-first (rejection sampling with ==-repair, witness validated on the ORIGINAL net, strict-interior check) → joint Star (x-space → α-space constraint mapping documented) → reach + verify_specification. Every error path → `unknown`.
- Runner guard: a parsed multinet property emits `unknown` until Phase-3c dispatch wiring — **competition behavior is unchanged** (monotonic scored unknown before via the gate, scores unknown now via the guard).

## Validation (MATLAB, local)

- `test_vnnlib2_multinet.m`: **11/11 pass** (parser values on a monotonic-style spec incl. exact propagated box + coupling-row signs; 4 gating tests; product blkdiag + evaluate-consistency; verifier refusals).
- Single-net regression: `test_load_vnnlib2` **13/13 pass** (single-network paths untouched).
- **Real spec E2E**: `monotonic_acasxu_2026/2.0/instance_0` parses to the expected 10×1 joint box, 9 coupling rows, 2-term crossProp; `verify_multinet` on the real imported acasxu net **fails closed** (instant `unknown` — net has ImageInput/Flatten/ElementwiseAffine beyond the FC+ReLU whitelist, all sound-refusable today, all affine and productizable as a follow-up).

## Notes for review

- **Polarity**: the unsafe region = the asserted region directly (mirrors the single-net parser + official witness-replay semantics); derivation documented in `mn_linear_two_terms`. The plan doc's §3.1 sketch had the negated form — the code follows the parser convention, which is the one the official checker validates witnesses against.
- Follow-ups (not in this PR): whitelist extension to ImageInput/Flatten/ElementwiseAffine (unlocks real acasxu monotonic verdicts), Phase-3c runner dispatch + tuple instances.csv parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)