### PR TITLE
fix(dispatcher): route adaptive_cruise + traffic_signs(48/64px) + smart_turn abstain

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -60,6 +60,8 @@ end
 % net to cp-star/manifest and emitting an unsound verdict -- unknown is always a
 % safe VNN-COMP verdict. A real fix (multimodal + quantization) is out of scope.
 if contains(category, "smart_turn")
+    status = 2;            % unknown
+    tTime = toc(t);        % assign both outputs before the early return
     fid = fopen(outputfile, 'w');
     fprintf(fid, 'unknown \n');
     fclose(fid);

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -53,6 +53,19 @@ if contains(category, 'collins_aerospace_benchmark')
     return;
 end
 
+% smart_turn_multimodal_2026: a 692-node INT8-quantized MULTIMODAL transformer
+% (199 DequantizeLinear + 119 QuantizeLinear + 22 Conv + 9 Erf + 5 Softmax, with a
+% 5D video input). MATLAB's importer collapses it to an opaque fused blob NNV
+% cannot soundly evaluate. Abstain (unknown) rather than risk feeding the fused
+% net to cp-star/manifest and emitting an unsound verdict -- unknown is always a
+% safe VNN-COMP verdict. A real fix (multimodal + quantization) is out of scope.
+if contains(category, "smart_turn")
+    fid = fopen(outputfile, 'w');
+    fprintf(fid, 'unknown \n');
+    fclose(fid);
+    return;
+end
+
 %% 1) Load components
 
 % Load networks
@@ -647,7 +660,21 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             reachOptions.numCores = 1;  % Phase 1.3: avoid nested-parpool errors when called inside parfeval workers
             reachOptionsList{2} = reachOptions;
         end
-        
+
+    elseif contains(category, "adaptive_cruise")
+        % adaptive_cruise_control_non_linear_2026: a pure FFNN (8x Gemm + 5x Relu,
+        % [1,2]->[1,1]) that imports cleanly; it only erred because no dispatcher
+        % branch matched and control fell to the catch-all "ONNX model not
+        % supported". Route it through the standard FFNN reach path.
+        net = importNetworkFromONNX(onnx, "InputDataFormats", "BC");
+        nnvnet = matlab2nnv(net);
+        reachOptions = struct;
+        reachOptions.reachMethod = 'approx-star';
+        reachOptionsList{1} = reachOptions;
+        reachOptions = struct;
+        reachOptions.reachMethod = 'exact-star'; % tiny net -> sound+complete fallback
+        reachOptions.numCores = 1;
+        reachOptionsList{2} = reachOptions;
 
     elseif contains(category, "cctsdb_yolo")
         % Handled by the complete-enumeration path at the TOP of
@@ -1020,7 +1047,11 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         %   img = permute(reshape(x, [3 30 30]), [3 2 1])  -> [30 30 3] HWC
         nnvnet = load_manifest_net(onnx);
         net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
-        inputSize = [3 30 30];   % reshape size BEFORE the [3 2 1] permute
+        % reshape size BEFORE the [3 2 1] permute. The old hardcoded [3 30 30]
+        % only fit the 30x30 models and threw "Number of elements must not
+        % change" on the 48x48 / 64x64 traffic-sign models (6912 / 12288 != 2700).
+        % Derive it from the net's own input layer: InputSize [H W C] -> [C W H].
+        inputSize = nnvnet.Layers{1}.InputSize([3 2 1]);
         needReshape = 3;
         reachOptions = struct;
         reachOptions.reachMethod = 'approx-star';


### PR DESCRIPTION
## What
Three dispatcher-routing fixes from the VNN-COMP 2026 sweep error analysis (~160 instances, all S-effort/sound):

| benchmark | was | now | inst |
|---|---|---|---|
| `adaptive_cruise_control_non_linear_2026` | `error: ONNX model not supported` (no dispatcher branch) | FFNN reach branch (approx-star + exact-star fallback) | +50 |
| `traffic_signs_recognition_2023` | `error: Number of elements must not change` on 48×48/64×64 | dynamic `inputSize` from the net's own input layer | +60 |
| `smart_turn_multimodal_2026` | `error: ONNX model not supported` (opaque fused blob) | abstain → `unknown` (sound) | +50 |

## Detail
- **adaptive_cruise** is a pure FFNN (8× Gemm + 5× Relu, `[1,2]→[1,1]`) that imports cleanly via `importNetworkFromONNX(...,'BC')` + `matlab2nnv`; it only errored because no `elseif` matched. Added an FFNN branch through the standard reach path.
- **traffic_signs** hardcoded `inputSize=[3 30 30]` (2700 elems) for all resolutions, so `reshape` threw on the 48×48 (6912) and 64×64 (12288) models. Now `inputSize = nnvnet.Layers{1}.InputSize([3 2 1])` — the 30×30 case is unchanged (`[3 30 30]`), and 48/64 build correctly. SAT remains gated by the onnxruntime witness replay, so no unsound SAT can leak from an orientation edge case.
- **smart_turn** is a 692-node INT8-quantized multimodal transformer (199 DequantizeLinear + 5D video input) that MATLAB collapses to an opaque fused layer NNV can't soundly evaluate. It now abstains to `unknown` at the top, instead of risking a verdict from a net NNV can't faithfully evaluate.

## Soundness
All three are sound-or-unknown: adaptive_cruise goes through the standard sound reach+falsify+validate pipeline; traffic_signs only fixes input-set *shape* (SAT still witness-validated); smart_turn abstains. Code Analyzer clean.

Second PR in the VNN-COMP 2026 importer/dispatcher fix backlog (after #349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)