### PR TITLE
fix(startup): self-heal corrupted tbxenabled.txt for robust parallel startup_nnv

### DIFF
--- a/code/nnv/startup_nnv.m
+++ b/code/nnv/startup_nnv.m
@@ -25,27 +25,36 @@ catch tbx_err
     warning('NNV:tbxRestore', ...
         'tbxmanager restorepath failed (%s); repairing tbxenabled.txt and retrying.', ...
         tbx_err.message);
-    tbx_dir = fileparts(which('tbxmanager.m'));
-    enabled_file = fullfile(tbx_dir, 'tbxenabled.txt');
-    toolboxes_dir = fullfile(tbx_dir, 'toolboxes');
-    if isfile(enabled_file)
-        raw_lines = strsplit(strtrim(fileread(enabled_file)), newline);
-        kept = {};
-        for tbx_i = 1:numel(raw_lines)
-            entry = strtrim(raw_lines{tbx_i});
-            parts = strsplit(entry, ':');   % name:version:arch
-            if numel(parts) == 3 && isfolder(fullfile(toolboxes_dir, parts{1}, parts{2}, parts{3}))
-                kept{end+1} = entry; %#ok<AGROW>
+    % Best-effort repair. If anything here fails (tbxmanager.m not on path, or a
+    % file op throws), surface the ORIGINAL restorepath error rather than mask it.
+    try
+        tbx_dir = fileparts(which('tbxmanager.m'));
+        if isempty(tbx_dir)
+            rethrow(tbx_err);   % can't locate tbxenabled.txt -> don't guess a cwd path
+        end
+        enabled_file = fullfile(tbx_dir, 'tbxenabled.txt');
+        toolboxes_dir = fullfile(tbx_dir, 'toolboxes');
+        if isfile(enabled_file)
+            raw_lines = strsplit(strtrim(fileread(enabled_file)), newline);
+            kept = {};
+            for tbx_i = 1:numel(raw_lines)
+                entry = strtrim(raw_lines{tbx_i});
+                parts = strsplit(entry, ':');   % name:version:arch
+                if numel(parts) == 3 && isfolder(fullfile(toolboxes_dir, parts{1}, parts{2}, parts{3}))
+                    kept{end+1} = entry; %#ok<AGROW>
+                end
+            end
+            kept = unique(kept, 'stable');      % drop duplicates from a partial write
+            fid = fopen(enabled_file, 'w');
+            if fid > 0
+                if ~isempty(kept)
+                    fprintf(fid, '%s\n', kept{:});
+                end
+                fclose(fid);
             end
         end
-        kept = unique(kept, 'stable');      % drop duplicates from a partial write
-        fid = fopen(enabled_file, 'w');
-        if fid > 0
-            if ~isempty(kept)
-                fprintf(fid, '%s\n', kept{:});
-            end
-            fclose(fid);
-        end
+    catch
+        rethrow(tbx_err);   % repair failed -> report the real cause, not the repair's
     end
     tbxmanager restorepath                  % retry once on the repaired list
 end

--- a/code/nnv/startup_nnv.m
+++ b/code/nnv/startup_nnv.m
@@ -12,7 +12,43 @@ end
 if ~exist("tbxmanager.m","file") % not added to the path
     addpath("tbxmanager");
 end
-tbxmanager restorepath
+% Restore toolbox paths. tbxmanager's enabled-toolbox list (tbxenabled.txt) is
+% shared mutable state that is NOT concurrency-safe: parallel startup_nnv calls
+% (e.g. batched/parallel verification jobs, as used when sweeping VNN-COMP
+% benchmarks) or a process killed mid-write can corrupt it, after which
+% 'restorepath' aborts with "Toolbox <name> is not installed". Self-heal by
+% dropping any enabled entry whose toolbox is not actually installed, then retry,
+% so a single corrupted line cannot take down every parallel worker's startup.
+try
+    tbxmanager restorepath
+catch tbx_err
+    warning('NNV:tbxRestore', ...
+        'tbxmanager restorepath failed (%s); repairing tbxenabled.txt and retrying.', ...
+        tbx_err.message);
+    tbx_dir = fileparts(which('tbxmanager.m'));
+    enabled_file = fullfile(tbx_dir, 'tbxenabled.txt');
+    toolboxes_dir = fullfile(tbx_dir, 'toolboxes');
+    if isfile(enabled_file)
+        raw_lines = strsplit(strtrim(fileread(enabled_file)), newline);
+        kept = {};
+        for tbx_i = 1:numel(raw_lines)
+            entry = strtrim(raw_lines{tbx_i});
+            parts = strsplit(entry, ':');   % name:version:arch
+            if numel(parts) == 3 && isfolder(fullfile(toolboxes_dir, parts{1}, parts{2}, parts{3}))
+                kept{end+1} = entry; %#ok<AGROW>
+            end
+        end
+        kept = unique(kept, 'stable');      % drop duplicates from a partial write
+        fid = fopen(enabled_file, 'w');
+        if fid > 0
+            if ~isempty(kept)
+                fprintf(fid, '%s\n', kept{:});
+            end
+            fclose(fid);
+        end
+    end
+    tbxmanager restorepath                  % retry once on the repaired list
+end
 
 fprintf('\nAdding NNV to Matlab path...\n');
 %mydir  = pwd;


### PR DESCRIPTION
## Problem
`tbxmanager`'s enabled-toolbox list (`code/nnv/tbxmanager/tbxenabled.txt`) is shared mutable state and is **not concurrency-safe**. When many MATLAB processes run `startup_nnv` simultaneously — exactly what happens in a **parallel VNN-COMP benchmark sweep** (one `matlab -batch` per benchmark) — or when a worker is killed mid-write, the file gets corrupted. We observed a `sedumi:1.3:glnxa64` entry mangled into `msedumi:1.3:glnxa64` plus a duplicate line.

After that, **every** subsequent `startup_nnv` aborts in `tbxmanager restorepath` with:
```
Error using tbxmanager>tbx_addPath (line 649)
Toolbox "msedumi:1.3:glnxa64" is not installed.
```
which takes down all parallel workers at once (in our sweep, ~57/60 benchmark jobs failed at startup until repaired).

## Fix
Wrap `tbxmanager restorepath` in a `try/catch`. On failure, drop any enabled entry whose `toolboxes/<name>/<version>/<arch>` directory does not actually exist, de-duplicate, rewrite the list, and retry once.

- **Normal startup is unaffected** — the repair only runs inside the `catch`, so an uncorrupted list never touches the new code path.
- Self-heals regardless of the corruption source (concurrent or partial write).
- No new files or dependencies; ~20 lines, validated clean by the MATLAB Code Analyzer (info-level lints only).

## Why it matters
This surfaced while running parallel benchmark sweeps in preparation for VNN-COMP 2026, and the same failure mode could hit the competition harness or any parallel/CI run of NNV. Operationally we also serialize startup across sweep workers, but making `startup_nnv` itself resilient is the right repo-level fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)