### PR TITLE
feat(vnnlib2): wire equal-to multinet verification (monotonic_acasxu 0 → 50 sat)

### DIFF
--- a/code/nnv/engine/utils/verify_multinet.m
+++ b/code/nnv/engine/utils/verify_multinet.m
@@ -52,15 +52,14 @@ end
 function [status, counterEx] = verify_multinet_impl(nnvnet, property, reachOptions)
     status = 2; counterEx = [];
 
-    % ---- 1) layer whitelist FIRST (and product-net assembly) ---------------
-    % every layer must be FullyConnectedLayer or ReluLayer; anything else
-    % cannot be soundly stacked -> unknown immediately
-    [prodNet, okp] = multinet_product_net(nnvnet);
-    if ~okp
-        return;
-    end
-
-    % ---- 2) property validation (anything off -> unknown) ------------------
+    % ---- 1) property validation (anything off -> unknown) ------------------
+    % FALSIFICATION-FIRST ordering: the sat path only needs nnvnet.evaluate (which
+    % handles the FULL imported net -- ImageInput/ElementwiseAffine/Flatten wrappers
+    % and all), so validate the property and try to falsify BEFORE assembling the
+    % FC+ReLU-only product net. The product net (and its whitelist) is built later and
+    % is needed ONLY for the unsat/reach direction. This recovers easily-falsifiable
+    % equal-to instances (measured on monotonic_acasxu: ~50% of feasible samples
+    % violate) that the old whitelist-first order discarded as unknown.
     if ~isstruct(property) || ~isfield(property, 'multinet'), return; end
     if isfield(property, 'unsupported') && property.unsupported, return; end
     mn = property.multinet;
@@ -141,6 +140,15 @@ function [status, counterEx] = verify_multinet_impl(nnvnet, property, reachOptio
                 return;
             end
         end
+    end
+
+    % ---- product net (FC+ReLU whitelist) -- needed ONLY for unsat/reach ----
+    % every layer must be FullyConnectedLayer or ReluLayer; anything else cannot be
+    % soundly stacked into [f(x_f); f(x_g)] -> no unsat proof -> unknown (the sat
+    % path above already ran on the original net regardless of this).
+    [prodNet, okp] = multinet_product_net(nnvnet);
+    if ~okp
+        return;
     end
 
     % ---- 4) product-net consistency cross-check ----------------------------

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_all_benchmarks.m
@@ -235,6 +235,37 @@ pairs = {};
 % Resolve onnx/vnnlib relative to the instances.csv's OWN directory so both the 2025
 % layout (<sub>/) and the 2026 version layout (<sub>/1.0/) work (bench_root/sub then unused).
 bench_dir = fileparts(inst_csv);
+% VNN-LIB 2.0 multi-network instances.csv: column 1 is a python list of (name,path)
+% tuples, e.g.  [('f','onnx/a.onnx'), ('g','onnx/b.onnx')]  (monotonic_acasxu /
+% isomorphic_acasxu). Those internal commas break the 3-column readtable parse (it
+% truncates column 1 to `"[('f'`), so detect the tuple format and parse the RAW lines:
+% the FIRST onnx is f (the shared net for equal-to), and the *.vnnlib token is the
+% spec. This ENUMERATES rows that previously matched no file and made the whole
+% benchmark log "no resolvable instance in CSV" = 0 rows. isomorphic-to (different g)
+% is gated to `unknown` downstream in run_vnncomp_instance.
+raw = readlines(inst_csv);
+if any(contains(raw, "('")) && any(contains(raw, ".onnx"))
+    for r = 1:numel(raw)
+        ln = strtrim(raw(r));
+        if ln == "", continue; end
+        onx = regexp(ln, "'([^']*\.onnx)'", 'tokens', 'once');
+        if isempty(onx), continue; end
+        onnx_rel = strrep(char(onx{1}), './', '');
+        vmt = regexp(ln, "([^\s,'""]*\.vnnlib)", 'match', 'once');
+        if strlength(vmt) == 0, continue; end
+        vnnlib_rel = strrep(char(vmt), './', '');
+        onnx_p   = ensure_decompressed(fullfile(bench_dir, onnx_rel));
+        vnnlib_p = ensure_decompressed(fullfile(bench_dir, vnnlib_rel));
+        if ~isempty(onnx_p) && ~isempty(vnnlib_p)
+            pairs{end+1} = struct('onnx_rel', onnx_rel, 'vnnlib_rel', vnnlib_rel, ...
+                'onnx', onnx_p, 'vnnlib', vnnlib_p); %#ok<AGROW>
+            if strcmp(run_which, 'first'), return; end
+        end
+    end
+    return;
+end
+
+% --- standard 2025/2026 3-column format (onnx_rel, vnnlib_rel, timeout_s) ---
 T = readtable(inst_csv, 'Delimiter', ',', 'ReadVariableNames', false, ...
     'TextType', 'string', 'Format', '%s%s%s');
 for r = 1:height(T)

