### PR TITLE
fix(importer): .Vars fallback for R2026a custom layers reading hardcoded .ONNXParams

### DIFF
--- a/code/nnv/engine/nn/layers/ReshapeLayer.m
+++ b/code/nnv/engine/nn/layers/ReshapeLayer.m
@@ -325,7 +325,21 @@ classdef ReshapeLayer < handle
                 error('Input is not a reshape layer');
             end
             
-            params = layer.ONNXParams.Nonlearnables;
+            % R2024b- importONNXLayers custom layers expose the reshape target
+            % dim as an ONNXParams.Nonlearnables struct. R2026a
+            % importNetworkFromONNX custom ReshapeLayer classes have NO
+            % ONNXParams property -- the ONNX Constant target shape lives on
+            % .Vars instead (e.g. Vars.x_base_Constant_outp = [-1 3 64 64]).
+            % Try ONNXParams, fall back to .Vars so both importer eras parse.
+            if isprop(layer, 'ONNXParams')
+                params = layer.ONNXParams.Nonlearnables;
+            elseif isprop(layer, 'Vars')
+                params = layer.Vars;
+            else
+                error('ReshapeLayer:noParams', ...
+                    ['Custom ReshapeLayer ''%s'' has neither ONNXParams nor ' ...
+                     'Vars; cannot recover the reshape target dim.'], layer.Name);
+            end
             par_fields = fields(params);
             if length(par_fields) == 1
                 params = struct2cell(params);

--- a/code/nnv/engine/nn/layers/UpsampleLayer.m
+++ b/code/nnv/engine/nn/layers/UpsampleLayer.m
@@ -250,7 +250,17 @@ classdef UpsampleLayer < handle
                 error('Input is not a upsample layer');
             end
             
-            params = layer.ONNXParams.Learnables;
+            % Same R2026a importer change as ReshapeLayer: custom layers may
+            % carry their params on .Vars instead of .ONNXParams. Fail closed.
+            if isprop(layer, 'ONNXParams')
+                params = layer.ONNXParams.Learnables;
+            elseif isprop(layer, 'Vars')
+                params = layer.Vars;
+            else
+                error('UpsampleLayer:noParams', ...
+                    ['Custom UpsampleLayer ''%s'' has neither ONNXParams nor ' ...
+                     'Vars; cannot recover the scale.'], layer.Name);
+            end
             par_fields = fields(params);
             if length(par_fields) == 1
                 params = struct2cell(params);

--- a/code/nnv/engine/utils/matlab2nnv.m
+++ b/code/nnv/engine/utils/matlab2nnv.m
@@ -410,10 +410,20 @@ end
 % Check if custom layers can be skipped (e.g., pad layer with 0 padding does not change anything in the network)
 function status = check_layer_parameters(L)
     status = 0;
-    if isempty(L.ONNXParams.Nonlearnables)
+    % R2026a importNetworkFromONNX custom layers may carry params on .Vars
+    % instead of .ONNXParams (see ReshapeLayer/UpsampleLayer). Fail closed.
+    if isprop(L, 'ONNXParams')
+        nonlearn = L.ONNXParams.Nonlearnables;
+    elseif isprop(L, 'Vars')
+        nonlearn = L.Vars;
+    else
+        error('matlab2nnv:noParams', ...
+            'Layer ''%s'' has neither ONNXParams nor Vars.', class(L));
+    end
+    if isempty(nonlearn)
         status = 1;
     elseif contains(class(L), 'PadLayer')
-        params = struct2cell(L.ONNXParams.Nonlearnables);
+        params = struct2cell(nonlearn);
         for i=1:length(params)
             tmp = extractdata(params{i});
             if ~all(tmp==0)


### PR DESCRIPTION
## Problem
R2024b `importONNXLayers` exposed custom-layer parameters on `.ONNXParams`. **R2026a `importNetworkFromONNX` custom layer classes (`ReshapeLayer`, `UpsampleLayer`, …) have no `ONNXParams` property** — the ONNX `Constant` target shape lives on `.Vars` instead (e.g. `Vars.x_base_Constant_outp = [-1 3 64 64]`). Every hardcoded `layer.ONNXParams` read therefore throws:
```
Unrecognized method, property, or field 'ONNXParams' for class '...ReshapeLayer...'
```
and the **entire network fails to convert** in `matlab2nnv`.

In the VNN-COMP 2026 sweep this took out **~160 relusplitter `cifar_biasfield` instances** (all recorded as `error`), the single biggest error bucket.

## Fix
Probe `isprop(layer,'ONNXParams')` → fall back to `.Vars` → else `error` loudly, at all three hardcoded sites:
- **`ReshapeLayer.parse`** — the live failure. Verified the recovered target dim `[-1 3 64 64]` matches the model and `evaluate` yields `[1 3 64 64]`.
- **`UpsampleLayer.parse`** and **`matlab2nnv.check_layer_parameters` (PadLayer)** — latent siblings of the same bug, hardened pre-emptively so the next R2026a Pad/Upsample net doesn't hit the same crash.

## Soundness
**Neutral / fail-closed.** The fix reads the *genuine* ONNX shape from the alternate storage — not a guess. `ONNXParams` is tried first, so existing (older-importer) conversions are byte-identical. If a layer has neither property, it errors loudly → the runner reports `error`/`unknown`, never a wrong verdict.

## Validation
- `importNetworkFromONNX(cifar_bias_field_*, 'InputDataFormats','BC')` + `matlab2nnv` now converts to the full NNV net (previously threw `MATLAB:noSuchMethodOrField`).
- MATLAB Code Analyzer: clean (info-level style lints only, none at the changed lines).

Unblocks ~160 instances; first of the VNN-COMP 2026 importer fix backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)