### PR TITLE
feat(onnx2nnv): tensor-layout model for transformers — vit_2023 manifests evaluate correctly

### DIFF
--- a/.github/workflows/vnncomp-sweep.yml
+++ b/.github/workflows/vnncomp-sweep.yml
@@ -158,7 +158,7 @@ jobs:
       # submission prepare_instance.sh; cheap (~1-3 s/model). Matches both the 2025 and 2026
       # folder names (cgan_2023/cgan2026, soundnessbench/soundnessbench_2026, etc.).
       - name: Generate NNV manifests for manifest categories (Python importer)
-        if: ${{ contains(matrix.folder, 'lsnc_relu') || contains(matrix.folder, 'traffic_signs') || contains(matrix.folder, 'cgan') || contains(matrix.folder, 'soundnessbench') }}
+        if: ${{ contains(matrix.folder, 'lsnc_relu') || contains(matrix.folder, 'traffic_signs') || contains(matrix.folder, 'cgan') || contains(matrix.folder, 'soundnessbench') || contains(matrix.folder, 'vit') }}
         shell: bash
         run: |
           python3 -m pip install --quiet onnx==1.20.0 onnxruntime==1.23.1 numpy scipy

--- a/code/nnv/engine/nn/layers/ElementwiseAffineLayer.m
+++ b/code/nnv/engine/nn/layers/ElementwiseAffineLayer.m
@@ -59,14 +59,20 @@ classdef ElementwiseAffineLayer < handle
             if obj.DoScale
                 s = obj.Scale;
                 if ~isscalar(s) && ~elementwiseaffine_broadcastable(size(s), size(x))
-                    s = align_to_input(s, size(x));
+                    s = onnx_trailing_align(s, x);
+                    if ~elementwiseaffine_broadcastable(size(s), size(x))
+                        s = align_to_input(s, size(x));
+                    end
                 end
                 y = y .* s;
             end
             if obj.DoOffset
                 o = obj.Offset;
                 if ~isscalar(o) && ~elementwiseaffine_broadcastable(size(o), size(x))
-                    o = align_to_input(o, size(x));
+                    o = onnx_trailing_align(o, x);
+                    if ~elementwiseaffine_broadcastable(size(o), size(x))
+                        o = align_to_input(o, size(x));
+                    end
                 end
                 y = y + o;
             end
@@ -449,3 +455,18 @@ function tf = elementwiseaffine_broadcastable(sz_p, sz_x)
     tf = all(sz_p == sz_x | sz_p == 1);
 end
 
+
+function p = onnx_trailing_align(p, x)
+    % ONNX/NumPy broadcasting aligns shapes from the TRAILING dimension;
+    % MATLAB implicit expansion aligns from the LEADING one. A per-token
+    % parameter like a ViT position embedding [N,C] against an [1,N,C]
+    % activation broadcasts fine in ONNX but fails MATLAB's rule (dim2:
+    % C vs N) -- and previously fell into align_to_input, which silently
+    % mis-applied it (vit_2023: pos-emb added with the wrong orientation,
+    % max err ~7). Pad LEADING singletons so the parameter's dims line up
+    % with x's trailing dims, exactly the ONNX semantics.
+    if ndims(p) < ndims(x)
+        sz = size(p);
+        p = reshape(p, [ones(1, ndims(x) - ndims(p)), sz]);
+    end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -973,38 +973,7 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         inputSize = nnvnet.Layers{1}.InputSize;
         needReshape = 1;   % CHW-flat vnnlib -> [H,W,C] image, same as cifar-class
         reachOptionsList = {};   % no sound reach available -> skip to unknown
-        if false
-        net = importNetworkFromONNX(onnx, "InputDataFormats", "BCSS", 'OutputDataFormats',"BC");
-        try
-            nnvnet = matlab2nnv(net);
-            needReshape = 1;
-            reachOptionsList = {};
-            % First: approx-star (tightest sound bound NNV offers without LP)
-            reachOpts1 = struct;
-            reachOpts1.reachMethod = 'approx-star';
-            reachOptionsList{end+1} = reachOpts1;
-            % Second: relax-star (faster fallback for deeper nets)
-            reachOpts2 = struct;
-            reachOpts2.reachMethod = 'relax-star-area';
-            reachOpts2.relaxFactor = 0.5;
-            reachOptionsList{end+1} = reachOpts2;
-        catch
-            nnvnet = "";
-            % cp-star fallback ONLY when sound conversion failed
-            reachOpts = struct;
-            reachOpts.train_epochs = 100;
-            reachOpts.train_lr = 0.001;
-            reachOpts.coverage = 0.999;
-            reachOpts.confidence = 0.999;
-            reachOpts.train_mode = 'Linear';
-            reachOpts.surrogate_dim = [-1,-1];
-            reachOpts.threshold_normal = 1e-5;
-            reachOpts.reachMethod = 'cp-star';
-            reachOptionsList = {reachOpts};
-            needReshape = 1;
-        end
-
-end
+        % (legacy MATLAB-import + cp-star path removed; see git history pre-#345)
 
     elseif contains(category, "yolo")
         % yolo: onnx to nnv

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -959,11 +959,21 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         reachOptionsList{1} = reachOptions;
     
     elseif contains(category, "vit")
-        % vit: onnx to matlab. Try sound Star-set reach first (approx-star
-        % then relax-star fallback), since cp-star is probabilistic and
-        % doesn't exercise the actual reach() chain through attention layers.
-        % If matlab2nnv conversion fails (e.g., unsupported layer in the ONNX
-        % import), fall back to cp-star to get *some* result.
+        % vit: MATLAB's importer collapses the 133-node ViT into ONE opaque
+        % fused custom layer (Shape_To_ReduceMeanLayer) -> matlab2nnv refuses ->
+        % the old path fell to cp-star (probabilistic + env-dependent) -> 200/200
+        % unknown. Route through the PYTHON manifest instead: the layout-model
+        % fix in onnx2nnv.py makes the manifest evaluate match onnxruntime to
+        % ~5e-7 (MATLAB-validated 2026-06-13), so the NN-net numerical-gradient
+        % PGD falsifier produces REAL sat witnesses (replayed through the
+        % onnxruntime gate before emission). Reach through DynamicMatmulLayer
+        % refuses by design -> unsat is out of scope -> sat-or-unknown only.
+        nnvnet = load_manifest_net(onnx);
+        net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+        inputSize = nnvnet.Layers{1}.InputSize;
+        needReshape = 1;   % CHW-flat vnnlib -> [H,W,C] image, same as cifar-class
+        reachOptionsList = {};   % no sound reach available -> skip to unknown
+        if false
         net = importNetworkFromONNX(onnx, "InputDataFormats", "BCSS", 'OutputDataFormats',"BC");
         try
             nnvnet = matlab2nnv(net);
@@ -993,6 +1003,8 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             reachOptionsList = {reachOpts};
             needReshape = 1;
         end
+
+end
 
     elseif contains(category, "yolo")
         % yolo: onnx to nnv

--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -22,7 +22,7 @@ pkill -f -q matlab 2>/dev/null
 # cross-validated vs onnxruntime; any SAT witness is replayed through onnxruntime before
 # being emitted, so a mis-import degrades to error/unknown, never an unsound verdict.
 case "$2" in
-    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*)
+    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*|*vit*)
         NNV_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"   # VNN_COMP2026 -> .../code/nnv
         MANIFEST="${3%.onnx}.nnv.mat"
         if [ ! -f "${MANIFEST}" ]; then

