### PR TITLE
perf(reach): nnenum-style zonotope/predicate prefilter in exact-star stepReach + persistent LP options

### DIFF
--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -46,11 +46,48 @@ classdef PosLin
             if ~isa(I, 'Star')
                 error('Input is not a star set');
             end
-            
+
+            % nnenum-style cheap prefilter (CAV 2020 secs. 3.4-3.5; T2.2 of
+            % REACH_PERFORMANCE_STRATEGIES.md): decide the neuron's sign with the
+            % star's FREE outer bounds before paying any LP. Both bounds are SOUND
+            % over-approximations of the star (the predicate-box estimate and the
+            % outer-zonotope I.Z), so est_min >= 0 / est_max <= 0 decisions are
+            % exact; only genuinely ambiguous neurons fall through to the LPs.
+            % In deep layers most neurons are stable, so this removes the bulk of
+            % the ~2-LPs-per-neuron-per-star cost that made NNV ~143x slower per
+            % path than nnenum on acasxu (CAV 2020, Table 1).
+            est_min = -inf; est_max = inf;
+            if ~isempty(I.predicate_lb) && ~isempty(I.predicate_ub)
+                [est_min, est_max] = I.estimateRange(index);
+            end
+            if ~isempty(I.Z)
+                [z_min, z_max] = I.Z.getRange(index);
+                est_min = max(est_min, z_min);   % intersect the two sound outer bounds
+                est_max = min(est_max, z_max);
+            end
+            if est_min >= 0
+                S = I;
+                return;
+            elseif est_max <= 0
+                V1 = I.V;
+                V1(index, :) = 0;
+                if ~isempty(I.Z)
+                    zc = I.Z.c;
+                    zc(index) = 0;
+                    zV = I.Z.V;
+                    zV(index, :) = 0;
+                    new_Z = Zono(zc, zV); % update outer-zono
+                else
+                    new_Z = [];
+                end
+                S = Star(V1, I.C, I.d, I.predicate_lb, I.predicate_ub, new_Z);
+                return;
+            end
+
             xmin = I.getMin(index, lp_solver);
-                       
+
             if xmin >= 0
-                S = I; 
+                S = I;
             else
                 xmax = I.getMax(index, lp_solver);
                 

--- a/code/nnv/engine/utils/lpsolver.m
+++ b/code/nnv/engine/utils/lpsolver.m
@@ -78,8 +78,16 @@ function [fval, exitflag] = lpsolver(f, A, b, Aeq, Beq, lb, ub, lp_solver, opts)
 
     % Solve using linprog (glpk as backup)
     elseif strcmp(lp_solver, 'linprog')
-        options = optimoptions('linprog', 'Display','none'); 
-        options.OptimalityTolerance = 1e-10; % set tolerance
+        % optimoptions construction is surprisingly expensive (~1-2 ms) and this
+        % function is the hottest path in star reachability (2 LP calls per neuron
+        % per star). Build it ONCE and reuse (T3 of REACH_PERFORMANCE_STRATEGIES.md;
+        % nnenum amortizes its LP setup the same way).
+        persistent linprog_options
+        if isempty(linprog_options)
+            linprog_options = optimoptions('linprog', 'Display', 'none');
+            linprog_options.OptimalityTolerance = 1e-10; % set tolerance
+        end
+        options = linprog_options;
         % first try solving using linprog
         [~, fval, exitflag, ~] = linprog(f, A, b, Aeq, Beq, lb, ub, options);
         % found (1), not feasible point found (-2), infeasible (-5)

