### PR TITLE
hotfix: literal newline broke run_all_benchmarks.m parse (killed overnight sweep)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -200,8 +200,7 @@ for i = 1:n
             catch ME_pool
                 % restarting the pool is the zombie-kill mechanism; if delete
                 % fails we still attempt the restart, but say so loudly
-                fprintf('WARN: pool delete failed (%s); attempting restart anyway
-', ME_pool.message);
+                fprintf('WARN: pool delete failed (%s); attempting restart anyway\n', ME_pool.message);
             end
             pool = parpool('Processes', 1);
             pool_is_cold = true;   % next instance gets the one-time cold-start grace


### PR DESCRIPTION
## What
The pool-restart `WARN` `fprintf` in `run_all_benchmarks.m` (added in #344) had a **literal newline** where `\n` was intended, so MATLAB failed to parse the file (`Character vector is not terminated properly`, line 203). Every worker in tonight's full sweep died at startup with this error.

CI didn't catch it because `run_all_benchmarks.m` is a sweep driver, not exercised by the unit/regression test suite. Same corruption class as the #341 fix in `run_vnncomp_instance.m`.

## Fix
One line: join the broken string with a proper `\n`. Verified no other orphan-quote lines remain in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)