### PR TITLE
fix(sweep): kill zombie workers on timeout + cold-start grace (fixes malbeware job death)

### DIFF
--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -161,7 +161,7 @@ jobs:
         if: ${{ contains(matrix.folder, 'lsnc_relu') || contains(matrix.folder, 'traffic_signs') || contains(matrix.folder, 'cgan') || contains(matrix.folder, 'soundnessbench') }}
         shell: bash
         run: |
-          python3 -m pip install --quiet onnx==1.20.0 onnxruntime==1.23.1 numpy scipy
+          python3 -m pip install --quiet onnx==1.20.0 onnxruntime==1.23.1 numpy scipy onnxsim onnxoptimizer
           BENCH="$GITHUB_WORKSPACE/vnncomp2025_benchmarks/${{ github.event.inputs.benchmarks_subdir }}/${{ matrix.folder }}"
           shopt -s nullglob
           # The 2026 benchmark set ships ONNX GZIPPED (<model>.onnx.gz). The manifest glob

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -109,6 +109,14 @@ results = cell(0, 8);   % grows per instance (all-instances mode -> count unknow
 existing_pool = gcp('nocreate');
 if ~isempty(existing_pool), delete(existing_pool); end
 pool = parpool('Processes', 1);   % 1 worker avoids the 16-vs-N config error
+% A FRESH Processes worker pays a large one-time cost on its first instance
+% (worker init + ONNX-importer custom-layer codegen): measured ~100 s even for a
+% model that solves in 9 s warm. Grant that first instance a one-time grace so
+% cold-start cannot masquerade as a solver timeout. The flag is tied to POOL
+% lifetime: set here (job start) and after every timeout-triggered pool restart
+% -- NOT reset per benchmark folder. Recorded time_s is still true wall time.
+cold_grace_s = 120;
+pool_is_cold = true;
 
 % --- Iterate ---
 for i = 1:n
@@ -155,19 +163,12 @@ for i = 1:n
         continue;
     end
     fprintf('  %d instance(s) [%s]\n', numel(pairs), run_which);
-    % A FRESH Processes worker pays a large one-time cost on its first instance
-    % (worker init + ONNX-importer custom-layer codegen): measured ~100 s even for
-    % a model that solves in 9 s warm. Grant that first instance a one-time grace
-    % so cold-start cannot masquerade as a solver timeout. Applies to the job's
-    % first instance and to the first instance after every timeout-triggered pool
-    % restart. The recorded time_s is still the true wall time.
-    cold_grace_s = 120;
-    pool_is_cold = true;
     for k = 1:numel(pairs)
         pr = pairs{k};
         out_file = [tempname '.txt'];
         t0 = tic;
         f = parfeval(pool, @run_vnncomp_instance, 2, cat, pr.onnx, pr.vnnlib, out_file);
+        was_cold = pool_is_cold;   % for accurate timeout reporting below
         ok = wait(f, 'finished', timeout_s + cold_grace_s*pool_is_cold);
         pool_is_cold = false;
         if ok
@@ -185,7 +186,7 @@ for i = 1:n
         else
             cancel(f);
             status = -1; status_str = 'timeout';
-            err = sprintf('exceeded %d s', timeout_s);
+            err = sprintf('exceeded %d s', timeout_s + cold_grace_s*was_cold);
             % cancel() CANNOT interrupt a BUSY worker (it only de-schedules queued
             % futures): the zombie keeps grinding the timed-out reach while the next
             % parfeval queues BEHIND it -- cascading false timeouts plus unbounded
@@ -196,7 +197,11 @@ for i = 1:n
             % ~15 s restart cost applies only on timeouts.
             try
                 delete(pool);
-            catch
+            catch ME_pool
+                % restarting the pool is the zombie-kill mechanism; if delete
+                % fails we still attempt the restart, but say so loudly
+                fprintf('WARN: pool delete failed (%s); attempting restart anyway
+', ME_pool.message);
             end
             pool = parpool('Processes', 1);
             pool_is_cold = true;   % next instance gets the one-time cold-start grace

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -155,12 +155,21 @@ for i = 1:n
         continue;
     end
     fprintf('  %d instance(s) [%s]\n', numel(pairs), run_which);
+    % A FRESH Processes worker pays a large one-time cost on its first instance
+    % (worker init + ONNX-importer custom-layer codegen): measured ~100 s even for
+    % a model that solves in 9 s warm. Grant that first instance a one-time grace
+    % so cold-start cannot masquerade as a solver timeout. Applies to the job's
+    % first instance and to the first instance after every timeout-triggered pool
+    % restart. The recorded time_s is still the true wall time.
+    cold_grace_s = 120;
+    pool_is_cold = true;
     for k = 1:numel(pairs)
         pr = pairs{k};
         out_file = [tempname '.txt'];
         t0 = tic;
         f = parfeval(pool, @run_vnncomp_instance, 2, cat, pr.onnx, pr.vnnlib, out_file);
-        ok = wait(f, 'finished', timeout_s);
+        ok = wait(f, 'finished', timeout_s + cold_grace_s*pool_is_cold);
+        pool_is_cold = false;
         if ok
             if isempty(f.Error)
                 try
@@ -177,6 +186,20 @@ for i = 1:n
             cancel(f);
             status = -1; status_str = 'timeout';
             err = sprintf('exceeded %d s', timeout_s);
+            % cancel() CANNOT interrupt a BUSY worker (it only de-schedules queued
+            % futures): the zombie keeps grinding the timed-out reach while the next
+            % parfeval queues BEHIND it -- cascading false timeouts plus unbounded
+            % CPU/memory growth. This is what killed the malbeware sweep runners
+            % (~50 scaled_16 instances need ~370 s each vs the 120 s cap; both sweep
+            % runs died with NO logs and NO rows = runner-level death). Restarting
+            % the pool is the only reliable way to kill a busy MATLAB worker; the
+            % ~15 s restart cost applies only on timeouts.
+            try
+                delete(pool);
+            catch
+            end
+            pool = parpool('Processes', 1);
+            pool_is_cold = true;   % next instance gets the one-time cold-start grace
         end
         time_s = toc(t0);
         fprintf('  [%d/%d] %s -> %s (%.1f s)%s\n', k, numel(pairs), pr.onnx_rel, status_str, time_s, ...


### PR DESCRIPTION
## Root cause (malbeware: 150 instances × 2 sweep runs = 0 rows, job dies with no logs)

`parfeval` **`cancel()` cannot interrupt a busy worker** — it only de-schedules queued futures. A timed-out reach keeps grinding while the next instance queues behind it: cascading false timeouts + unbounded CPU/memory → runner-level death (no logs, no artifact). malbeware triggers it reliably: ~50 `scaled_16` instances need ~370 s each (measured locally; the model solves `unsat`) against the 120 s sweep cap.

## Fix

1. **Pool restart on timeout** — delete + recreate the 1-worker pool (the only reliable kill for a busy MATLAB worker).
2. **Cold-start grace (120 s, one-time)** for the first instance on any fresh pool — a fresh worker pays ~100 s of init + ONNX-importer codegen, which otherwise masquerades as a solver timeout (measured: a 9 s-warm model "timed out" at 121 s cold). Recorded `time_s` is still true wall time.

## Validation (synthetic 2-instance malbeware bench, timeout=30 s)

| | pre-fix | post-fix |
|---|---|---|
| `scaled_16` (needs ~370 s) | timeout, zombie lives on | **honest timeout + pool restart** |
| `linear` (9 s warm) | **false timeout @121 s** (queued behind zombie) | **`unsat` in 26.7 s** |

Recovers the malbeware bucket — the field analysis shows it's the largest cheap-remaining gap (98 instances the field solves in ~7 s; NNV-2025 solved 53; the verifier itself is fine — `unsat` in 8.9 s locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)