--- a/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/run_vnncomp_instance.m
@@ -116,19 +116,36 @@ if isfield(property, 'unsupported') && property.unsupported
     return;
 end
 
-% Phase 2 guard: a clean multi-network `equal-to` pair parses into
-% property.multinet (unsupported = false) with the single-network fields
-% lb/ub/prop intentionally EMPTY. The runner plumbing for it (python-tuple onnx
-% list in instances.csv, product-net dispatch -- plan Phase 3c) is not wired
-% yet, so emit `unknown` rather than fall through to the single-network path.
-% Verification entry point for these properties: engine/utils/verify_multinet.m.
+% Phase 3c: a clean multi-network `equal-to` pair parses into property.multinet
+% (unsupported = false) with the single-network fields lb/ub/prop intentionally
+% EMPTY. `equal-to` means both declared networks are the SAME model (e.g.
+% monotonic_acasxu: g equal-to f), evaluated on two inputs coupled by the parsed
+% jointC/jointd. verify_multinet builds the product net [f(x_f); f(x_g)], falsifies
+% the cross-network unsafe region FIRST (sound, witness validated by concrete
+% evaluation) for sat, then reaches the joint input Star for unsat; ANY doubt ->
+% unknown (sound-or-unknown; the -150 rule holds). isomorphic-to (different g) is
+% flagged property.unsupported above and never reaches here.
 if isfield(property, 'multinet')
-    fprintf('vnnlib 2.0 multi-network (equal-to) property parsed -> unknown: runner wiring is Phase 3c (see verify_multinet.m)\n');
-    status = 2;
+    [status, counterEx] = verify_multinet(nnvnet, property);
+    fprintf('vnnlib 2.0 multi-network (equal-to) -> status=%d (0 sat / 1 unsat / 2 unknown)\n', status);
     tTime = toc(t);
     fid = fopen(outputfile, 'w');
-    fprintf(fid, 'unknown \n');
-    fclose(fid);
+    if status == 0
+        fprintf(fid, 'sat \n');
+        fclose(fid);
+        % witness = stacked product-net I/O [x_f; x_g] -> [f(x_f); f(x_g)] (the
+        % order verify_multinet's product net uses); sound -- the verdict, not the
+        % witness format, is what the sweep scores, and the CE is already validated.
+        xf = counterEx{1}; xg = counterEx{2};
+        yf = nnvnet.evaluate(xf); yg = nnvnet.evaluate(xg);
+        write_counterexample(outputfile, {[xf(:); xg(:)], [yf(:); yg(:)]});
+    elseif status == 1
+        fprintf(fid, 'unsat \n');
+        fclose(fid);
+    else
+        fprintf(fid, 'unknown \n');
+        fclose(fid);
+    end
     return;
 end
 

--- a/code/nnv/tests/utils/test_vnnlib2_multinet.m
+++ b/code/nnv/tests/utils/test_vnnlib2_multinet.m
@@ -186,13 +186,36 @@ end
 
 % ---------- (c) verify_multinet: sound refusals ----------
 
-function test_verify_multinet_whitelist_gate(tc)
-    % a net with a non-whitelisted layer must return unknown (2) IMMEDIATELY
-    % (whitelist runs before falsification and reach)
+function test_verify_multinet_falsifies_non_whitelisted(tc)
+    % FALSIFICATION-FIRST: a non-whitelisted net (TanhLayer) can still be SOUNDLY
+    % falsified -- the sat path only evaluates the real net; the FC+ReLU whitelist
+    % gates ONLY the unsat/reach path. f(x)=tanh(x) with INDEPENDENT boxes on x_f,x_g
+    % makes the unsafe region Y_f[0] < Y_g[0] trivially reachable -> sat, with a
+    % concretely-validated witness. (Old behavior here was an immediate unknown.)
     net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), TanhLayer()});
-    property = hand_built_multinet_property('equal');
+    property = hand_built_multinet_property('equal');   % crossProp Y_f[0]-Y_g[0] <= 0, NO coupling
     [status, counterEx] = verify_multinet(net, property, struct('reachMethod', 'approx-star'));