--- a/code/nnv/tools/onnx2nnv_python/check_manifest_matrix.py
+++ b/code/nnv/tools/onnx2nnv_python/check_manifest_matrix.py
@@ -1,0 +1,202 @@
+"""check_manifest_matrix.py — end-to-end layout-model regression matrix for
+the ONNX -> NNV manifest importer.
+
+For each benchmark model:
+  1. preprocess the ONNX exactly like onnx2nnv.py (opset upgrade, onnxsim,
+     onnxoptimizer, dead-node elimination),
+  2. emit the .nnv.mat manifest (onnx2nnv.walk + manifest_to_mat),
+  3. run onnxruntime on the SAME preprocessed graph with every intermediate
+     exposed as an output,
+  4. execute the manifest with manifest_sim.ManifestSim (a numpy replica of
+     the MATLAB load_nnv_from_mat + layer evaluate semantics),
+  5. compare every mapped tensor ORIENTATION-STRICTLY (per-layer MlLayout
+     convention; no permutation guessing).
+
+Gate: max|diff| < 1e-4 * max(1, ||ref||_inf) on every clean mapped tensor,
+< 1e-3 on the final output. The scale factor exists ONLY because the ground
+truth itself is float32 (onnxruntime CPU has no float64 Conv kernel): an
+IBP-trained ViT carries ~5e2-magnitude residual activations whose float32
+ULP is ~6e-5, so a few e-4 of ABSOLUTE noise is the reference's own
+rounding (~2e-7 relative), demonstrably not an orientation error (layout
+bugs produce O(||x||) errors). Shape/orientation checks remain STRICT —
+any mismatch is reported as inf.
+
+Layers wrapping ops MATLAB refuses to evaluate (UnsupportedOp:*, Resize)
+are oracle-patched from onnxruntime and tracked separately, as are tensors
+transitively downstream of a patch ("tainted") — those mirror what the
+MATLAB xval also cannot check (collins).
+
+Usage:
+  python3 check_manifest_matrix.py                # full matrix
+  python3 check_manifest_matrix.py vit_pgd cgan   # subset
+  VNNCOMP_BENCH=<path> overrides the benchmark root (default: the
+  vnncomp2026_benchmarks clone next to the nnv repo).
+"""
+
+import os
+import sys
+import tempfile
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import onnx2nnv
+from manifest_sim import ManifestSim, ort_to_matlab, strict_diff
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_DEFAULT_BENCH = os.path.normpath(os.path.join(
+    _HERE, '..', '..', '..', '..', '..', 'vnncomp2026_benchmarks', 'benchmarks'))
+BENCH = os.environ.get('VNNCOMP_BENCH', _DEFAULT_BENCH)
+
+MODELS = {
+    'vit_pgd': 'vit_2023/1.0/onnx/pgd_2_3_16.onnx',
+    'vit_ibp': 'vit_2023/1.0/onnx/ibp_3_3_8.onnx',
+    'soundnessbench': 'soundnessbench/1.0/onnx/model.onnx',
+    'cgan': 'cgan_2023/1.0/onnx/cGAN_imgSz32_nCh_1.onnx',
+    'lsnc': 'lsnc_relu/1.0/onnx/relu_quadrotor2d_state.onnx',
+    'traffic': ('traffic_signs_recognition_2023/1.0/onnx/'
+                '3_30_30_QConv_16_3_QConv_32_2_Dense_43_ep_30.onnx'),
+    'collins': 'collins_aerospace_benchmark/1.0/onnx/yolov5nano_LRelu_640.onnx',
+}
+
+TOL_TENSOR = 1e-4
+TOL_FINAL = 1e-3
+SEED = 20260612
+
+
+def _maybe_gunzip(path):
+    if os.path.exists(path):
+        return path
+    gz = path + '.gz'
+    if os.path.exists(gz):
+        import gzip, shutil
+        with gzip.open(gz, 'rb') as f, open(path, 'wb') as g:
+            shutil.copyfileobj(f, g)
+        return path
+    raise FileNotFoundError(path)
+
+
+def _ort_session_with_intermediates(model, wanted):
+    """Build an ORT session on `model` with `wanted` tensor names added as
+    graph outputs (only those that have value_info / are already outputs)."""
+    m = onnx.ModelProto()
+    m.CopyFrom(model)
+    have = {o.name for o in m.graph.output}
+    vi_map = {vi.name: vi for vi in m.graph.value_info}
+    for name in wanted:
+        if name in have or name not in vi_map:
+            continue
+        m.graph.output.append(vi_map[name])
+        have.add(name)
+    sess = ort.InferenceSession(m.SerializeToString(),
+                                providers=['CPUExecutionProvider'])
+    return sess, [o.name for o in sess.get_outputs()]
+
+
+def check_model(key, onnx_rel, verbose=False):
+    path = _maybe_gunzip(os.path.join(BENCH, onnx_rel))
+    model = onnx.load(path)
+    model = onnx2nnv.preprocess_onnx(model)
+
+    layers, weights, inp_name, inp_shape, out_name = onnx2nnv.walk(model)
+    tmpdir = tempfile.mkdtemp(prefix=f'nnvman_{key}_')
+    mat_path = os.path.join(tmpdir, key + '.nnv.mat')
+    onnx2nnv.manifest_to_mat(layers, weights, inp_name, inp_shape, out_name,
+                             mat_path, 0, path)
+
+    sim = ManifestSim(mat_path)
+
+    # tensors we want from ORT: every real (graph) tensor a manifest layer
+    # produces. Synthetic decomposition outputs ('*_out', '*_flat') are
+    # internal and not present in the ONNX graph.
+    graph_tensors = set()
+    for n in model.graph.node:
+        graph_tensors.update(n.output)
+    graph_tensors.update(o.name for o in model.graph.output)
+    layer_out = {}
+    for L in sim.layers:
+        if L.outputs and L.outputs[0] in graph_tensors:
+            layer_out[L.name] = L.outputs[0]
+
+    sess, out_names = _ort_session_with_intermediates(model, set(layer_out.values()))
+    rng = np.random.default_rng(SEED)
+    x = rng.uniform(-1.0, 1.0, size=[d if d > 0 else 1 for d in inp_shape])
+    x = x.astype(np.float32)
+    ort_vals = dict(zip(out_names, sess.run(None, {inp_name: x})))
+
+    def oracle(L):
+        t = L.outputs[0] if L.outputs else None
+        if t is None or t not in ort_vals:
+            return None
+        return ort_to_matlab(ort_vals[t], L.layout)
+
+    values, patched, tainted = sim.run(x, oracle=oracle)
+
+    rows = []
+    clean_max, clean_scaled_max, taint_max = 0.0, 0.0, 0.0
+    n_clean = n_taint = 0
+    final_diff = None
+    for L in sim.layers:
+        nm = L.name
+        if nm not in layer_out or nm in patched:
+            continue
+        t = layer_out[nm]
+        if t not in ort_vals:
+            continue
+        d = strict_diff(values[nm], ort_vals[t], L.layout)
+        scale = max(1.0, float(np.max(np.abs(ort_vals[t]))) if np.asarray(ort_vals[t]).size else 1.0)
+        d_scaled = d / scale
+        is_taint = nm in tainted
+        rows.append((nm, t, L.layout, d, d_scaled, is_taint))
+        if t == out_name:
+            final_diff = d
+        if is_taint:
+            taint_max = max(taint_max, d); n_taint += 1
+        else:
+            clean_max = max(clean_max, d)
+            clean_scaled_max = max(clean_scaled_max, d_scaled)
+            n_clean += 1
+        if verbose:
+            flag = ' TAINTED' if is_taint else ''
+            mark = '  <<<<' if (d_scaled > TOL_TENSOR and not is_taint) else ''
+            print(f'  {nm[:34]:34s} {L.layout:4s} {str(t)[:42]:42s} {d:9.2e}{flag}{mark}')
+
+    ok = clean_scaled_max < TOL_TENSOR and (final_diff is None or final_diff < TOL_FINAL
+                                            or out_name in {layer_out.get(n) for n in tainted})
+    return {
+        'key': key, 'ok': ok, 'clean_max': clean_max,
+        'clean_scaled_max': clean_scaled_max, 'n_clean': n_clean,
+        'taint_max': taint_max, 'n_taint': n_taint, 'n_patched': len(patched),
+        'final': final_diff, 'n_layers': len(sim.layers), 'mat': mat_path,
+        'rows': rows,
+    }
+
+
+def main(argv):
+    verbose = '-v' in argv
+    keys = [a for a in argv if not a.startswith('-')] or list(MODELS)
+    results = []
+    for k in keys:
+        print(f'=== {k} ({MODELS[k]})', flush=True)
+        try:
+            r = check_model(k, MODELS[k], verbose=verbose)
+        except Exception as e:
+            print(f'  ERROR: {type(e).__name__}: {e}')
+            results.append({'key': k, 'ok': False, 'error': str(e)})
+            continue
+        f = 'n/a' if r['final'] is None else f"{r['final']:.2e}"
+        print(f"  layers={r['n_layers']} compared={r['n_clean']} clean_max={r['clean_max']:.2e} "
+              f"(scaled {r['clean_scaled_max']:.2e}) "
+              f"final={f} patched={r['n_patched']} tainted_cmp={r['n_taint']}"
+              f"{'' if r['n_taint']==0 else f' taint_max={r['taint_max']:.2e}'}"
+              f"  -> {'PASS' if r['ok'] else 'FAIL'}", flush=True)
+        results.append(r)
+    n_bad = sum(1 for r in results if not r.get('ok'))
+    print(f"\n{len(results) - n_bad}/{len(results)} models PASS")
+    return 1 if n_bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/code/nnv/tools/onnx2nnv_python/check_manifest_matrix.py
+++ b/code/nnv/tools/onnx2nnv_python/check_manifest_matrix.py
@@ -190,8 +190,8 @@ def main(argv):
         print(f"  layers={r['n_layers']} compared={r['n_clean']} clean_max={r['clean_max']:.2e} "
               f"(scaled {r['clean_scaled_max']:.2e}) "
               f"final={f} patched={r['n_patched']} tainted_cmp={r['n_taint']}"
-              f"{'' if r['n_taint']==0 else f' taint_max={r['taint_max']:.2e}'}"
-              f"  -> {'PASS' if r['ok'] else 'FAIL'}", flush=True)
+              + ("" if r['n_taint'] == 0 else " taint_max={:.2e}".format(r['taint_max']))
+              + "  -> " + ("PASS" if r['ok'] else "FAIL"), flush=True)
         results.append(r)
     n_bad = sum(1 for r in results if not r.get('ok'))
     print(f"\n{len(results) - n_bad}/{len(results)} models PASS")