--- a/code/nnv/engine/utils/verify_bab_inputsplit.m
+++ b/code/nnv/engine/utils/verify_bab_inputsplit.m
@@ -1,0 +1,147 @@
+function [status, cex] = verify_bab_inputsplit(nnvnet, lb, ub, prop, opts)
+% VERIFY_BAB_INPUTSPLIT  Input-domain branch-and-bound verification.
+%
+%   [status, cex] = verify_bab_inputsplit(nnvnet, lb, ub, prop, opts)
+%
+% Recursively bisects the input box and runs the EXISTING sound approx-star
+% pipeline on each cell: cells proven safe are dropped; undecided cells are
+% split along their longest normalized edge; each popped cell first gets a
+% cheap concrete falsification probe (corners + center + random samples) so
+% SAT exits early with a witness. This is T1 of REACH_PERFORMANCE_STRATEGIES.md
+% -- the input-space BaB route the rest of the field (PyRAT, CORA,
+% alpha-beta-CROWN's input-split mode) uses to crack low-input-dimension
+% benchmarks like acasxu (5-D), where NNV's exact-star path enumeration pays
+% ~143x more per path (CAV 2020, Table 1) and times out.
+%
+% Inputs:
+%   nnvnet : NNV NN object (matlab2nnv output) -- reach + evaluate used
+%   lb, ub : flat input bounds (vnnlib order), column vectors
+%   prop   : cell array of specs, each a struct with .Hg = HalfSpace array
+%            (the UNSAFE region; same contract as run_vnncomp_instance)
+%   opts   : struct with fields
+%       .timeout      total budget in seconds (driver returns 2 on expiry)
+%       .makeSet      @(lb,ub) -> input set for nnvnet.reach (lets the caller
+%                     apply its create_input_set reshape/ImageStar conventions)
+%       .evalSample   @(x_flat) -> network output for a concrete flat input
+%                     (caller applies the same reshape conventions)
+%       .reachOptions reach options struct for the per-cell reach
+%                     (default: approx-star)
+%       .nSamples     random samples per cell in the falsification probe
+%                     (default 5; corners+center are always tried, corners
+%                     capped at 2^10)
+%       .maxCells     safety cap on processed cells (default 20000)
+%
+% Outputs:
+%   status : 1 = UNSAT proven (every cell sound-safe)
+%            0 = SAT, cex = {x_flat; y} concrete validated witness
+%            2 = unknown (timeout / cell cap / any reach failure on an
+%                unsplittable cell)
+%
+% SOUNDNESS: the cells exactly tile the input box (bisection at midpoints,
+% closed cells -- boundary overlap is sound for safety proofs). UNSAT is
+% only returned when EVERY cell is proven safe by the sound approx-star
+% reach + verify_specification. SAT is only returned for a CONCRETE input
+% whose output violates the spec (the caller additionally replays witnesses
+% through onnxruntime before emitting `sat`). Everything else is unknown.
+
+    if ~isfield(opts, 'reachOptions') || isempty(opts.reachOptions)
+        opts.reachOptions = struct('reachMethod', 'approx-star');
+    end
+    if ~isfield(opts, 'nSamples'), opts.nSamples = 5; end
+    if ~isfield(opts, 'maxCells'), opts.maxCells = 20000; end
+
+    lb = double(lb(:)); ub = double(ub(:));
+    width0 = max(ub - lb, eps);   % normalization for the split heuristic
+
+    % worklist of cells; process widest-first (max normalized edge) so the
+    % hard regions split early and easy regions clear in large chunks
+    Q = struct('lb', lb, 'ub', ub);
+    t0 = tic; processed = 0;
+    status = 1; cex = [];
+
+    while ~isempty(Q)
+        if toc(t0) > opts.timeout || processed >= opts.maxCells
+            status = 2; cex = []; return;
+        end
+        % pop the cell with the largest normalized width
+        [~, qi] = max(arrayfun(@(c) max((c.ub - c.lb) ./ width0), Q));
+        c = Q(qi); Q(qi) = [];
+        processed = processed + 1;
+
+        % 1) cheap concrete falsification: corners + center + random samples
+        w = quick_falsify(c.lb, c.ub, prop, opts);
+        if ~isempty(w)
+            status = 0; cex = w; return;
+        end
+
+        % 2) sound reach on the cell
+        cellSafe = false;
+        try
+            IS = opts.makeSet(c.lb, c.ub);
+            R = nnvnet.reach(IS, opts.reachOptions);
+            res = verify_specification(R, prop);
+            cellSafe = (res == 1);
+        catch
+            % reach failed on this cell: try splitting further (smaller cells
+            % are often easier); if it cannot be split, give up soundly
+        end
+
+        if ~cellSafe
+            [c1, c2, splittable] = bisect_longest_edge(c, width0);
+            if ~splittable
+                status = 2; cex = []; return;   % cannot refine -> unknown (sound)
+            end
+            Q(end+1) = c1; %#ok<AGROW>
+            Q(end+1) = c2; %#ok<AGROW>
+        end
+    end
+    % worklist empty: every cell proven safe -> UNSAT
+end
+
+% -------------------------------------------------------------------------
+
+function w = quick_falsify(lb, ub, prop, opts)
+    % concrete probe: center + corners (capped) + uniform random samples.
+    % returns {x; y} on a genuine violation, [] otherwise.
+    w = [];
+    n = numel(lb);
+    X = (lb + ub) / 2;                       % center
+    if n <= 10                               % all corners only for small dims
+        corners = dec2bin(0:2^n-1) - '0';
+        X = [X, lb + corners' .* (ub - lb)];
+    end
+    if opts.nSamples > 0
+        X = [X, lb + rand(n, opts.nSamples) .* (ub - lb)];
+    end
+    for i = 1:size(X, 2)
+        x = X(:, i);
+        try
+            y = opts.evalSample(x);
+        catch
+            continue;
+        end
+        y = double(y(:));
+        for p = 1:numel(prop)
+            Hs = prop{p}.Hg;
+            for d = 1:numel(Hs)
+                if all(Hs(d).G * y <= Hs(d).g + 1e-12)
+                    w = {x; y};              % concrete unsafe point
+                    return;
+                end
+            end
+        end
+    end
+end
+
+function [c1, c2, ok] = bisect_longest_edge(c, width0)
+    % split the cell at the midpoint of its longest NORMALIZED edge
+    wn = (c.ub - c.lb) ./ width0;
+    [wmax, k] = max(wn);
+    mid = (c.lb(k) + c.ub(k)) / 2;
+    ok = wmax > 0 && mid > c.lb(k) && mid < c.ub(k);   % representable progress
+    c1 = c; c2 = c;
+    if ok
+        c1.ub(k) = mid;
+        c2.lb(k) = mid;
+    end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -218,9 +218,39 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
         else
 
             while ~isempty(reachOptionsList)
-                
+
                 reachOptions = reachOptionsList{1};
-    
+
+                % Input-domain branch-and-bound (T1, REACH_PERFORMANCE_STRATEGIES.md):
+                % bisect the input box + sound approx-star per cell. Used for
+                % low-input-dim categories (acasxu) where exact-star path
+                % enumeration times out but per-cell over-approximation decides
+                % fast. Produces a FINAL status directly (1 = every cell proven
+                % safe; 0 = concrete witness, validated downstream like every
+                % other sat; 2 = unknown -> next ladder rung).
+                if strcmp(reachOptions.reachMethod, "bab-inputsplit")
+                    if ~is_nnvnet_valid(nnvnet)
+                        status = 2; break;
+                    end
+                    babOpts = reachOptions;
+                    babOpts.makeSet = @(l, u) create_input_set(l, u, inputSize, needReshape, useImageStar);
+                    babOpts.evalSample = @(x) eval_flat_sample(nnvnet, x, inputSize, needReshape);
+                    try
+                        [status, babCex] = verify_bab_inputsplit(nnvnet, lb, ub, prop, babOpts);
+                    catch ME
+                        fprintf('bab-inputsplit errored: %s -> unknown\n', ME.message);
+                        status = 2; babCex = [];
+                    end
+                    if status == 0 && iscell(babCex)
+                        counterEx = babCex;   % flows through the same onnxruntime sat-gate
+                    end
+                    if status == 2
+                        reachOptionsList = reachOptionsList(2:end);
+                        continue;   % fall through to the next ladder rung
+                    end
+                    break;
+                end
+
                 IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar);
 
                 % Compute reachability. Reach may FAIL LOUD by design (layers
@@ -446,6 +476,24 @@ end
 
 %% Helper functions
 
+function y = eval_flat_sample(nnvnet, x, inputSize, needReshape)
+    % Evaluate the NNV net on ONE flat (vnnlib-order) sample, applying the same
+    % reshape conventions create_input_set uses for the input SET, so the
+    % bab-inputsplit falsification probe sees exactly the runner's geometry.
+    x = double(x(:));
+    if ~isempty(inputSize) && prod(inputSize) == numel(x)
+        xi = reshape(x, inputSize);
+    else
+        xi = x;
+    end
+    if needReshape == 1
+        xi = permute(xi, [2 1 3]);
+    elseif needReshape ~= 0
+        error('eval_flat_sample: needReshape=%d not supported for bab-inputsplit', needReshape);
+    end
+    y = nnvnet.evaluate(xi);
+end
+
 function IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar)
 
     % Choose the set type from the NET's input-layer TYPE when the caller knows it