-    verifyEqual(tc, status, 2, 'non-whitelisted layer (TanhLayer) must yield unknown');
+    verifyEqual(tc, status, 0, 'falsifiable non-whitelisted equal-to net must yield sat');
+    verifyTrue(tc, iscell(counterEx) && numel(counterEx) == 2);
+    yf = net.evaluate(counterEx{1}); yg = net.evaluate(counterEx{2});
+    verifyLessThan(tc, yf(1) - yg(1), 0, 'sat witness must really violate Y_f[0] >= Y_g[0]');
+end
+
+function test_verify_multinet_whitelist_gates_unsat(tc)
+    % the FC+ReLU whitelist gates ONLY the unsat/reach direction: a non-whitelisted
+    % net (TanhLayer) whose property has NO strict violation (x_f == x_g forces
+    % Y_f == Y_g, so Y_f[0]-Y_g[0]=0 is never < 0) cannot be falsified, and the
+    % product net cannot be built -> unknown (never a false unsat). This is the
+    % -150 guard for the unsat path under the falsification-first ordering.
+    net = NN({FullyConnectedLayer('fc1', eye(2), zeros(2, 1)), TanhLayer()});
+    mn = struct('names', {{'f', 'g'}}, 'inShapes', {{2, 2}}, 'outShapes', {{2, 2}}, ...
+                'equivKind', 'equal', 'jointLb', -ones(4, 1), 'jointUb', ones(4, 1));
+    mn.jointC = [1 0 -1 0; -1 0 1 0; 0 1 0 -1; 0 -1 0 1];   % x_f == x_g (two-row pairs)
+    mn.jointd = zeros(4, 1);
+    mn.crossProp = HalfSpace([1 0 -1 0], 0);                % Y_f[0] - Y_g[0] <= 0
+    property = struct('lb', [], 'ub', [], 'prop', {{}}, 'unsupported', false, 'reason', '', 'multinet', mn);
+    [status, counterEx] = verify_multinet(net, property, struct('reachMethod', 'approx-star'));
+    verifyEqual(tc, status, 2, 'non-whitelisted net with no violation must yield unknown (gated unsat path)');
     verifyTrue(tc, isempty(counterEx));
 end
 


### PR DESCRIPTION
## Summary

VNN-LIB 2.0 multi-network **`equal-to`** benchmarks (`monotonic_acasxu_2026`, `isomorphic_acasxu_2026`) were producing **zero rows** in the sweep (`"no resolvable instance in CSV"`) because (1) `pick_instances` couldn't parse the python list-of-tuples onnx column, and (2) the `equal-to` runner branch abstained (Phase 3c unwired). This wires the **already-present, sound** `verify_multinet` end to end.

## Changes
- **`run_all_benchmarks.m` (`pick_instances`)** — parse the multi-network `instances.csv` (col 1 = `[('f','a.onnx'),('g','b.onnx')]`) from raw lines; the internal commas break the 3-column `readtable` parse. Resolve f's onnx so each instance is **enumerated**. Standard 2025/2026 3-column path untouched.
- **`run_vnncomp_instance.m`** — at the `property.multinet` branch, call `verify_multinet` and emit its sat/unsat/unknown verdict (stacked product-net witness on sat) instead of the unconditional `unknown` abstain.
- **`verify_multinet.m`** — **falsification-first reorder**. The sat path only needs `nnvnet.evaluate` (handles the full imported net — acasxu is 23 layers: ImageInput/ElementwiseAffine/Flatten + FC/ReLU), so validate the property and falsify **before** assembling the FC+ReLU-only product net. The product net (and its whitelist) is built later and gates **only** the unsat/reach direction.

## Soundness (−150 rule)
`sat` only with a **concrete witness the real network violates** (strict interior of the parsed unsafe halfspace, all input couplings satisfied); `unsat` only when the product-net reach set is provably disjoint from the unsafe region; else `unknown`. The reorder relaxes **no** check — it only lets the whitelist-independent sat path run on nets the product net can't represent.

## Validation (real vnncomp2026 benchmarks)
- **`monotonic_acasxu_2026`: 50/50 sat** (was 0 rows). Diagnostic confirms a real violation per instance (instance_0: 13011/25118 feasible samples violate, interior margin +0.159).
- **`isomorphic_acasxu_2026`: 50 enumerated**, all `unknown` (isomorphic-to needs g's net — follow-up); was 0 rows.
- **`tests/utils/test_vnnlib2_multinet`: 12/12** — replaced the obsolete whitelist-first gate test with two for the new contract (falsify-regardless-of-whitelist + whitelist-gates-unsat).

## Follow-ups (not in this PR)
1. Plumb g's onnx to falsify `isomorphic-to`.
2. Extend `multinet_product_net` to ImageInput/ElementwiseAffine/Flatten so the `equal-to` **unsat**/reach path works for acasxu.
3. onnxruntime witness replay for multinet sat (parity with single-net path) — recommended before trusting these `sat` vs the 2026 gold standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)