--- a/code/nnv/tools/onnx2nnv_python/manifest_sim.py
+++ b/code/nnv/tools/onnx2nnv_python/manifest_sim.py
@@ -1,0 +1,791 @@
+"""manifest_sim.py — a pure-numpy interpreter for the .nnv.mat manifests
+produced by onnx2nnv.py, replicating the MATLAB-side semantics of
+engine/utils/load_nnv_from_mat.m + each NNV layer's evaluate() EXACTLY
+(column-major reshapes, trailing-singleton trimming, MATLAB implicit
+expansion, the FullyConnectedLayer token fast path, ...).
+
+Purpose: iterate on the importer's tensor-LAYOUT model without a MATLAB
+session. If this simulator reproduces onnxruntime on manifests whose MATLAB
+evaluate is KNOWN-GOOD (soundnessbench, cgan), it faithfully models the
+MATLAB semantics; the same simulator then validates layout fixes (vit_2023)
+ORIENTATION-STRICTLY before the human re-checks in MATLAB.
+
+The companion matrix runner lives in check_manifest_matrix.py.
+
+MATLAB-array model
+------------------
+Values are numpy float64 arrays kept in "MATLAB normal form": ndim >= 2 and
+no trailing singleton dimensions beyond ndim 2 (MATLAB's size() semantics).
+All reshapes are column-major (order='F'); broadcasting pads TRAILING
+singleton dims (MATLAB implicit expansion), unlike numpy's leading-dim rule.
+"""
+
+import numpy as np
+from scipy.io import loadmat
+
+
+class SimError(Exception):
+    """A MATLAB-side evaluate() would have errored the same way."""
+
+
+class OracleNeeded(Exception):
+    """Layer wraps an op MATLAB refuses to evaluate (UnsupportedOp:* /
+    Resize); the harness substitutes onnxruntime ground truth."""
+
+
+# ---------------------------------------------------------------------------
+# MATLAB array helpers
+# ---------------------------------------------------------------------------
+
+def mn(a):
+    """MATLAB normal form: float64, ndim >= 2, trailing singletons trimmed."""
+    a = np.asarray(a, dtype=np.float64)
+    if a.ndim == 0:
+        return a.reshape(1, 1)
+    if a.ndim == 1:
+        return a.reshape(1, -1)   # scipy/savemat convention for 1-D: row
+    shp = list(a.shape)
+    while len(shp) > 2 and shp[-1] == 1:
+        shp.pop()
+    return a.reshape(shp)
+
+
+def m_size(a):
+    return list(a.shape)
+
+
+def m_ndims(a):
+    return a.ndim
+
+
+def m_numel(a):
+    return a.size
+
+
+def m_isvector(a):
+    return a.ndim == 2 and (a.shape[0] == 1 or a.shape[1] == 1)
+
+
+def m_isscalar(a):
+    return a.size == 1
+
+
+def m_reshape(a, tgt):
+    """MATLAB reshape: column-major; numel must match; allows trailing 1s."""
+    tgt = [int(t) for t in tgt]
+    if -1 in tgt:
+        known = int(np.prod([t for t in tgt if t != -1]))
+        tgt[tgt.index(-1)] = a.size // max(known, 1)
+    if int(np.prod(tgt)) != a.size:
+        raise SimError(f"reshape: numel mismatch {a.size} -> {tgt}")
+    return mn(np.reshape(a, tgt, order='F'))
+
+
+def m_permute(a, perm1):
+    """MATLAB permute with a 1-indexed perm; perm may exceed ndims (pads the
+    array with trailing singletons) and is padded with identity if shorter."""
+    perm1 = [int(p) for p in perm1]
+    k = max(len(perm1), a.ndim)
+    perm1 = perm1 + list(range(len(perm1) + 1, k + 1))
+    a2 = a.reshape(a.shape + (1,) * (k - a.ndim))
+    return mn(np.transpose(a2, [p - 1 for p in perm1]))
+
+
+def m_broadcast(a, b, f):
+    """MATLAB implicit expansion: align LEADING dims (pad TRAILING 1s)."""
+    a = mn(a); b = mn(b)
+    k = max(a.ndim, b.ndim)
+    a2 = a.reshape(a.shape + (1,) * (k - a.ndim))
+    b2 = b.reshape(b.shape + (1,) * (k - b.ndim))
+    for da, db in zip(a2.shape, b2.shape):
+        if da != db and da != 1 and db != 1:
+            raise SimError(f"implicit expansion size mismatch {a.shape} vs {b.shape}")
+    return mn(f(a2, b2))
+
+
+def m_col(a):
+    """MATLAB a(:) — column-major flatten to a column vector."""
+    return mn(np.reshape(a, (-1, 1), order='F'))
+
+
+# ---------------------------------------------------------------------------
+# .mat decoding helpers (scipy loadmat, struct_as_record=False)
+# ---------------------------------------------------------------------------
+
+def _to_str(x):
+    a = np.asarray(x)
+    if a.size == 0:
+        return ''
+    return str(a.flatten()[0])
+
+
+def _to_str_list(x):
+    if x is None:
+        return []
+    a = np.asarray(x)
+    if a.size == 0:
+        return []
+    if a.dtype == object:
+        return [_to_str(e) for e in a.flatten()]
+    if a.dtype.kind in 'US':
+        return [str(e) for e in a.flatten()]
+    return [_to_str(a)]
+
+
+def _attr(attrs, name, default=None):
+    if attrs is None or not hasattr(attrs, name):
+        return default
+    return getattr(attrs, name)
+
+
+def _num(x, default=None):
+    if x is None:
+        return default
+    a = np.asarray(x)
+    if a.size == 0:
+        return default
+    return float(np.asarray(a).flatten()[0])
+
+
+def _ivec(x):
+    return [int(v) for v in np.asarray(x).flatten()]
+
+
+# ---------------------------------------------------------------------------
+# ElementwiseAffineLayer helpers (mirror ElementwiseAffineLayer.m)
+# ---------------------------------------------------------------------------
+
+def _ea_broadcastable(sz_p, sz_x):
+    if len(sz_p) != len(sz_x):
+        return False
+    return all(p == x or p == 1 for p, x in zip(sz_p, sz_x))
+
+
+def _ea_trailing_align(p, x):
+    # onnx_trailing_align: pad LEADING singletons up to ndims(x)
+    if p.ndim < x.ndim:
+        p = mn(p.reshape((1,) * (x.ndim - p.ndim) + p.shape))
+    return p
+
+
+def _ea_padshape_left(arr, target_ndims):
+    sz = m_size(arr)
+    while len(sz) > target_ndims and sz[0] == 1:
+        sz = sz[1:]
+    need = target_ndims - len(sz)
+    if need > 0:
+        sz = [1] * need + sz
+    if len(sz) < 2:
+        sz = sz + [1] * (2 - len(sz))
+    return m_reshape(arr, sz)
+
+
+def _ea_align_to_input(arr, x_shape):
+    sz_a = m_size(arr)
+    ns_a = [d for d in sz_a if d > 1]
+    if not ns_a:
+        return arr
+    if len(ns_a) == 1:
+        target = [1] * max(2, len(x_shape))
+        placed = False
+        val = ns_a[0]
+        for k, d in enumerate(x_shape):
+            if d == val and not placed:
+                target[k] = val
+                placed = True
+        if placed:
+            return m_reshape(arr, target)
+    target = [1] * max(2, len(x_shape))
+    remaining = list(ns_a)
+    for k, d in enumerate(x_shape):
+        if remaining and d == remaining[0]:
+            target[k] = remaining[0]
+            remaining.pop(0)
+    if not remaining:
+        return m_reshape(arr, target)
+    return _ea_padshape_left(arr, len(x_shape))
+
+
+# ---------------------------------------------------------------------------
+# Layer evaluates
+# ---------------------------------------------------------------------------
+
+def _fc_eval(W, b_col, x):
+    """FullyConnectedLayer.evaluate — including the transformer batched-FC
+    fast path (rank>=3 input whose LAST dim equals in_features)."""
+    n = m_size(x)
+    in_feats = W.shape[1]
+    if len(n) >= 3 and n[-1] == in_feats and int(np.prod(n[:-1])) > 1:
+        lead = n[:-1]
+        x_flat = m_reshape(x, [int(np.prod(lead)), in_feats])
+        y_flat = (W @ x_flat.T).T + b_col.T   # [N, out] + [1, out]
+        return m_reshape(y_flat, list(lead) + [W.shape[0]])
+    if len(n) > 4:
+        raise SimError('FC: invalid input rank')
+    x_col = m_col(x)
+    if x_col.shape[0] != in_feats:
+        raise SimError(f'FC: inconsistent input vector ({x_col.shape[0]} vs {in_feats})')
+    return mn(W @ x_col + b_col)
+
+
+def _conv2d_eval(x, Wm, b_col, pads_tblr, strides, dils, groups=1):
+    """Conv2DLayer.evaluate (dlconv 'SSCB' on HWC; correlation, no flip)."""
+    if groups != 1:
+        raise SimError('Conv2D: grouped conv not supported by NNV manifest path')
+    x = mn(x)
+    if x.ndim == 2:
+        x = x.reshape(x.shape + (1,))
+    t, bo, l, r = [int(v) for v in pads_tblr]
+    xp = np.pad(x, ((t, bo), (l, r), (0, 0)))
+    kH, kW, C, F = Wm.shape
+    if xp.shape[2] != C:
+        raise SimError(f'Conv2D: channel mismatch {xp.shape[2]} vs {C}')
+    sh, sw = [int(v) for v in strides]
+    dh, dw = [int(v) for v in dils]
+    eKH = (kH - 1) * dh + 1
+    eKW = (kW - 1) * dw + 1
+    Ho = (xp.shape[0] - eKH) // sh + 1
+    Wo = (xp.shape[1] - eKW) // sw + 1
+    if Ho <= 0 or Wo <= 0:
+        raise SimError('Conv2D: empty output')
+    y = np.tile(b_col.reshape(1, 1, F), (Ho, Wo, 1)).astype(np.float64)
+    for i in range(kH):
+        for j in range(kW):
+            xs = xp[i * dh: i * dh + (Ho - 1) * sh + 1: sh,
+                    j * dw: j * dw + (Wo - 1) * sw + 1: sw, :]
+            y += xs @ Wm[i, j]          # [Ho,Wo,C] @ [C,F]
+    return mn(y)
+
+
+def _transp_conv2d_eval(x, Wm, b_col, crops_tblr, strides):
+    """TransposedConv2DLayer.evaluate (dltranspconv 'SSCU')."""
+    x = mn(x)
+    if x.ndim == 2:
+        x = x.reshape(x.shape + (1,))
+    kH, kW, F, C = Wm.shape
+    H, W_, Cin = x.shape
+    if Cin != C:
+        raise SimError(f'TranspConv2D: channel mismatch {Cin} vs {C}')
+    sh, sw = [int(v) for v in strides]
+    t, bo, l, r = [int(v) for v in crops_tblr]
+    Hf = (H - 1) * sh + kH
+    Wf = (W_ - 1) * sw + kW
+    y = np.zeros((Hf, Wf, F), dtype=np.float64)
+    for i in range(kH):
+        for j in range(kW):
+            # scatter: y[i + h*sh, j + w*sw, f] += sum_c x[h,w,c] W[i,j,f,c]
+            y[i: i + (H - 1) * sh + 1: sh,
+              j: j + (W_ - 1) * sw + 1: sw, :] += x @ Wm[i, j].T
+    y = y[t: Hf - bo, l: Wf - r, :]
+    return mn(y + b_col.reshape(1, 1, F))
+
+
+def _maxpool_eval(x, pool, stride, pads_tblr):
+    x = mn(x)
+    if x.ndim == 2:
+        x = x.reshape(x.shape + (1,))
+    t, bo, l, r = [int(v) for v in pads_tblr]
+    xp = np.pad(x, ((t, bo), (l, r), (0, 0)), constant_values=-np.inf)
+    kH, kW = [int(v) for v in pool]
+    sh, sw = [int(v) for v in stride]
+    Ho = (xp.shape[0] - kH) // sh + 1
+    Wo = (xp.shape[1] - kW) // sw + 1
+    y = np.full((Ho, Wo, x.shape[2]), -np.inf)
+    for i in range(kH):
+        for j in range(kW):
+            y = np.maximum(y, xp[i: i + (Ho - 1) * sh + 1: sh,
+                                 j: j + (Wo - 1) * sw + 1: sw, :])
+    return mn(y)
+
+
+def _avgpool_eval(x, pool, stride, pads_tblr):
+    x = mn(x)
+    if x.ndim == 2:
+        x = x.reshape(x.shape + (1,))
+    t, bo, l, r = [int(v) for v in pads_tblr]
+    xp = np.pad(x, ((t, bo), (l, r), (0, 0)))
+    kH, kW = [int(v) for v in pool]
+    sh, sw = [int(v) for v in stride]
+    Ho = (xp.shape[0] - kH) // sh + 1
+    Wo = (xp.shape[1] - kW) // sw + 1
+    y = np.zeros((Ho, Wo, x.shape[2]))
+    for i in range(kH):
+        for j in range(kW):
+            y += xp[i: i + (Ho - 1) * sh + 1: sh,
+                    j: j + (Wo - 1) * sw + 1: sw, :]
+    return mn(y / (kH * kW))
+
+
+def _softmax_layer_eval(x):
+    """SoftmaxLayer.evaluate: isvector -> column-wise softmax (NN toolbox
+    softmax()); rank-3 -> 'SSC' channel softmax over MATLAB dim 3; else error."""
+    x = mn(x)
+    if m_isvector(x):
+        e = np.exp(x - np.max(x, axis=0, keepdims=True))
+        return mn(e / np.sum(e, axis=0, keepdims=True))
+    if x.ndim == 3:
+        e = np.exp(x - np.max(x, axis=2, keepdims=True))
+        return mn(e / np.sum(e, axis=2, keepdims=True))
+    raise SimError('SoftmaxLayer: input is not a vector or multi-channel image')
+
+
+def _flatten_into2d_eval(x):
+    """FlattenLayer.evaluate, Type='nnet.onnx.layer.FlattenInto2dLayer'."""
+    x = mn(x)
+    n = m_size(x)
+    if len(n) == 2:
+        xi = m_permute(x, [2, 1])
+        return m_reshape(xi, [1, 1, n[0] * n[1]])
+    if len(n) == 3:
+        xi = m_permute(x, [2, 1, 3])
+        return m_reshape(xi, [1, 1, n[0] * n[1] * n[2]])
+    if len(n) == 4:
+        xi = m_permute(x, [3, 2, 1, 4])
+        return m_reshape(xi, [1, 1, int(np.prod(n))])
+    if len(n) == 5:
+        xi = m_permute(x, [1, 5, 4, 3, 2])
+        return m_reshape(xi, [1, 1, int(np.prod(n))])
+    raise SimError('FlattenLayer: invalid input rank')
+
+
+def _reshape_layer_eval(x, tgt, onnx_bchw):
+    x = mn(x)
+    tgt = [int(t) for t in tgt]
+    neg = [k for k, t in enumerate(tgt) if t < 0]
+    if len(neg) > 1:
+        raise SimError('ReshapeLayer: more than one -1 sentinel')
+    if len(neg) == 1:
+        known = list(tgt)
+        known[neg[0]] = 1
+        rest = int(np.prod(known))
+        tgt[neg[0]] = x.size // rest if rest > 0 else 1
+    if onnx_bchw and len(tgt) == 3:
+        H, W_, C = tgt
+        tmp = m_reshape(x, [W_, H, C])
+        return m_permute(tmp, [2, 1, 3])
+    return m_reshape(x, tgt)
+
+
+def _dynmatmul_eval(A, B):
+    A = mn(A); B = mn(B)
+    if A.ndim <= 2 and B.ndim <= 2:
+        if A.shape[1] != B.shape[0]:
+            raise SimError(f'DynamicMatmul: inner dims mismatch ({A.shape[1]} vs {B.shape[0]})')
+        return mn(A @ B)
+    sa = m_size(A); sb = m_size(B)
+    k_a, k_a_in = sa[-2], sa[-1]
+    k_b, k_b_in = sb[-2], sb[-1]
+    if k_a_in != k_b:
+        raise SimError(f'DynamicMatmul: inner dims mismatch ({k_a_in} vs {k_b})')
+    lead_a, lead_b = sa[:-2], sb[:-2]
+    if lead_a != lead_b:
+        raise SimError(f'DynamicMatmul: leading dims differ ({lead_a} vs {lead_b})')
+    n_lead = max(int(np.prod(lead_a)), 1) if lead_a else 1
+    A_flat = m_reshape(A, [n_lead, k_a, k_a_in])
+    B_flat = m_reshape(B, [n_lead, k_b, k_b_in])
+    # guard: m_reshape may have trimmed trailing singletons
+    A_flat = np.reshape(A_flat, (n_lead, k_a, k_a_in), order='F')
+    B_flat = np.reshape(B_flat, (n_lead, k_b, k_b_in), order='F')
+    out_flat = np.zeros((n_lead, k_a, k_b_in))
+    for i in range(n_lead):
+        out_flat[i] = A_flat[i] @ B_flat[i]
+    return m_reshape(out_flat, list(lead_a) + [k_a, k_b_in])
+
+
+# ---------------------------------------------------------------------------
+# Layer objects (mirror load_nnv_from_mat.build_layer + each evaluate)
+# ---------------------------------------------------------------------------
+
+class SimLayer:
+    def __init__(self, type_str, name, attrs, wkeys, weights, inputs, outputs):
+        self.type = type_str
+        self.name = name
+        self.attrs = attrs
+        self.inputs = inputs
+        self.outputs = outputs
+        self.layout = _to_str(_attr(attrs, 'MlLayout', 'FLAT')) or 'FLAT'
+        w = [mn(np.asarray(getattr(weights, k))) for k in wkeys] if wkeys else []
+
+        t = type_str
+        if t == 'FullyConnectedLayer':
+            self.W = w[0]
+            self.b = m_col(w[1])
+        elif t == 'Conv2DLayer':
+            # MATLAB trims trailing singleton dims of the stored [F,C,kH,kW]
+            # tensor (1x1 kernels); permute() pads them back — replicate.
+            W4 = np.asarray(w[0], dtype=np.float64)
+            W4 = W4.reshape(W4.shape + (1,) * (4 - W4.ndim))
+            self.Wm = np.transpose(W4, (2, 3, 1, 0))   # [kH,kW,C,F]
+            self.b = m_col(w[1])
+            self.pads = self._pads(_attr(attrs, 'Pads'))
+            self.strides = _ivec(_attr(attrs, 'Strides', [1, 1]))
+            self.dils = _ivec(_attr(attrs, 'Dilations', [1, 1]))
+            self.groups = int(_num(_attr(attrs, 'Groups'), 1))
+        elif t == 'TransposedConv2DLayer':
+            W4 = np.asarray(w[0], dtype=np.float64)
+            W4 = W4.reshape(W4.shape + (1,) * (4 - W4.ndim))
+            self.Wm = np.transpose(W4, (2, 3, 1, 0))   # [kH,kW,F,C]
+            self.b = m_col(w[1])
+            self.pads = self._pads(_attr(attrs, 'Pads'))
+            self.strides = _ivec(_attr(attrs, 'Strides', [1, 1]))
+        elif t == 'BatchNormalizationLayer':
+            nC = w[0].size
+            self.nC = nC
+            self.scale = np.reshape(w[0], (1, 1, nC), order='F')
+            self.bias = np.reshape(w[1], (1, 1, nC), order='F')
+            self.mean = np.reshape(w[2], (1, 1, nC), order='F')
+            self.var = np.reshape(w[3], (1, 1, nC), order='F')
+            self.eps = _num(_attr(attrs, 'Epsilon'), 1e-5)
+        elif t == 'ElementwiseAffineLayer':
+            s, o = w[0], w[1]
+            if m_isvector(s) or m_isscalar(s):
+                s = m_col(s)
+            if m_isvector(o) or m_isscalar(o):
+                o = m_col(o)
+            self.scale, self.offset = s, o
+            self.do_scale = bool(_num(_attr(attrs, 'DoScale'), 0))
+            self.do_offset = bool(_num(_attr(attrs, 'DoOffset'), 0))
+        elif t == 'LeakyReluLayer':
+            self.gamma = _num(_attr(attrs, 'Scale'), 0.01)
+        elif t == 'ReshapeLayer':
+            self.tgt = _ivec(_attr(attrs, 'TargetShape'))
+            self.onnx_bchw = bool(_num(_attr(attrs, 'OnnxBCHW'), 0))
+        elif t == 'TransposeLayer':
+            perm = _ivec(_attr(attrs, 'Perm', []))
+            mperm = [p + 1 for p in perm]
+            self.perm = mperm if (mperm and mperm != list(range(1, len(mperm) + 1))) else None
+        elif t == 'ConcatenationLayer':
+            self.dim = self._concat_dim(attrs)
+        elif t in ('MaxPooling2DLayer', 'AveragePooling2DLayer'):
+            self.pool = _ivec(_attr(attrs, 'KernelSize'))
+            self.strides = _ivec(_attr(attrs, 'Strides', [1, 1]))
+            self.pads = self._pads(_attr(attrs, 'Pads'))
+        elif t == 'SignLayer':
+            self.mode = _to_str(_attr(attrs, 'Mode', 'polar_zero_to_pos_one'))
+        elif t == 'SoftmaxLayer':
+            pass
+        elif t == 'PlaceholderLayer':
+            # mirror the loader's tag logic
+            op = _to_str(_attr(attrs, 'OriginalOp', ''))
+            if op in ('Sign', 'Abs', 'Constant', 'Floor', 'Ceil', 'Round',
+                      'Sin', 'Cos', 'Tan', 'Exp', 'Log', 'Sqrt'):
+                tag = op
+            elif op in ('', 'Identity', 'Cast', 'Dropout', 'extra_graph_input',
+                        'Transpose_2D_no_op_vector', 'Transpose_BCHW_to_BHWC',
+                        'Transpose_BHWC_to_BCHW'):
+                tag = 'Identity'
+            else:
+                tag = 'UnsupportedOp:' + op
+            self.tag = tag
+            self.constant = None
+            if tag == 'Constant':
+                if w:
+                    self.constant = w[0]
+                else:
+                    self.tag = 'UnsupportedOp:Constant'
+        self.in_size = _attr(attrs, 'InputSize')
+
+    @staticmethod
+    def _pads(p):
+        pf = _ivec(p) if p is not None else []
+        if len(pf) == 4:
+            return [pf[0], pf[2], pf[1], pf[3]]   # ONNX [t,l,b,r] -> [t,b,l,r]
+        return [0, 0, 0, 0]
+
+    @staticmethod
+    def _concat_dim(attrs):
+        axis = int(_num(_attr(attrs, 'Axis'), 0))
+        in_rank = int(_num(_attr(attrs, 'InRank'), 0))
+        if axis < 0:
+            onnx_pos = axis + in_rank if in_rank > 0 else max(0, axis + 4)
+        else:
+            onnx_pos = axis
+        if in_rank == 2:
+            d = (onnx_pos == 1) * 1 + (onnx_pos == 0) * 2
+            return d if d != 0 else 1
+        if in_rank == 3:
+            return onnx_pos + 1
+        if in_rank == 4:
+            map4 = [3, 3, 1, 2]
+            return map4[min(max(onnx_pos + 1, 1), 4) - 1]
+        d = axis
+        if d < 0:
+            d = max(1, d + 4)
+        return max(d, 1)
+
+    # ---- evaluate dispatch -------------------------------------------------
+
+    def evaluate(self, vals):
+        t = self.type
+        if t in ('FeatureInputLayer', 'ImageInputLayer'):
+            return vals[0]
+        if t == 'FullyConnectedLayer':
+            return _fc_eval(self.W, self.b, vals[0])
+        if t == 'Conv2DLayer':
+            return _conv2d_eval(vals[0], self.Wm, self.b, self.pads,
+                                self.strides, self.dils, self.groups)
+        if t == 'TransposedConv2DLayer':
+            return _transp_conv2d_eval(vals[0], self.Wm, self.b, self.pads,
+                                       self.strides)
+        if t == 'BatchNormalizationLayer':
+            return self._bn_eval(vals[0])
+        if t == 'ReluLayer':
+            return mn(np.maximum(vals[0], 0))
+        if t == 'LeakyReluLayer':
+            x = mn(vals[0])
+            return mn(np.where(x >= 0, x, self.gamma * x))
+        if t == 'SigmoidLayer':
+            return mn(1.0 / (1.0 + np.exp(-mn(vals[0]))))
+        if t == 'TanhLayer':
+            return mn(np.tanh(vals[0]))
+        if t == 'SoftmaxLayer':
+            return _softmax_layer_eval(vals[0])
+        if t == 'SignLayer':
+            y = np.sign(mn(vals[0]))
+            if self.mode == 'polar_zero_to_pos_one':
+                y = y + (y == 0)
+            elif self.mode == 'nonnegative_zero_to_pos_one':
+                y = y + (y == 0)
+                y = y + (y == -1)
+            return mn(y)
+        if t == 'ElementwiseAffineLayer':
+            return self._ea_eval(vals[0])
+        if t == 'AdditionLayer':
+            out = mn(vals[0])
+            for v in vals[1:]:
+                out = m_broadcast(out, v, np.add)
+            return out
+        if t == 'ElementwiseProductLayer':
+            out = mn(vals[0])
+            for v in vals[1:]:
+                out = m_broadcast(out, v, np.multiply)
+            return out
+        if t == 'ElementwiseDivisionLayer':
+            return m_broadcast(vals[0], vals[1], np.divide)
+        if t == 'DynamicMatmulLayer':
+            return _dynmatmul_eval(vals[0], vals[1])
+        if t == 'ConcatenationLayer':
+            out = mn(vals[0])
+            for v in vals[1:]:
+                v = mn(v)
+                k = max(out.ndim, v.ndim, self.dim)
+                o2 = out.reshape(out.shape + (1,) * (k - out.ndim))
+                v2 = v.reshape(v.shape + (1,) * (k - v.ndim))
+                out = mn(np.concatenate([o2, v2], axis=self.dim - 1))
+            return out
+        if t == 'FlattenLayer':
+            return _flatten_into2d_eval(vals[0])
+        if t == 'ReshapeLayer':
+            return _reshape_layer_eval(vals[0], self.tgt, self.onnx_bchw)
+        if t == 'TransposeLayer':
+            # loader maps TransposeLayer -> PlaceholderLayer with Perm
+            if self.perm is None:
+                return mn(vals[0])
+            return m_permute(vals[0], self.perm)
+        if t == 'MaxPooling2DLayer':
+            return _maxpool_eval(vals[0], self.pool, self.strides, self.pads)
+        if t == 'AveragePooling2DLayer':
+            return _avgpool_eval(vals[0], self.pool, self.strides, self.pads)
+        if t == 'GlobalAveragePooling2DLayer':
+            x = mn(vals[0])
+            return mn(np.mean(x, axis=(0, 1), keepdims=True))
+        if t == 'Resize2DLayer':
+            raise OracleNeeded(self.name)
+        if t == 'PlaceholderLayer':
+            return self._placeholder_eval(vals)
+        raise SimError(f'unknown layer type {t}')
+
+    def _placeholder_eval(self, vals):
+        if self.tag.startswith('UnsupportedOp:'):
+            raise OracleNeeded(self.name)
+        if self.constant is not None:
+            return mn(self.constant)
+        x = mn(vals[0]) if vals else None
+        f = {'Sign': np.sign, 'Abs': np.abs, 'Floor': np.floor,
+             'Ceil': np.ceil, 'Round': np.round, 'Sin': np.sin,
+             'Cos': np.cos, 'Tan': np.tan, 'Exp': np.exp, 'Log': np.log,
+             'Sqrt': np.sqrt}.get(self.tag)
+        if f is not None:
+            return mn(f(x))
+        return x
+
+    def _bn_eval(self, x):
+        x = mn(x)
+        scale, bias, mean, var, eps = self.scale, self.bias, self.mean, self.var, self.eps
+        nC = self.nC
+        if m_isvector(x):
+            m = m_col(mean); v = m_col(var); s = m_col(scale); o = m_col(bias)
+            y = (m_col(x) - m) / np.sqrt(v + eps)
+            y = s * y + o
+            if x.shape[0] == 1:   # row in -> row out
+                y = y.T
+            return mn(y)
+        # axis-aware fast path: exactly one input dim equals NumChannels
+        if nC > 1:
+            sz = m_size(x)
+            ch_dims = [k for k, d in enumerate(sz) if d == nC]
+            if len(ch_dims) == 1:
+                ax = ch_dims[0]
+                tgt = [1] * max(2, len(sz))
+                tgt[ax] = nC
+                m = np.reshape(mean, tgt, order='F')
+                v = np.reshape(var, tgt, order='F')
+                s = np.reshape(scale, tgt, order='F')
+                o = np.reshape(bias, tgt, order='F')
+                return mn(((x - m) / np.sqrt(v + eps)) * s + o)
+        # generic image path: [1,1,C] params broadcast over MATLAB dim 3
+        if x.ndim >= 3 and x.shape[2] == nC:
+            return mn(((x - mean) / np.sqrt(var + eps)) * scale + bias)
+        if nC == 1:
+            return mn(((x - mean.flatten()[0]) / np.sqrt(var.flatten()[0] + eps))
+                      * scale.flatten()[0] + bias.flatten()[0])
+        raise SimError(f'BatchNorm: ambiguous/unsupported input shape {m_size(x)} for C={nC}')
+
+    def _ea_eval(self, x):
+        x = mn(x)
+        y = x
+        if self.do_scale:
+            s = self.scale
+            if not m_isscalar(s) and not _ea_broadcastable(m_size(s), m_size(x)):
+                s = _ea_trailing_align(s, x)
+                if not _ea_broadcastable(m_size(s), m_size(x)):
+                    s = _ea_align_to_input(s, m_size(x))
+            y = m_broadcast(y, s, np.multiply)
+        if self.do_offset:
+            o = self.offset
+            if not m_isscalar(o) and not _ea_broadcastable(m_size(o), m_size(x)):
+                o = _ea_trailing_align(o, x)
+                if not _ea_broadcastable(m_size(o), m_size(x)):
+                    o = _ea_align_to_input(o, m_size(x))
+            y = m_broadcast(y, o, np.add)
+        return y
+
+
+# ---------------------------------------------------------------------------
+# Manifest network
+# ---------------------------------------------------------------------------
+
+class ManifestSim:
+    """Loads a .nnv.mat manifest (scipy) and evaluates it layer-by-layer the
+    way NNV's NN.evaluate would after load_nnv_from_mat."""
+
+    def __init__(self, mat_path):
+        s = loadmat(mat_path, struct_as_record=False, squeeze_me=False)
+        weights = s['weights'][0, 0] if isinstance(s['weights'], np.ndarray) else s['weights']
+        raw_layers = np.asarray(s['layers']).flatten()
+        self.layers = []
+        for L in raw_layers:
+            if isinstance(L, np.ndarray):
+                L = L.flatten()[0]
+            attrs = getattr(L, 'attrs', None)
+            if isinstance(attrs, np.ndarray):
+                attrs = attrs.flatten()[0] if attrs.size else None
+            self.layers.append(SimLayer(
+                _to_str(L.type), _to_str(L.name), attrs,
+                _to_str_list(getattr(L, 'weight_keys', None)), weights,
+                _to_str_list(getattr(L, 'inputs', None)),
+                _to_str_list(getattr(L, 'outputs', None))))
+        self.input_shape = _ivec(s['input_shape'])
+        self.input_name = _to_str(s['input_name'])
+        self.output_name = _to_str(s['output_name'])
+
+    def prepare_input(self, x_onnx):
+        """Convert the ONNX-layout input array to the MATLAB-side form the
+        manifest's input layer expects."""
+        L0 = self.layers[0]
+        x = np.asarray(x_onnx, dtype=np.float64)
+        if L0.type == 'ImageInputLayer':
+            want = _ivec(L0.in_size)
+            if x.ndim == 4:
+                x = x[0]
+            if list(x.shape) == want:           # BHWC source: already HWC
+                return mn(x)
+            if x.ndim == 3 and [x.shape[1], x.shape[2], x.shape[0]] == want:
+                return mn(np.transpose(x, (1, 2, 0)))   # CHW -> HWC
+            raise SimError(f'input shape {x.shape} does not map to InputSize {want}')
+        return mn(x.reshape(-1, 1))             # FLAT column (ONNX C-order)
+
+    def run(self, x_onnx, oracle=None):
+        """Execute all layers. Returns (values, patched, tainted):
+        values: layer_name -> MATLAB-form numpy array
+        patched: set of layer names whose output came from the oracle
+        tainted: set of layer names transitively downstream of a patch."""
+        values, patched, tainted = {}, set(), set()
+        name2layer = {L.name: L for L in self.layers}
+        for L in self.layers:
+            if L.type in ('FeatureInputLayer', 'ImageInputLayer'):
+                values[L.name] = self.prepare_input(x_onnx)
+                continue
+            vals = []
+            missing = None
+            for p in L.inputs:
+                if p in values:
+                    vals.append(values[p])
+                else:
+                    missing = p
+            is_tainted = any(p in patched or p in tainted for p in L.inputs)
+            try:
+                if missing is not None:
+                    raise OracleNeeded(f'{L.name}: missing input {missing}')
+                out = L.evaluate(vals)
+            except Exception as e:
+                # An evaluation error on a CLEAN path is a real importer/sim
+                # bug — never mask it. On a TAINTED path (downstream of an
+                # unsupported-op placeholder, e.g. the collins detection head)
+                # garbage shapes are expected; MATLAB xval cannot check there
+                # either. OracleNeeded is patchable on any path.
+                if not isinstance(e, OracleNeeded) and not is_tainted:
+                    raise
+                if oracle is None:
+                    raise
+                out = oracle(L)
+                if out is None:
+                    raise SimError(f'{L.name}: oracle has no value for {L.outputs} '
+                                   f'(after {type(e).__name__}: {e})')
+                patched.add(L.name)
+                is_tainted = False   # ground truth resets the taint at this node
+            if is_tainted:
+                tainted.add(L.name)
+            values[L.name] = out
+        return values, patched, tainted
+
+
+# ---------------------------------------------------------------------------
+# ORT <-> MATLAB layout conversion + strict comparison
+# ---------------------------------------------------------------------------
+
+def ort_to_matlab(arr, lay):
+    """Convert an onnxruntime tensor to the MATLAB-side form the manifest
+    DEFINES for that layout. No permutation guessing."""
+    a = np.asarray(arr, dtype=np.float64)
+    if lay == 'HWC':
+        if a.ndim == 4 and a.shape[0] == 1:
+            a = a[0]
+        if a.ndim == 3:
+            return mn(np.transpose(a, (1, 2, 0)))
+        return mn(a)        # non-conforming rank: treat as RAW
+    if lay == 'HWCB':
+        # ONNX tensor is [B,H,W,C]; the MATLAB value is the same [H,W,C]
+        if a.ndim == 4 and a.shape[0] == 1:
+            a = a[0]
+        return mn(a)
+    if lay == 'FLAT':
+        return mn(a.reshape(-1, 1))     # ONNX C-order sequence as a column
+    return mn(a)            # RAW: dims literally equal (trailing 1s trimmed)
+
+
+def strict_diff(sim_val, ort_val, lay):
+    """Orientation-STRICT max|diff|: shapes must agree under the declared
+    layout convention; no permutation search. Returns np.inf on mismatch."""
+    ref = ort_to_matlab(ort_val, lay)
+    a = mn(np.asarray(sim_val, dtype=np.float64))
+    if lay == 'FLAT':
+        # contract: <=1 non-singleton dim; the SEQUENCE is the comparison
+        if sum(1 for d in a.shape if d > 1) > 1 or a.size != ref.size:
+            return np.inf
+        return float(np.max(np.abs(a.flatten() - ref.flatten()))) if a.size else 0.0
+    if a.shape != ref.shape:
+        return np.inf
+    if a.size == 0:
+        return 0.0
+    return float(np.max(np.abs(a - ref)))

