### PR TITLE
acasxu: nnenum-style predicate-bound contraction + estimate-first in exact-star (sound, verdict-invariant)

### DIFF
--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -55,23 +55,29 @@ classdef PosLin
             % return, so exactness/completeness is untouched. Only the genuinely
             % two-sided case falls through to the LPs below. Compounds with predicate
             % contraction: contraction creates one-sided neurons, this cashes them in.
-            [emin, emax] = I.estimateRange(index);
-            if emin >= 0
-                S = I;                  % provably active: identity, no LP
-                return;
-            end
-            if emax <= 0                % provably inactive: zero the row, no LP
-                V1 = I.V;
-                V1(index, :) = 0;
-                if ~isempty(I.Z)        % outer-zono update mirrors the xmax<=0 branch
-                    zc = I.Z.c; zc(index) = 0;
-                    zV = I.Z.V; zV(index, :) = 0;
-                    new_Z = Zono(zc, zV);
-                else
-                    new_Z = [];
+            % Only run the shortcut when the predicate box is available (exact-star
+            % always sets it). If it is empty, estimateRange would fall back to an LP
+            % that ignores the caller's lp_solver, so skip the shortcut and use the
+            % getMin/getMax LPs below directly. (Addresses Copilot review #2.)
+            if ~isempty(I.predicate_lb) && ~isempty(I.predicate_ub)
+                [emin, emax] = I.estimateRange(index);
+                if emin >= 0
+                    S = I;                  % provably active: identity, no LP
+                    return;
                 end
-                S = Star(V1, I.C, I.d, I.predicate_lb, I.predicate_ub, new_Z);
-                return;
+                if emax <= 0                % provably inactive: zero the row, no LP
+                    V1 = I.V;
+                    V1(index, :) = 0;
+                    if ~isempty(I.Z)        % outer-zono update mirrors the xmax<=0 branch
+                        zc = I.Z.c; zc(index) = 0;
+                        zV = I.Z.V; zV(index, :) = 0;
+                        new_Z = Zono(zc, zV);
+                    else
+                        new_Z = [];
+                    end
+                    S = Star(V1, I.C, I.d, I.predicate_lb, I.predicate_ub, new_Z);
+                    return;
+                end
             end
 
             xmin = I.getMin(index, lp_solver);

--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -88,13 +88,22 @@ classdef PosLin
                     else
                         new_Z = [];
                     end
-                    S1 = Star(new_V, new_C, new_d, I.predicate_lb, I.predicate_ub, new_Z);
+                    % nnenum-style predicate-bound contraction (CAV 2020): tighten
+                    % the predicate box from the newly-added split constraint so the
+                    % NEXT layer's stability prefilter (estimateRanges) sees smaller
+                    % bounds and flags fewer neurons as branching -> fewer splits ->
+                    % smaller exact-star tree. Sound: contraction only intersects the
+                    % box with a constraint already in C*alpha<=d, so no feasible
+                    % alpha is removed and the represented set is unchanged.
+                    [plb1, pub1] = Star.updatePredicateRanges(V, -c, I.predicate_lb, I.predicate_ub);
+                    S1 = Star(new_V, new_C, new_d, plb1, pub1, new_Z);
 
                     % S2 = I && x[index] >= 0
                     new_C = vertcat(I.C, -V);
                     new_d = vertcat(I.d, c);
 
-                    S2 = Star(I.V, new_C, new_d, I.predicate_lb, I.predicate_ub, I.Z);
+                    [plb2, pub2] = Star.updatePredicateRanges(-V, c, I.predicate_lb, I.predicate_ub);
+                    S2 = Star(I.V, new_C, new_d, plb2, pub2, I.Z);
 
                    S = [S1 S2];
 

--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -46,9 +46,36 @@ classdef PosLin
             if ~isa(I, 'Star')
                 error('Input is not a star set');
             end
-            
+
+            % --- nnenum-style estimate-first sign decision (CAV 2020, Step 2) ---
+            % estimateRange is a SOUND interval over-approximation of x[index] over
+            % the (Step-1-contracted) predicate box: true range subset of [emin,emax].
+            % A one-sided estimate therefore decides the neuron with ZERO LPs and the
+            % deterministic assignment is exactly what the getMin/getMax LPs would
+            % return, so exactness/completeness is untouched. Only the genuinely
+            % two-sided case falls through to the LPs below. Compounds with predicate
+            % contraction: contraction creates one-sided neurons, this cashes them in.
+            [emin, emax] = I.estimateRange(index);
+            if emin >= 0
+                S = I;                  % provably active: identity, no LP
+                return;
+            end
+            if emax <= 0                % provably inactive: zero the row, no LP
+                V1 = I.V;
+                V1(index, :) = 0;
+                if ~isempty(I.Z)        % outer-zono update mirrors the xmax<=0 branch
+                    zc = I.Z.c; zc(index) = 0;
+                    zV = I.Z.V; zV(index, :) = 0;
+                    new_Z = Zono(zc, zV);
+                else
+                    new_Z = [];
+                end
+                S = Star(V1, I.C, I.d, I.predicate_lb, I.predicate_ub, new_Z);
+                return;
+            end
+
             xmin = I.getMin(index, lp_solver);
-                       
+
             if xmin >= 0
                 S = I; 
             else

--- a/code/nnv/engine/set/Star.m
+++ b/code/nnv/engine/set/Star.m
@@ -2095,6 +2095,49 @@ classdef Star
 
     methods(Static) % helper functions
 
+        function [plb, pub] = updatePredicateRanges(a, b, plb, pub)
+            % nnenum-style LP-free predicate-bound contraction (CAV 2020,
+            % "Contract-Simple"). Given a SINGLE new constraint row a*alpha <= b
+            % (one that was just appended to the star's C*alpha<=d during a ReLU
+            % split) and the current per-variable predicate box [plb, pub],
+            % tighten the box by interval-propagating that one constraint.
+            %
+            % @a    : 1 x nVar (or nVar x 1) constraint row
+            % @b    : scalar rhs
+            % @plb,@pub : nVar x 1 predicate lower/upper bounds (contracted in place)
+            %
+            % SOUND: the box is only ever shrunk to the interval implied by a
+            % constraint already present in C*alpha<=d, so no feasible alpha is
+            % removed -- the represented set {V*[1;alpha] : C*alpha<=d} is
+            % unchanged; only its box descriptor tightens. estimateRange over the
+            % smaller box stays a sound over-approximation of the true range.
+            if isempty(plb) || isempty(pub)
+                return;                          % no box to contract against
+            end
+            a = a(:).';                          % force row
+            apos = max(a, 0);  aneg = min(a, 0);
+            Slo = apos*plb + aneg*pub;           % min of a*alpha over the box
+            for j = find(a ~= 0)
+                % remove variable j's contribution from the interval minimum,
+                % then isolate alpha_j against a*alpha <= b.
+                if a(j) > 0
+                    rest_lo = Slo - a(j)*plb(j);
+                    new_ub  = (b - rest_lo) / a(j);   % alpha_j <= new_ub
+                    if new_ub < pub(j), pub(j) = max(new_ub, plb(j)); end
+                else % a(j) < 0  (dividing flips the inequality sense)
+                    rest_lo = Slo - a(j)*pub(j);
+                    new_lb  = (b - rest_lo) / a(j);   % alpha_j >= new_lb
+                    if new_lb > plb(j), plb(j) = min(new_lb, pub(j)); end
+                end
+            end
+            % numerical safety: keep plb <= pub (clip to midpoint, never widen).
+            bad = plb > pub;
+            if any(bad)
+                mid = 0.5*(plb(bad) + pub(bad));
+                plb(bad) = mid;  pub(bad) = mid;
+            end
+        end
+
         % generate random star set
         function S = rand(dim)
             % @dim: dimension of the random star set


### PR DESCRIPTION
## Summary

Two sound, verdict-invariant performance improvements to the **exact-star** reach core (`PosLin.stepReach` + `Star`), targeting acasxu path explosion (the CAV-2020 nnenum techniques). No new solves come *from these two commits alone* — they make exact-star **faster** and are the enabler for routing it to small nets where approx-star is too loose.

1. **Predicate-bound contraction** (`Star.updatePredicateRanges`): when a ReLU split appends a constraint, tighten the per-variable predicate box by LP-free interval propagation of that single constraint, so the next layer's stability prefilter sees smaller bounds → fewer downstream splits.
2. **Estimate-first sign decision** in `stepReach`: before the `getMin`/`getMax` LPs, screen the neuron with `estimateRange` (a sound interval over-approx of the contracted box). One-sided estimate → decide with **zero LPs**; the two-sided LP path is **byte-identical** to before.

## Soundness (the reason this is safe to merge)

- **Contraction only shrinks the box descriptor**, never the represented set: it intersects the box with a constraint already in `C·α ≤ d`, so no feasible `α` is removed. Verified by a randomized **containment property test** (sample `α` satisfying the new constraint + original box → all remain inside the contracted box): **0/30,000 violations**.
- **Estimate-first** uses `estimateRange`, a sound interval over-approximation: a one-sided estimate is one-sided on the true set, so the deterministic assignment equals what the LP would return. The genuinely two-sided neuron still hits the exact LP — **no split is missed**.
- **Verdict-invariance gate (the hard one):** on the acasxu instances NNV solves under exact-star, every verdict is **byte-identical** to master — **25 sat + 5 timeout, 0 flips, 0 spurious verdicts**. Solvable instances solve fast (2–21 s).

## Validated on
AWS m5.16xlarge, MATLAB R2026a. acasxu instances 55–84 @116 s: identical verdicts vs master, faster. Full design + merge gates in `examples/Submission/.../ACASXU_NNENUM_PLAN.md`.

## Notes
- This is the soundness-critical reach core; reviewed for the verdict-invariance and containment gates above.
- The dispatcher *routing* that uses this (exact-star as a fallback for metaroom/dist_shift/cersyve) is a **separate** follow-up PR, after confirming it does not regress already-solved benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)