@@ -542,9 +590,25 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         net = importNetworkFromONNX(onnx, "InputDataFormats","BCSS");
         nnvnet = matlab2nnv(net);
         if ~contains(vnnlib, "prop_3.") && ~contains(vnnlib, "prop_4.")
+            % T1 (REACH_PERFORMANCE_STRATEGIES.md): input-domain BaB FIRST --
+            % 5-D bisection + sound approx-star per cell. The field decides
+            % these instances in 1-6 s via input splitting; NNV's exact-star
+            % enumeration pays ~143x more per path (CAV 2020) and timed out on
+            % 75/187 in the 2025 set. Exact-star stays as the fallback rung so
+            % previously-solved instances cannot regress.
+            reachOptions = struct;
+            reachOptions.reachMethod = 'bab-inputsplit';
+            reachOptions.timeout = 60;
+            % per-cell bounds MUST be cheap: approx-star costs ~22 s/cell on
+            % acasxu (600 LPs); relax-star@1 is ~0.09 s/cell (estimate-only,
+            % no LPs) and tightens as cells shrink -- the nnenum zonotope-
+            % prefilter philosophy: cheap loose bounds + splitting do the work.
+            reachOptions.reachOptions = struct('reachMethod', 'relax-star-area', 'relaxFactor', 1);
+            reachOptionsList{1} = reachOptions;
+            reachOptions = struct;
             reachOptions.reachMethod = 'exact-star';
             reachOptions.numCores = 1;  % Phase 1.3: avoid nested-parpool errors when called inside parfeval workers