--- a/code/nnv/tools/onnx2nnv_python/onnx2nnv.py
+++ b/code/nnv/tools/onnx2nnv_python/onnx2nnv.py
@@ -49,6 +49,62 @@ import onnxoptimizer
 from scipy.io import savemat
 
 
+# ---------- tensor-layout model ----------
+#
+# Every tensor we emit lives in exactly one MATLAB-side layout:
+#
+#   'HWC'  — image tensor. ONNX [B,C,H,W] is stored MATLAB-side as an
+#            [H,W,C] array (NNV's image convention; Conv/Pool/ImageInput
+#            layers all assume it).
+#   'HWCB' — image tensor whose ONNX form is [B,H,W,C] (keras/larq BHWC
+#            graphs around the no-op layout transposes). MATLAB-side it is
+#            the SAME [H,W,C] array as 'HWC'; the tag only records the ONNX
+#            dim order for strict ground-truth comparison.
+#   'FLAT' — feature vector. ONNX [B,F] (or [F]) is stored as a column
+#            [F,1] (or row/[1,1,F] from FlattenLayer); the element SEQUENCE
+#            equals the ONNX C-order flattening.
+#   'RAW'  — everything else (attention/token tensors: [B,T,C], [B,h,T,d],
+#            ...). Stored MATLAB-side with dims IDENTICAL to the ONNX dims,
+#            element-by-element (no permutation). MATLAB trims trailing
+#            singleton dims, which is harmless here (batch leads).
+#
+# The old importer pushed the HWC/flat machinery through transformer
+# pipelines too, silently rotating token tensors relative to what the
+# Transpose perms / DynamicMatmul shapes expect (vit_2023: pos-emb added in
+# the wrong orientation, then 'inner dims mismatch' at attn x V). The walk()
+# below tracks the layout of every tensor and only applies HWC conventions
+# on actual image flows; attention/token tensors stay RAW with explicit
+# C-order reshapes.
+#
+# Key consequences for RAW tensors:
+#   * ONNX Reshape/Flatten must use C-order semantics. MATLAB reshape is
+#     column-major, so we emit the standard decomposition
+#         permute(reverse-dims) -> reshape(flip(target)) -> permute(reverse)
+#     using the existing TransposeLayer/ReshapeLayer (exact, no new MATLAB
+#     machinery).
+#   * ONNX Transpose perms apply literally (TransposeLayer; never the
+#     BHWC/BCHW "no-op" placeholders, which are an HWC-only convention).
+#   * FullyConnectedLayer's batched fast path (last dim == in_features)
+#     evaluates per-token FCs on [1,T,C] without reordering.
+#   * Selector matrices (Split/Slice/Gather/Reduce*) must index the
+#     COLUMN-MAJOR flattening of the RAW array (MATLAB reshape(x,[],1)),
+#     not the ONNX C-order one used for FLAT flows.
+#   * Per-channel biases are emitted trailing-aligned ([1,...,1,C]) so ONNX
+#     broadcasting semantics hold under MATLAB implicit expansion.
+#   * Softmax over the last axis of a rank-3 RAW tensor maps to NNV's
+#     SoftmaxLayer 'SSC' channel softmax; other ranks are wrapped in
+#     reshape-[1,L,N] / softmax / reshape-back (exact: softmax is
+#     per-leading-slice over the last dim).
+
+IMAGE_CONSUMER_OPS = {'Conv', 'ConvTranspose', 'MaxPool', 'AveragePool',
+                      'GlobalAveragePool', 'BatchNormalization', 'Resize',
+                      'Upsample'}
+
+# Ops whose NNV layer always produces an HWC image output.
+IMAGE_PRODUCER_OPS = {'Conv', 'ConvTranspose', 'MaxPool', 'AveragePool',
+                      'GlobalAveragePool', 'Resize', 'Upsample'}
+
+
 # ---------- helpers ----------
 
 def to_array(t):
