### PR TITLE
harden(lpsolver): linprog exitflag -2 must not certify emptySet on its own (run glpk) [SUPERVISED]

### DIFF
--- a/code/nnv/engine/utils/lpsolver.m
+++ b/code/nnv/engine/utils/lpsolver.m
@@ -100,7 +100,18 @@ function [fval, exitflag] = lpsolver(f, A, b, Aeq, Beq, lb, ub, lp_solver, opts)
         % first try solving using linprog
         [~, fval, exitflag, ~] = linprog(f, A, b, Aeq, Beq, lb, ub, options);
         % found (1), not feasible point found (-2), infeasible (-5)
-        if ~( (exitflag == -2 && strcmp(opts, 'emptySet')) || ismember(exitflag, [1, -5]) ) % return existflag if one of these conditions is met
+        % SOUNDNESS HARDENING: only trust linprog's exitflag directly when it is a
+        % DEFINITIVE result -- success (1) or PROVEN-infeasible (-5). exitflag -2
+        % ("No feasible point found") is a numerical/iteration GIVE-UP, NOT a proof of
+        % infeasibility, so it must NOT be accepted as an emptySet certificate on its own
+        % (the old code short-circuited the glpk cross-check for `-2 && emptySet`). A
+        % give-up on a large/near-degenerate but FEASIBLE LP would then be reported EMPTY,
+        % which Star.isEmptySet maps to "robust" -> a possible false UNSAT (-150 direction).
+        % Now -2 always falls through to the glpk backup: EMPTY is certified only when both
+        % solvers agree infeasible (or glpk proves it); if glpk also can't decide it errors
+        % -> caught upstream as `unknown`. This can only convert a possibly-wrong robust into
+        % unknown, NEVER create a false sat. (Equality-constrained LPs still error->unknown.)
+        if ~( ismember(exitflag, [1, -5]) ) % trust only definitive linprog results; -2 -> glpk
             if ~isempty(Aeq) || ~isempty(Beq)
                 error("Problem cannot be solved by linprog, and task not supported by glpk.")
             else


### PR DESCRIPTION
**DRAFT — needs supervised review** (blast radius = every reach/verdict).

## What
`lpsolver.m:103` accepted linprog `exitflag == -2` ("No feasible point found") as a **definitive EMPTY** certificate when `opts='emptySet'`, short-circuiting the glpk backup cross-check. `-2` is a numerical **give-up**, not an infeasibility proof — on a large/near-degenerate but **feasible** LP, linprog can return `-2`, and the disjunct was then reported EMPTY → `Star.isEmptySet` → `verify_specification` reads robust → a possible **false UNSAT (−150)**.

## Fix
Trust linprog directly only when **definitive**: success (`1`) or proven-infeasible (`-5`). `-2` now always falls through to glpk; EMPTY is certified only when both solvers agree infeasible. If glpk also can't decide → error → caught upstream as `unknown`.

## Soundness
**Strictly one-directional.** `sat` is never produced via `isEmptySet` (only via falsification + witness-replay), so no emptiness change can create a false sat. This can only convert a possibly-wrong `robust`→`unknown`. Adversarial-audited: no false-sat kill-chain.

## Caveat / why draft
Latent hardening, **not** a confirmed-bug fix — the suspected cora `mnist-point` false-unsat **did not reproduce** (the instance is genuinely robust: 0/8000 box samples violate). It removes a real −150-exposure regardless. Before merge, please validate vs the full test suite + the gold-standard sweep to confirm no previously-decided instance flips to `unknown` beyond the intended give-up cases, and consider the (separate) double-precision emptiness-LP hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)