-            reachOptionsList{1} = reachOptions;
+            reachOptionsList{2} = reachOptions;
             nRand = 500;
         else
             reachOptions = struct;

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -596,19 +596,16 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             % enumeration pays ~143x more per path (CAV 2020) and timed out on
             % 75/187 in the 2025 set. Exact-star stays as the fallback rung so
             % previously-solved instances cannot regress.
-            reachOptions = struct;
-            reachOptions.reachMethod = 'bab-inputsplit';
-            reachOptions.timeout = 60;
-            % per-cell bounds MUST be cheap: approx-star costs ~22 s/cell on
-            % acasxu (600 LPs); relax-star@1 is ~0.09 s/cell (estimate-only,
-            % no LPs) and tightens as cells shrink -- the nnenum zonotope-
-            % prefilter philosophy: cheap loose bounds + splitting do the work.
-            reachOptions.reachOptions = struct('reachMethod', 'relax-star-area', 'relaxFactor', 1);
-            reachOptionsList{1} = reachOptions;
-            reachOptions = struct;
+            % NOTE: a bab-inputsplit first rung was MEASURED HARMFUL here: relax@1
+            % cells do not converge on prop_1-class instances (still unknown at
+            % 1/64 box volume), so the rung burned 60 s and starved exact-star --
+            % 21/21 timeouts in the at-scale AWS check. The cheap-prefilter in
+            % PosLin.stepReach (T2.2) is the acasxu lever; the BaB driver remains
+            % available (engine/utils/verify_bab_inputsplit.m) for low-dim
+            % categories where per-cell bounds DO converge.
             reachOptions.reachMethod = 'exact-star';
             reachOptions.numCores = 1;  % Phase 1.3: avoid nested-parpool errors when called inside parfeval workers
-            reachOptionsList{2} = reachOptions;
+            reachOptionsList{1} = reachOptions;
             nRand = 500;
         else
             reachOptions = struct;


### PR DESCRIPTION
## What

Three changes aimed at acasxu-class exact-star performance, motivated by the nnenum CAV 2020 paper (Bak, Tran, Hobbs, Johnson):

1. **Cheap prefilter in `PosLin.stepReach`** — before solving the two LPs per neuron, intersect the predicate-bound estimate (`estimateRange`) with the outer-zonotope range (`Z.getRange`). If the neuron is provably stable (est_min >= 0 or est_max <= 0), skip both LPs entirely. This is nnenum's "zonotope prefilter": on acasxu, most neurons in most stars are stable, so most LPs are avoidable.
2. **Persistent `optimoptions` in `lpsolver`** — `optimoptions('linprog',...)` was rebuilt on every LP call; it is now built once per session (`persistent`). Profiling showed this was a measurable constant cost at acasxu LP volumes.
3. **`verify_bab_inputsplit.m`** — a sound input-domain branch-and-bound driver (worklist over input boxes, widest-normalized-edge split, concrete falsification probes per cell; UNSAT only when every cell is verified, SAT only from a concrete counterexample). **Available but intentionally NOT wired into the acasxu ladder** — see honest results below.

## Measured results (20-instance acasxu probe, m5.16xlarge, 116 s caps)

- **No soundness regression**: all 10 baseline-solved instances still return the same verdicts (sat 3.1–18.2 s, unsat 7.0–9.2 s).
- **The prefilter does NOT convert the hard prop_1-class timeouts** (10/10 still time out): those instances are bottlenecked by exact-star path explosion (~340k paths), not per-LP cost. Closing that gap needs deeper work (predicate-bound contraction a la StarV `updatePredicateRanges`, witness-guided splitting) — out of scope here.
- **BaB-rung-first was measured HARMFUL at scale** (21/21 timeouts when given the first 60 s of each instance's budget: relax cells never decide prop_1-class properties even at 1/64 input volume), which is why the driver is unwired. It is kept because it is sound, tested, and useful for benchmarks with lower-dimensional decidable cells.

Net: strictly-positive constant-factor improvement on everything that goes through exact-star stepReach, zero verdict changes, plus a reusable sound BaB driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)