@@ -65,6 +121,20 @@ def get_attr(node, name, default=None):
             if a.type == onnx.AttributeProto.FLOATS: return list(a.floats)
             if a.type == onnx.AttributeProto.TENSOR: return to_array(a.t)
     return default
+
+def _trailing_align_param(arr, x_shape):
+    """Pad an ONNX broadcast parameter with LEADING singleton dims so its
+    dims line up with the trailing dims of an x of rank len(x_shape) — the
+    ONNX/NumPy broadcasting rule, made explicit for MATLAB implicit
+    expansion (which aligns LEADING dims). Used for RAW-layout consumers."""
+    a = np.asarray(arr)
+    if x_shape is None:
+        return a
+    r = len(x_shape)
+    if a.ndim < r:
+        a = a.reshape((1,) * (r - a.ndim) + a.shape)
+    return a
+
 
 _NAME_HASH_TABLE = {}
 def safe_name(s):
@@ -83,7 +153,7 @@ def safe_name(s):
 # ---------- preprocessing ----------
 
 def _try_emit_reduce(node, nm, value_shapes, initializers, producer,
-                     add_weight, emit, op_name):
+                     add_weight, emit, op_name, raw_order=False):
     """Try to emit a ReduceSum / ReduceMean as a sparse FullyConnectedLayer.
 
     For an input of known shape S = [d_0, ..., d_{n-1}] with axes A and
@@ -94,6 +164,13 @@ def _try_emit_reduce(node, nm, value_shapes, initializers, producer,
     Returns True on successful emit, False on fallback.
 
     op_name: 'sum' or 'mean'. For sum, no division.
+
+    raw_order: when the producer tensor is in 'RAW' layout, the MATLAB-side
+    FullyConnectedLayer flattens it COLUMN-MAJOR (F-order over the ONNX
+    dims), not C-order. Build the selector with F-order strides on both
+    sides, and follow the FC with a ReshapeLayer restoring the RAW output
+    shape (the plain MATLAB column-major reshape inverts the F-order
+    flatten exactly).
     """
     in_name = node.input[0]
     in_sh = value_shapes.get(in_name)
@@ -149,13 +226,23 @@ def _try_emit_reduce(node, nm, value_shapes, initializers, producer,
     import numpy as _np
     W = _np.zeros((flat_out, flat_in), dtype=_np.float32)
 
-    # Input strides (row-major / C-order, matching how we treat NNV's flat layout).
-    in_strides = [1] * n
-    for k in range(n - 2, -1, -1):
-        in_strides[k] = in_strides[k+1] * eff_sh[k+1]
-    out_strides = [1] * len(out_sh)
-    for k in range(len(out_sh) - 2, -1, -1):
-        out_strides[k] = out_strides[k+1] * out_sh[k+1]
+    if raw_order:
+        # F-order (column-major) strides over the RAW dims — matches how
+        # MATLAB's FullyConnectedLayer flattens a RAW [d0,...,dn-1] array.
+        in_strides = [1] * n
+        for k in range(1, n):
+            in_strides[k] = in_strides[k-1] * eff_sh[k-1]
+        out_strides = [1] * len(out_sh)
+        for k in range(1, len(out_sh)):
+            out_strides[k] = out_strides[k-1] * out_sh[k-1]
+    else:
+        # Input strides (row-major / C-order, matching how we treat NNV's flat layout).
+        in_strides = [1] * n
+        for k in range(n - 2, -1, -1):
+            in_strides[k] = in_strides[k+1] * eff_sh[k+1]
+        out_strides = [1] * len(out_sh)
+        for k in range(len(out_sh) - 2, -1, -1):
+            out_strides[k] = out_strides[k+1] * out_sh[k+1]
 
     reduce_vol = 1
     for ax in axes: reduce_vol *= eff_sh[ax]
@@ -179,6 +266,24 @@ def _try_emit_reduce(node, nm, value_shapes, initializers, producer,
         W[out_flat, in_flat] += coeff
 
     b = _np.zeros(flat_out, dtype=_np.float32)
+    if raw_order:
+        # FC emits an F-order flat column; restore the RAW output shape with
+        # a plain (column-major) ReshapeLayer so downstream RAW consumers
+        # (BatchNorm, FC, ...) see the ONNX dims.
+        fc_nm = safe_name(nm + '_red')
+        wkey = add_weight(fc_nm, 'W', W)
+        bkey = add_weight(fc_nm, 'b', b)
+        emit(LayerSpec('FullyConnectedLayer', fc_nm,
+                       attrs={'OutputSize': int(flat_out)},
+                       inputs=[producer[in_name]],
+                       outputs=[fc_nm + '_out'],
+                       weight_keys=[wkey, bkey]))
+        spec = LayerSpec('ReshapeLayer', nm,
+                         attrs={'TargetShape': [int(d) for d in out_sh]},
+                         inputs=[fc_nm],
+                         outputs=[node.output[0]])
+        emit(spec)
+        return True
     wkey = add_weight(nm, 'W', W)
     bkey = add_weight(nm, 'b', b)
     spec = LayerSpec('FullyConnectedLayer', nm,
@@ -389,11 +494,31 @@ def walk(model):
                          attrs={'InputSize': sz}, outputs=[inp_name])
     layers.append(spec)
     producer[inp_name] = 'input'
+
+    # Per-tensor MATLAB-side layout tracking ('HWC' | 'FLAT' | 'RAW') — see
+    # the layout-model comment at the top of this file.
+    layout = {}
+    if spec.type == 'ImageInputLayer':
+        layout[inp_name] = 'HWCB' if bhwc_input else 'HWC'
+    else:
+        layout[inp_name] = 'FLAT'
+
+    def tensor_layout(tname):
+        return layout.get(tname, 'FLAT')
+
+    def node_in_layout(node):
+        """Layout of the first input we know about (dynamic tensors only)."""
+        for x in node.input:
+            if x in layout:
+                return layout[x]
+        return 'FLAT'
+
     # If we detected a BHWC input layout, the leading BHWC->BCHW Transpose
     # is a no-op in NNV's HWC convention. Skip it by mapping its output
     # name to 'input' directly so downstream Conv layers wire correctly.
     if drop_first_transpose:
         producer[drop_first_transpose] = 'input'
+        layout[drop_first_transpose] = 'HWC'   # post-transpose ONNX form is BCHW
         # value_shapes for the transpose's output should match input HWC.
     # Also register any other graph inputs (some ONNX exports have multiple
     # inputs, e.g. multi-input attention models). They map to PlaceholderLayer
@@ -409,6 +534,7 @@ def walk(model):
                             outputs=[extra_inp.name])
         layers.append(ph_spec)
         producer[extra_inp.name] = ph_name
+        layout[extra_inp.name] = 'FLAT'
 
     # Helper: register a layer + its outputs
     def emit(spec):
@@ -446,6 +572,67 @@ def walk(model):
             key = f"{key[:25]}_{_wkey_counter[0]}"
         weights[key] = np.ascontiguousarray(arr.astype(np.float32))
         return key
+
+    def emit_conorder_reshape(nm, src_tensor, tgt_static, out_tensor, pre_perm0):
+        """Emit an EXACT ONNX (C-order) reshape for a RAW-destined tensor as a
+        composition of existing NNV layers:
+
+            [pre-permute] -> reshape(flip(tgt)) -> permute(reverse(tgt-rank))
+
+        MATLAB's reshape is column-major; flattening the REVERSE-permuted
+        array column-major equals the ONNX C-order flattening, and refilling
+        flip(tgt) then reverse-permuting realizes the C-order refill.
+
+        pre_perm0: 0-indexed permutation applied to the MATLAB-side input
+        array so its column-major flatten equals the ONNX C-order flatten of
+        the source tensor: reversed(range(rank)) for RAW inputs, [1,0,2] for
+        HWC image inputs ([H,W,C] -> [W,H,C]), None for FLAT columns (their
+        element sequence is already the C-order one).
+
+        The final layer carries `nm` and `out_tensor` so downstream wiring
+        and debug-name mapping stay 1:1 with the ONNX node.
+        """
+        cur = producer[src_tensor]
+        if pre_perm0 is not None and list(pre_perm0) != list(range(len(pre_perm0))):
+            pre_nm = safe_name(nm + '_cpre')
+            emit(LayerSpec('TransposeLayer', pre_nm,
+                           attrs={'Perm': [int(p) for p in pre_perm0]},
+                           inputs=[cur], outputs=[pre_nm + '_out']))
+            cur = pre_nm
+        rs_nm = safe_name(nm + '_crs')
+        emit(LayerSpec('ReshapeLayer', rs_nm,
+                       attrs={'TargetShape': [int(d) for d in reversed(tgt_static)]},
+                       inputs=[cur], outputs=[rs_nm + '_out']))
+        cur = rs_nm
+        post = list(range(len(tgt_static) - 1, -1, -1))
+        spec = LayerSpec('TransposeLayer', nm, attrs={'Perm': post},
+                         inputs=[cur], outputs=[out_tensor])
+        emit(spec)
+        return spec
+
+    def static_reshape_target(node, tgt):
+        """Resolve an ONNX Reshape target ([-1]/0 sentinels) to a fully
+        static shape, preferring the inferred output shape."""
+        out_sh = value_shapes.get(node.output[0])
+        if out_sh and len(out_sh) == len(tgt) and all(d > 0 for d in out_sh):
+            return [int(d) for d in out_sh]
+        in_sh = value_shapes.get(node.input[0])
+        res = [int(t) for t in tgt]
+        if in_sh and all(d > 0 for d in in_sh):
+            for k, t in enumerate(res):
+                if t == 0:
+                    res[k] = int(in_sh[k]) if k < len(in_sh) else 1
+            if res.count(-1) == 1:
+                known = 1
+                for t in res:
+                    if t != -1:
+                        known *= t
+                tot = int(np.prod(in_sh))
+                if known > 0 and tot % known == 0:
+                    res[res.index(-1)] = tot // known
+            if all(t > 0 for t in res):
+                return res
+        return None
 
     def to_hwc_if_image_bias(arr):
         """Convert ONNX-shape (broadcasting) bias arrays to HWC layout if they
@@ -587,6 +774,14 @@ def walk(model):
         op = node.op_type
         nm = safe_name(node.name) if node.name else f"{op}_{i}"
         node_key = node.name or f"_n_{op}_{i}"
+        # Default layout propagation: image producers emit HWC; everything
+        # else inherits the first known input layout. Handlers that change
+        # representation (Reshape boundary, FC, Flatten, ...) overwrite
+        # these entries below. Assign BEFORE any skip/rewrite so fused
+        # patterns (STE Sign, PWL) still propagate to their consumers.
+        _in_lay = node_in_layout(node)
+        for _o in node.output:
+            layout[_o] = 'HWC' if op in IMAGE_PRODUCER_OPS else _in_lay
         # Larq STE pattern: skip the inner Sign + Add entirely; the outer
         # Sign takes the original x and emits a polar SignLayer.
         if node_key in ste_skip:
@@ -690,6 +885,7 @@ def walk(model):
                                  outputs=[node.output[0]],
                                  weight_keys=[wkey, bkey])
                 emit(spec)
+                layout[node.output[0]] = 'FLAT'
                 continue
 
             if op == 'MatMul':
@@ -740,6 +936,15 @@ def walk(model):
                                  outputs=[node.output[0]],
                                  weight_keys=[wkey, bkey])
                 emit(spec)
+                # Token-batched FC on a RAW [B,T,C] input keeps RAW layout
+                # (MATLAB FC's last-dim fast path); everything else flattens
+                # to a feature column.
+                out_sh_mm = value_shapes.get(node.output[0])
+                if (B is not None and tensor_layout(A_name) == 'RAW'
+                        and out_sh_mm is not None and len(out_sh_mm) >= 3):
+                    layout[node.output[0]] = 'RAW'
+                else:
+                    layout[node.output[0]] = 'FLAT'
                 continue
 
             if op == 'Conv':
@@ -824,6 +1029,48 @@ def walk(model):
 
             if op == 'Softmax':
                 axis = get_attr(node, 'axis', -1)
+                in_sh_sm = value_shapes.get(node.input[0])
+                if tensor_layout(node.input[0]) == 'RAW' and in_sh_sm \
+                        and all(d > 0 for d in in_sh_sm):
+                    # RAW tensor: NNV's SoftmaxLayer computes a channel ('SSC')
+                    # softmax over MATLAB dim 3 for rank-3 inputs and errors on
+                    # other ranks. ONNX last-axis softmax on a rank-3 RAW
+                    # [1,L,N] maps to it directly; for other ranks wrap in
+                    # reshape-[1,L,N] / softmax / reshape-back (exact: softmax
+                    # is per-leading-slice over the last dim, and the plain
+                    # column-major reshape repacks leading dims bijectively
+                    # while preserving the last dim).
+                    r_sm = len(in_sh_sm)
+                    ax_sm = int(axis) % r_sm
+                    if ax_sm == r_sm - 1:
+                        if r_sm == 3:
+                            spec = LayerSpec('SoftmaxLayer', nm,
+                                             attrs={'Axis': int(axis)},
+                                             inputs=[producer[node.input[0]]],
+                                             outputs=[node.output[0]])
+                            emit(spec)
+                        else:
+                            Lp = int(np.prod(in_sh_sm[:-1]))
+                            Nl = int(in_sh_sm[-1])
+                            pre_nm = safe_name(nm + '_smpre')
+                            emit(LayerSpec('ReshapeLayer', pre_nm,
+                                           attrs={'TargetShape': [1, Lp, Nl]},
+                                           inputs=[producer[node.input[0]]],
+                                           outputs=[pre_nm + '_out']))
+                            sm_nm = safe_name(nm + '_smax')
+                            emit(LayerSpec('SoftmaxLayer', sm_nm,
+                                           attrs={'Axis': int(axis)},
+                                           inputs=[pre_nm],
+                                           outputs=[sm_nm + '_out']))
+                            spec = LayerSpec('ReshapeLayer', nm,
+                                             attrs={'TargetShape': [int(d) for d in in_sh_sm]},
+                                             inputs=[sm_nm],
+                                             outputs=[node.output[0]])
+                            emit(spec)
+                        layout[node.output[0]] = 'RAW'
+                        continue
+                    print(f"  [warn] Softmax {nm}: RAW input with non-last axis "
+                          f"{axis}; legacy emission (likely wrong dim)", file=sys.stderr)
                 spec = LayerSpec('SoftmaxLayer', nm, attrs={'Axis': int(axis)},
                                  inputs=[producer[node.input[0]]],
                                  outputs=[node.output[0]])
@@ -837,10 +1084,18 @@ def walk(model):
                 if a_init or b_init:
                     raw_bias = initializers[node.input[1]] if b_init else initializers[node.input[0]]
                     other_in = node.input[0] if b_init else node.input[1]
-                    # Preserve multi-dim shape for broadcasting (e.g. positional
-                    # embedding [1, T, C], CLS bias [1, 1, C]); permute genuine
-                    # image biases via to_hwc_if_image_bias.
-                    bias_arr = to_hwc_if_image_bias(raw_bias)
+                    if tensor_layout(other_in) == 'RAW':
+                        # RAW consumer: store the parameter trailing-aligned
+                        # ([1,...,1,*shape]) so ONNX trailing-dim broadcasting
+                        # holds under MATLAB implicit expansion (e.g. a [T,C]
+                        # pos-emb or a [C] per-channel bias against [1,T,C]).
+                        bias_arr = _trailing_align_param(
+                            raw_bias, value_shapes.get(other_in))
+                    else:
+                        # Preserve multi-dim shape for broadcasting (e.g. positional
+                        # embedding [1, T, C], CLS bias [1, 1, C]); permute genuine
+                        # image biases via to_hwc_if_image_bias.
+                        bias_arr = to_hwc_if_image_bias(raw_bias)
                     bkey = add_weight(nm, 'bias', bias_arr)
                     scale_key = add_weight(nm, 'scale', np.ones(1, dtype=np.float32))
                     spec = LayerSpec('ElementwiseAffineLayer', nm,
@@ -858,7 +1113,12 @@ def walk(model):
             if op == 'Sub':
                 # bias subtract: one operand is initializer -> ElementwiseAffine
                 if node.input[1] in initializers:
-                    bias_arr = to_hwc_if_image_bias(-initializers[node.input[1]])
+                    if tensor_layout(node.input[0]) == 'RAW':
+                        bias_arr = _trailing_align_param(
+                            -initializers[node.input[1]],
+                            value_shapes.get(node.input[0]))
+                    else:
+                        bias_arr = to_hwc_if_image_bias(-initializers[node.input[1]])
                     bkey = add_weight(nm, 'bias', bias_arr)
                     scale_key = add_weight(nm, 'scale', np.ones_like(bias_arr).flatten()[:1])
                     spec = LayerSpec('ElementwiseAffineLayer', nm,
@@ -869,7 +1129,12 @@ def walk(model):
                     emit(spec); continue
                 if node.input[0] in initializers:
                     # const - x  =  -1*x + const
-                    bias_arr = to_hwc_if_image_bias(initializers[node.input[0]])
+                    if tensor_layout(node.input[1]) == 'RAW':
+                        bias_arr = _trailing_align_param(
+                            initializers[node.input[0]],
+                            value_shapes.get(node.input[1]))
+                    else:
+                        bias_arr = to_hwc_if_image_bias(initializers[node.input[0]])
                     bkey = add_weight(nm, 'bias', bias_arr)
                     scale_key = add_weight(nm, 'scale', -np.ones(1, dtype=np.float32))
                     spec = LayerSpec('ElementwiseAffineLayer', nm,
@@ -904,8 +1169,13 @@ def walk(model):
                 if a_init or b_init:
                     scale_arr = initializers[node.input[1]] if b_init else initializers[node.input[0]]
                     other_in = node.input[0] if b_init else node.input[1]
-                    skey = add_weight(nm, 'scale', scale_arr.flatten())
-                    bkey = add_weight(nm, 'bias', np.zeros_like(scale_arr.flatten()))
+                    if tensor_layout(other_in) == 'RAW' and scale_arr.size > 1:
+                        scale_out = _trailing_align_param(
+                            scale_arr, value_shapes.get(other_in))
+                    else:
+                        scale_out = scale_arr.flatten()
+                    skey = add_weight(nm, 'scale', scale_out)
+                    bkey = add_weight(nm, 'bias', np.zeros(1, dtype=np.float32))
                     spec = LayerSpec('ElementwiseAffineLayer', nm,
                                      attrs={'DoScale': True, 'DoOffset': False},
                                      inputs=[producer[other_in]],
@@ -924,9 +1194,32 @@ def walk(model):
 
             if op == 'Flatten':
                 axis = get_attr(node, 'axis', 1)
+                if tensor_layout(node.input[0]) == 'RAW':
+                    # ONNX Flatten(axis) == C-order reshape to
+                    # [prod(d[:axis]), prod(d[axis:])]; the legacy
+                    # FlattenLayer assumes image (HWC) input and flattens ALL
+                    # dims, which is wrong for RAW tensors (e.g. the ViT
+                    # [1,h,T,T] -> [h*T, T] pre-softmax flatten).
+                    in_sh_f = value_shapes.get(node.input[0])
+                    out_sh_f = value_shapes.get(node.output[0])
+                    if in_sh_f and all(d > 0 for d in in_sh_f):
+                        if not (out_sh_f and len(out_sh_f) == 2
+                                and all(d > 0 for d in out_sh_f)):
+                            ax_f = int(axis) % (len(in_sh_f) + 1)
+                            out_sh_f = [int(np.prod(in_sh_f[:ax_f])) if ax_f > 0 else 1,
+                                        int(np.prod(in_sh_f[ax_f:])) if ax_f < len(in_sh_f) else 1]
+                        pre0 = list(range(len(in_sh_f) - 1, -1, -1))
+                        emit_conorder_reshape(nm, node.input[0],
+                                              [int(d) for d in out_sh_f],
+                                              node.output[0], pre0)
+                        layout[node.output[0]] = 'RAW'
+                        continue
+                    print(f"  [warn] Flatten {nm}: RAW input without static shape; "
+                          f"legacy emission (likely wrong)", file=sys.stderr)
                 spec = LayerSpec('FlattenLayer', nm, attrs={'Axis': int(axis)},
                                  inputs=[producer[node.input[0]]],
                                  outputs=[node.output[0]])
+                layout[node.output[0]] = 'FLAT'
                 emit(spec); continue
 
             if op == 'Reshape':
@@ -944,7 +1237,49 @@ def walk(model):
                     continue
                 tgt = [int(x) for x in shape_arr]
 
-                # Heuristic: convert ONNX-style targets to NNV-friendly forms.
+                in_lay = tensor_layout(node.input[0])
+                consumer_ops = {n2.op_type for n2 in model.graph.node
+                                if node.output[0] in n2.input}
+                feeds_image = bool(consumer_ops & IMAGE_CONSUMER_OPS)
+                # Flatten-like rank-2 targets ([B,F] / [-1,F] / [F,1]) stay on
+                # the proven legacy path even when leaving an image flow (the
+                # FlattenLayer's C-style flatten IS the ONNX semantics there,
+                # and a column target is the NNV feature convention already).
+                flatten_like = len(tgt) == 2 and (tgt[0] in (-1, 1) or tgt[1] in (-1, 1))
+
+                # ---- RAW (attention/token) path: exact ONNX C-order reshape.
+                # Taken when the producer is already RAW, or when an HWC/FLAT
+                # producer feeds NON-image consumers with a non-flatten target
+                # (the image<->token boundary, e.g. ViT patch-embed
+                # [1,C,H,W] -> [1,C,T]).
+                want_raw = (in_lay == 'RAW') or \
+                           (bool(consumer_ops) and not feeds_image and not flatten_like)
+                if want_raw:
+                    tgt_static = static_reshape_target(node, tgt)
+                    in_sh = value_shapes.get(node.input[0])
+                    pre0 = None
+                    ok = tgt_static is not None
+                    if ok:
+                        if in_lay == 'HWC':
+                            pre0 = [1, 0, 2]      # [H,W,C] -> [W,H,C]
+                        elif in_lay == 'HWCB':
+                            pre0 = [2, 1, 0]      # [H,W,C] -> [C,W,H] (ONNX BHWC C-order)
+                        elif in_lay == 'RAW':
+                            if in_sh is not None and all(d > 0 for d in in_sh):
+                                pre0 = list(range(len(in_sh) - 1, -1, -1))
+                            else:
+                                ok = False
+                        # FLAT: column-major flatten already equals the ONNX
+                        # C-order sequence; no pre-permute needed.
+                    if ok:
+                        emit_conorder_reshape(nm, node.input[0], tgt_static,
+                                              node.output[0], pre0)
+                        layout[node.output[0]] = 'RAW'
+                        continue
+                    print(f"  [warn] Reshape {nm}: RAW path needs static shapes; "
+                          f"falling back to legacy emission", file=sys.stderr)
+
+                # ---- legacy image/feature-flow paths (behavior unchanged).
                 # Common cases:
                 #   * [-1, F]  or  [B, F]  -> FlattenLayer (rank-2, the typical
                 #     Conv->FC adapter; numel preserved)
@@ -986,16 +1321,20 @@ def walk(model):
                         spec = LayerSpec('FlattenLayer', nm,
                                          inputs=[producer[node.input[0]]],
                                          outputs=[node.output[0]])
+                    layout[node.output[0]] = 'FLAT'
                 elif len(tgt) == 4:
-                    # Drop batch dim, swap from CHW -> HWC for NNV convention.
-                    # OnnxBCHW=1 tells ReshapeLayer to apply ONNX C-order
-                    # semantics (reshape to [W,H,C] then permute to [H,W,C]).
+                    # IMAGE restore ([B,C,H,W] feeding Conv/Pool): drop batch,
+                    # swap from CHW -> HWC for NNV convention. OnnxBCHW=1
+                    # tells ReshapeLayer to apply ONNX C-order semantics
+                    # (reshape to [W,H,C] then permute to [H,W,C]). Non-image
+                    # consumers were already diverted to the RAW path above.
                     _, c, h, w = tgt
                     nnv_shape = [int(h), int(w), int(c)]
                     spec = LayerSpec('ReshapeLayer', nm,
                                      attrs={'TargetShape': nnv_shape, 'OnnxBCHW': 1},
                                      inputs=[producer[node.input[0]]],
                                      outputs=[node.output[0]])
+                    layout[node.output[0]] = 'HWC'
                 else:
                     spec = LayerSpec('ReshapeLayer', nm, attrs={'TargetShape': tgt},
                                      inputs=[producer[node.input[0]]],
@@ -1009,6 +1348,18 @@ def walk(model):
                     continue
                 perm = get_attr(node, 'perm')
                 perm_l = list(map(int, perm)) if perm else []
+                # RAW (attention/token) tensors carry the ONNX dims literally,
+                # so EVERY permutation is a real data movement — never apply
+                # the HWC-convention "no-op" shortcuts below (treating e.g.
+                # the K^T perm [0,2,3,1] as a no-op transposed the key matrix
+                # and broke Q@K^T in vit_2023).
+                if tensor_layout(node.input[0]) == 'RAW':
+                    spec = LayerSpec('TransposeLayer', nm, attrs={'Perm': perm_l},
+                                     inputs=[producer[node.input[0]]],
+                                     outputs=[node.output[0]])
+                    emit(spec)
+                    layout[node.output[0]] = 'RAW'
+                    continue
                 # Common BHWC<->BCHW transposes (perm=[0,2,3,1] or [0,3,1,2])
                 # are no-ops in NNV's HWC convention — *unless* the next op is a
                 # Flatten/Reshape, in which case the ONNX flatten happens on
@@ -1062,6 +1413,9 @@ def walk(model):
                                      attrs={'OriginalOp': tag},
                                      inputs=[producer[node.input[0]]],
                                      outputs=[node.output[0]])
+                    # The MATLAB value stays the same [H,W,C] array; only the
+                    # ONNX-side dim order flips (for strict comparison).
+                    layout[node.output[0]] = 'HWCB' if perm_l == [0, 2, 3, 1] else 'HWC'
                 else:
                     spec = LayerSpec('TransposeLayer', nm, attrs={'Perm': perm_l},
                                      inputs=[producer[node.input[0]]],
@@ -1255,9 +1609,21 @@ def walk(model):
                                     f"slice selector too large "
                                     f"(flat_out={flat_out}, flat_in={flat_in}); "
                                     f"falling back to placeholder")
-                            strides = [1]*n
-                            for k in range(n-2, -1, -1):
-                                strides[k] = strides[k+1] * eff_sh[k+1]
+                            # RAW producers flatten column-major in MATLAB's
+                            # FullyConnectedLayer; FLAT/HWC keep legacy C-order.
+                            raw_in_sl = tensor_layout(in_name) == 'RAW'
+                            if raw_in_sl:
+                                strides = [1]*n
+                                for k in range(1, n):
+                                    strides[k] = strides[k-1] * eff_sh[k-1]
+                                out_strides_sl = [1]*n
+                                for k in range(1, n):
+                                    out_strides_sl[k] = out_strides_sl[k-1] * out_dims[k-1]
+                            else:
+                                strides = [1]*n
+                                for k in range(n-2, -1, -1):
+                                    strides[k] = strides[k+1] * eff_sh[k+1]
+                                out_strides_sl = None
                             from itertools import product
                             ranges = [range(d) for d in out_dims]
                             W_sel = np.zeros((flat_out, flat_in), dtype=np.float32)
@@ -1266,16 +1632,34 @@ def walk(model):
                                 for ax2, idxs2 in indices_per_axis.items():
                                     src[ax2] = idxs2[coord[ax2]]
                                 src_flat = sum(s*st for s, st in zip(src, strides))
+                                if out_strides_sl is not None:
+                                    r = sum(c*st for c, st in zip(coord, out_strides_sl))
                                 W_sel[r, src_flat] = 1.0
                             b_sel = np.zeros(flat_out, dtype=np.float32)
-                            wkey = add_weight(nm, 'W', W_sel)
-                            bkey = add_weight(nm, 'b', b_sel)
-                            spec = LayerSpec('FullyConnectedLayer', nm,
-                                             attrs={'OutputSize': int(flat_out)},
-                                             inputs=[producer[in_name]],
-                                             outputs=[node.output[0]],
-                                             weight_keys=[wkey, bkey])
-                            emit(spec)
+                            if raw_in_sl:
+                                fc_nm = safe_name(nm + '_sel')
+                                wkey = add_weight(fc_nm, 'W', W_sel)
+                                bkey = add_weight(fc_nm, 'b', b_sel)
+                                emit(LayerSpec('FullyConnectedLayer', fc_nm,
+                                               attrs={'OutputSize': int(flat_out)},
+                                               inputs=[producer[in_name]],
+                                               outputs=[fc_nm + '_out'],
+                                               weight_keys=[wkey, bkey]))
+                                spec = LayerSpec('ReshapeLayer', nm,
+                                                 attrs={'TargetShape': list(map(int, out_dims))},
+                                                 inputs=[fc_nm],
+                                                 outputs=[node.output[0]])
+                                emit(spec)
+                                layout[node.output[0]] = 'RAW'
+                            else:
+                                wkey = add_weight(nm, 'W', W_sel)
+                                bkey = add_weight(nm, 'b', b_sel)
+                                spec = LayerSpec('FullyConnectedLayer', nm,
+                                                 attrs={'OutputSize': int(flat_out)},
+                                                 inputs=[producer[in_name]],
+                                                 outputs=[node.output[0]],
+                                                 weight_keys=[wkey, bkey])
+                                emit(spec)
                             emitted = True
                         except Exception as e:
                             print(f"  [warn] Slice {nm}: selector build failed ({e}), falling back to placeholder", file=sys.stderr)
@@ -1336,6 +1720,26 @@ def walk(model):
 
                         if split_sizes and sum(split_sizes) == eff_sh[ax]:
                             try:
+                                # ATOMIC size pre-check: validate EVERY part
+                                # against the memory cap BEFORE emitting any
+                                # layer. Emitting part0 and then bailing on
+                                # part1 used to leave orphaned, mis-wired
+                                # selector FCs alongside the fallback
+                                # placeholder (collins /model.24/Split_2),
+                                # which crash evaluate on both the MATLAB and
+                                # simulator sides.
+                                flat_in_all = int(np.prod(eff_sh))
+                                for ssz in split_sizes:
+                                    od = list(eff_sh); od[ax] = ssz
+                                    fo = int(np.prod(od))
+                                    if (fo > 200000 or flat_in_all > 200000
+                                            or fo * flat_in_all > 64_000_000):
+                                        raise RuntimeError("split selector too large")
+                                # Flat-order of the selector must match how the
+                                # MATLAB FullyConnectedLayer flattens its input:
+                                # column-major (F-order over the ONNX dims) for
+                                # RAW producers; legacy C-order otherwise.
+                                raw_in = tensor_layout(in_name) == 'RAW'
                                 offset = 0
                                 for k, (out_name, ssz) in enumerate(zip(node.output, split_sizes)):
                                     sub_nm = safe_name(f"{nm}_part{k}")
@@ -1351,9 +1755,18 @@ def walk(model):
                                     if (flat_out > 200000 or flat_in > 200000
                                         or flat_out * flat_in > 64_000_000):
                                         raise RuntimeError("split selector too large")
-                                    strides = [1] * n_dims
-                                    for j in range(n_dims - 2, -1, -1):
-                                        strides[j] = strides[j+1] * eff_sh[j+1]
+                                    if raw_in:
+                                        strides = [1] * n_dims
+                                        for j in range(1, n_dims):
+                                            strides[j] = strides[j-1] * eff_sh[j-1]
+                                        out_strides = [1] * n_dims
+                                        for j in range(1, n_dims):
+                                            out_strides[j] = out_strides[j-1] * out_dims[j-1]
+                                    else:
+                                        strides = [1] * n_dims
+                                        for j in range(n_dims - 2, -1, -1):
+                                            strides[j] = strides[j+1] * eff_sh[j+1]
+                                        out_strides = None
                                     W_sel = np.zeros((flat_out, flat_in), dtype=np.float32)
                                     from itertools import product
                                     ranges = [range(d) for d in out_dims]
@@ -1361,6 +1774,8 @@ def walk(model):
                                         src = list(coord)
                                         src[ax] = coord[ax] + offset
                                         src_flat = sum(s*st for s, st in zip(src, strides))
+                                        if out_strides is not None:
+                                            r = sum(c*st for c, st in zip(coord, out_strides))
                                         W_sel[r, src_flat] = 1.0
                                     b_sel = np.zeros(flat_out, dtype=np.float32)
                                     wkey = add_weight(sub_nm, 'W', W_sel)
@@ -1375,12 +1790,17 @@ def walk(model):
                                     # Reshape flat output back to the original
                                     # logical shape so downstream ops with
                                     # rank-3 broadcasting (Add, etc.) see [1, T, C].
+                                    # (For RAW producers the F-order selector
+                                    # output + column-major reshape compose
+                                    # exactly back to the RAW dims.)
                                     rs_nm = safe_name(f"{sub_nm}_rs")
                                     rs_spec = LayerSpec('ReshapeLayer', rs_nm,
                                                         attrs={'TargetShape': list(map(int, out_dims))},
                                                         inputs=[sub_nm],
                                                         outputs=[out_name])
                                     emit(rs_spec)
+                                    if raw_in:
+                                        layout[out_name] = 'RAW'
                                     offset += ssz
                                 emitted_real = True
                             except Exception as e:
@@ -1431,8 +1851,11 @@ def walk(model):
                 continue
 
             if op == 'ReduceMean':
+                _raw_red = tensor_layout(node.input[0]) == 'RAW'
                 if _try_emit_reduce(node, nm, value_shapes, initializers, producer,
-                                    add_weight, emit, op_name='mean'):
+                                    add_weight, emit, op_name='mean',
+                                    raw_order=_raw_red):
+                    layout[node.output[0]] = 'RAW' if _raw_red else 'FLAT'
                     continue
                 axes = get_attr(node, 'axes', None)
                 spec = LayerSpec('PlaceholderLayer', nm, attrs={'OriginalOp':'ReduceMean',
@@ -1500,16 +1923,28 @@ def walk(model):
                             # Build flat row->col map. For each output position
                             # (lex over I_0..ax-1, q_0..q_{r-1}, I_{ax+1}..),
                             # compute the source flat index.
-                            # Strides over eff_sh (C-order matches MATLAB column-major
-                            # of the flat after our reshape convention).
-                            strides = [1]*n
-                            for k in range(n-2, -1, -1):
-                                strides[k] = strides[k+1] * eff_sh[k+1]
+                            # Strides over eff_sh: C-order for legacy FLAT/HWC
+                            # flows; F-order (MATLAB column-major) for RAW.
+                            raw_in_g = tensor_layout(data_name) == 'RAW'
+                            if raw_in_g:
+                                strides = [1]*n
+                                for k in range(1, n):
+                                    strides[k] = strides[k-1] * eff_sh[k-1]
+                            else:
+                                strides = [1]*n
+                                for k in range(n-2, -1, -1):
+                                    strides[k] = strides[k+1] * eff_sh[k+1]
                             # Iterate output coordinates
                             outer_dims = eff_sh[:ax]
                             inner_dims = eff_sh[ax+1:]
                             out_dims_full = list(outer_dims) + [len(idxs)] + list(inner_dims)
                             flat_out = int(np.prod(out_dims_full)) if out_dims_full else 1
+                            if raw_in_g:
+                                out_strides_g = [1]*len(out_dims_full)
+                                for k in range(1, len(out_dims_full)):
+                                    out_strides_g[k] = out_strides_g[k-1] * out_dims_full[k-1]
+                            else:
+                                out_strides_g = None
                             W_sel = np.zeros((flat_out, flat_in), dtype=np.float32)
                             from itertools import product
                             ranges = [range(d) for d in outer_dims] + [range(len(idxs))] + [range(d) for d in inner_dims]
@@ -1518,16 +1953,34 @@ def walk(model):
                                 src = list(coord)
                                 src[ax] = idxs[coord[ax]]
                                 src_flat = sum(s*st for s, st in zip(src, strides))
+                                if out_strides_g is not None:
+                                    r = sum(c*st for c, st in zip(coord, out_strides_g))
                                 W_sel[r, src_flat] = 1.0
                             b_sel = np.zeros(flat_out, dtype=np.float32)
-                            wkey = add_weight(nm, 'W', W_sel)
-                            bkey = add_weight(nm, 'b', b_sel)
-                            spec = LayerSpec('FullyConnectedLayer', nm,
-                                             attrs={'OutputSize': int(flat_out)},
-                                             inputs=[producer[data_name]],
-                                             outputs=[node.output[0]],
-                                             weight_keys=[wkey, bkey])
-                            emit(spec)
+                            if raw_in_g:
+                                fc_nm = safe_name(nm + '_sel')
+                                wkey = add_weight(fc_nm, 'W', W_sel)
+                                bkey = add_weight(fc_nm, 'b', b_sel)
+                                emit(LayerSpec('FullyConnectedLayer', fc_nm,
+                                               attrs={'OutputSize': int(flat_out)},
+                                               inputs=[producer[data_name]],
+                                               outputs=[fc_nm + '_out'],
+                                               weight_keys=[wkey, bkey]))
+                                spec = LayerSpec('ReshapeLayer', nm,
+                                                 attrs={'TargetShape': list(map(int, out_dims_full))},
+                                                 inputs=[fc_nm],
+                                                 outputs=[node.output[0]])
+                                emit(spec)
+                                layout[node.output[0]] = 'RAW'
+                            else:
+                                wkey = add_weight(nm, 'W', W_sel)
+                                bkey = add_weight(nm, 'b', b_sel)
+                                spec = LayerSpec('FullyConnectedLayer', nm,
+                                                 attrs={'OutputSize': int(flat_out)},
+                                                 inputs=[producer[data_name]],
+                                                 outputs=[node.output[0]],
+                                                 weight_keys=[wkey, bkey])
+                                emit(spec)
                             emitted = True
                     except Exception as e:
                         print(f"  [warn] Gather {nm}: selector build failed ({e}), falling back to placeholder", file=sys.stderr)
@@ -1616,8 +2069,11 @@ def walk(model):
                 continue
 
             if op == 'ReduceSum':
+                _raw_red = tensor_layout(node.input[0]) == 'RAW'
                 if _try_emit_reduce(node, nm, value_shapes, initializers, producer,
-                                    add_weight, emit, op_name='sum'):
+                                    add_weight, emit, op_name='sum',
+                                    raw_order=_raw_red):
+                    layout[node.output[0]] = 'RAW' if _raw_red else 'FLAT'
                     continue
                 axes = get_attr(node, 'axes', None)
                 spec = LayerSpec('PlaceholderLayer', nm, attrs={'OriginalOp':'ReduceSum',
@@ -1666,6 +2122,14 @@ def walk(model):
 
     # Output spec
     out_name = model.graph.output[0].name
+
+    # Stamp each layer with the MATLAB-side layout of its (first) output —
+    # metadata only (the MATLAB loader ignores unknown attrs); used by
+    # manifest_sim.py for orientation-STRICT comparison against onnxruntime.
+    for L in layers:
+        if L.outputs:
+            L.attrs = dict(L.attrs) if L.attrs else {}
+            L.attrs.setdefault('MlLayout', layout.get(L.outputs[0], 'FLAT'))
 
     return layers, weights, inp_name, inp_shape, out_name
 


### PR DESCRIPTION
## What

Fixes the manifest importer's tensor-LAYOUT model so **transformer/attention pipelines** import correctly — the machinery (built for CNN image flows) silently rotated token tensors (pos-emb broadcast misalignment, image-rotation applied to `[B,heads,N,M]` reshapes, no-op'd Kᵀ transposes), which broke every ViT manifest (`inner dims mismatch` crash; 200/200 vit_2023 unknown).

- **Per-tensor layout tracking** through emission (HWC image vs RAW token tensors); RAW reshapes/transposes/selectors use exact ONNX C-order semantics; constants stored trailing-aligned; `ElementwiseAffineLayer` gets an ONNX trailing-broadcast shim.
- New test utilities: `manifest_sim.py` (numpy replica of the MATLAB evaluate semantics, certified vs the known-good manifests) + `check_manifest_matrix.py` (orientation-STRICT regression matrix).
- Runner: `vit` routes through the manifest + NN numerical-gradient PGD falsification (sat-or-unknown; witnesses replayed via the onnxruntime gate). vit added to the manifest-gen lists.

## Validation (orientation-strict max|diff| vs onnxruntime)

| model | tensors | max diff | final out |
|---|---|---|---|
| **vit pgd_2_3_16** | 80 | 2.0e-05 | **4.3e-07** (MATLAB-confirmed: 5.5e-07) |
| **vit ibp_3_3_8** | 116 | 1.2e-04* | 8.6e-07 |
| soundnessbench / cgan / lsnc / traffic / collins | 16–83 | ≤2.5e-05 | all PASS |

\* float32 ULP of the IBP residual stream in the ORT ground truth itself. **All live manifest categories regression-guarded — none changed behavior.**

Beyond VNN-COMP: this is the foundation for general transformer support via the python importer (per project priorities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)