### PR TITLE
feat(gpu-bab): feedforward-CNN linear layer support — Conv2D + ImageInput-norm + BatchNorm + Avg/Global pooling (sound)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -55,6 +55,7 @@ function w = i_layer_width(ops, upto)
         t = ops{k}.type;
         if strcmp(t, 'affine'),         w = size(ops{k}.W, 1);     return;
         elseif strcmp(t, 'conv'),       w = prod(ops{k}.outShape); return;
+        elseif strcmp(t, 'avgpool'),    w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
         end
     end
@@ -77,6 +78,8 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
             [A, d] = i_conv_backward(A, d, op, precision);
         elseif strcmp(op.type, 'normaffine')
             [A, d] = i_normaffine_backward(A, d, op, precision);
+        elseif strcmp(op.type, 'avgpool')
+            [A, d] = i_avgpool_backward(A, d, op, precision);
         else
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
@@ -123,6 +126,24 @@ function [A2, d2] = i_conv_backward(A, d, op, precision)
     bc = reshape(cast(op.b(:), precision), [1 1 osh(3)]);
     dinc = squeeze(sum(extractdata(A4) .* bc, [1 2 3]));
     d2 = d + dinc(:);
+end
+
+function [A2, d2] = i_avgpool_backward(A, d, op, precision)
+% Exact CROWN backward through avgpool (LINEAR, no relaxation): each output cell is the
+% mean of its kh x kw window, so the adjoint distributes A_out/(kh*kw) uniformly back to
+% the window's input cells. Non-overlapping (stride==pool) -> every input cell lies in at
+% most one window -> the adjoint is repelem(A_out, kh, kw)/(kh*kw), zero-padded to inShape
+% (floor-dropped tail cells were in no window -> zero coefficient). No bias -> d unchanged.
+    nS = size(A, 1);
+    osh = op.outShape; ish = op.inShape;
+    kh = op.pool(1); kw = op.pool(2);
+    A4 = reshape(A.', [osh(1) osh(2) osh(3) nS]);           % [Hout Wout C nS]
+    Aup = repelem(cast(A4, precision), kh, kw, 1, 1) / (kh*kw);   % distribute to window cells
+    Ain = zeros([ish(1) ish(2) ish(3) nS], precision);
+    hi = min(ish(1), size(Aup,1)); wi = min(ish(2), size(Aup,2));
+    Ain(1:hi, 1:wi, :, :) = Aup(1:hi, 1:wi, :, :);
+    A2 = reshape(Ain, [prod(ish) nS]).';                   % nS x prod(inShape)
+    d2 = d;
 end
 
 function [A2, d2] = i_normaffine_backward(A, d, op, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -62,6 +62,7 @@ function w = i_layer_width(ops, upto)
         elseif strcmp(t, 'conv'),       w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'avgpool'),    w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'maxpool'),    w = prod(ops{k}.outShape); return;
+        elseif strcmp(t, 'add'),        w = prod(ops{k}.shape);    return;
         elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
         end
     end
@@ -74,9 +75,27 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
     A = A0;
     nS = size(A0, 1);
     d = zeros(nS, 1, precision);
+    % DAG support: an 'add' op (out = out[a]+out[b]) sends its coefficient UNCHANGED to BOTH
+    % inputs (linear -> exact). skipA{k} accumulates the coefficient arriving at op k's OUTPUT
+    % from later adds; inputSkipA accumulates skips that target op 0 (the engine input).
+    hasAdd = any(cellfun(@(o) strcmp(o.type, 'add'), ops(1:upto)));
+    skipA = cell(upto, 1); inputSkipA = 0;
     for k = upto:-1:1
         op = ops{k};
-        if strcmp(op.type, 'affine')
+        if hasAdd && ~isempty(skipA{k}), A = A + skipA{k}; end
+        if strcmp(op.type, 'add')
+            for ii = 1:numel(op.inputs)
+                src = op.inputs(ii);
+                if src == 0
+                    inputSkipA = inputSkipA + A;
+                elseif isempty(skipA{src})
+                    skipA{src} = A;
+                else
+                    skipA{src} = skipA{src} + A;
+                end
+            end
+            A = zeros(nS, size(A, 2), precision);   % fully distributed to its inputs
+        elseif strcmp(op.type, 'affine')
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             d = d + A * b;
             A = A * W;
@@ -101,6 +120,7 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
             end
         end
     end
+    if hasAdd, A = A + inputSkipA; end   % coeff on the input = chain + skips-to-input
     Apos = max(A, 0); Aneg = min(A, 0);
     if lower
         bound = Apos * cast(x_lb, precision) + Aneg * cast(x_ub, precision) + d;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -26,22 +26,27 @@ function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, 
     unstable = cell(nOps, 1);
 
     % ---- tight intermediate bounds, layer by layer ----
+    % Compute input bounds for every op whose backward relaxation needs them: ReLU (the
+    % pre-activation) AND maxpool (the window inputs that decide the sound max relaxation).
     for k = 1:nOps
-        if strcmp(ops{k}.type, 'relu')
-            % z_k (the pre-activation feeding this ReLU) = output of ops[1..k-1].
-            % Bound each of its neurons via a backward CROWN pass over ops[1..k-1],
-            % which uses preL/preU of the strictly-earlier ReLUs (already computed).
+        tk = ops{k}.type;
+        if strcmp(tk, 'relu') || strcmp(tk, 'maxpool')
+            % z_k (the input feeding this op) = output of ops[1..k-1]. Bound each of its
+            % elements via a backward CROWN pass over ops[1..k-1], which reuses preL/preU of
+            % the strictly-earlier ReLUs/maxpools (already computed -- sound by induction).
             nk = i_layer_width(ops, k-1);
             Ck = eye(nk, precision);
             pu = i_backward(ops, k-1, Ck, x_lb, x_ub, preL, preU, precision, false);
             pl = i_backward(ops, k-1, Ck, x_lb, x_ub, preL, preU, precision, true);
-            if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
+            if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
                 pl(fx == 1)  = max(pl(fx == 1),  0);
                 pu(fx == -1) = min(pu(fx == -1), 0);
             end
             preL{k} = pl; preU{k} = pu;
-            unstable{k} = (pl < 0) & (pu > 0);
+            if strcmp(tk, 'relu')
+                unstable{k} = (pl < 0) & (pu > 0);
+            end
         end
     end
 
@@ -56,6 +61,7 @@ function w = i_layer_width(ops, upto)
         if strcmp(t, 'affine'),         w = size(ops{k}.W, 1);     return;
         elseif strcmp(t, 'conv'),       w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'avgpool'),    w = prod(ops{k}.outShape); return;
+        elseif strcmp(t, 'maxpool'),    w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
         end
     end
@@ -80,6 +86,8 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
             [A, d] = i_normaffine_backward(A, d, op, precision);
         elseif strcmp(op.type, 'avgpool')
             [A, d] = i_avgpool_backward(A, d, op, precision);
+        elseif strcmp(op.type, 'maxpool')
+            [A, d] = i_maxpool_backward(A, d, op, preL{k}, preU{k}, precision, lower);
         else
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
@@ -144,6 +152,58 @@ function [A2, d2] = i_avgpool_backward(A, d, op, precision)
     Ain(1:hi, 1:wi, :, :) = Aup(1:hi, 1:wi, :, :);
     A2 = reshape(Ain, [prod(ish) nS]).';                   % nS x prod(inShape)
     d2 = d;
+end
+
+function [A2, d2] = i_maxpool_backward(A, d, op, l, u, precision, lower)
+% Sound CROWN backward through max pooling. For each output cell o = max over its window:
+%   lower bound  y_o >= x_m        (m = argmax of the window's LOWER bounds; max >= any elem)
+%   upper bound  y_o <= x_m        if m is DECIDED (l_m >= u_i for every other i) -- EXACT
+%               y_o <= max_i u_i  otherwise (a constant; sound since max <= max of uppers)
+% Lmat/Umat are n_out x n_in selection matrices (sparse); overlapping windows accumulate
+% naturally in Apos*Lmat. Sign-aware: +coeff uses the relaxation that bounds the spec on the
+% correct side. Undecided cells leave a constant gap (the BaB can split the feeding ReLUs).
+    [mIdx, decided, umax] = i_maxpool_relax(op, l, u);
+    n_in = prod(op.inShape); n_out = prod(op.outShape);
+    Lmat = sparse(1:n_out, mIdx, 1, n_out, n_in);               % y_o >= x_{m_o}
+    dec  = find(decided);
+    Umat = sparse(dec, mIdx(dec), 1, n_out, n_in);              % decided: y_o <= x_{m_o}
+    Ubias = zeros(n_out, 1); Ubias(~decided) = umax(~decided);  % undecided: y_o <= umax
+    Ad = double(A); Apos = max(Ad, 0); Aneg = min(Ad, 0);
+    if lower
+        A2 = cast(Apos * Lmat + Aneg * Umat, precision);
+        d2 = d + cast(Aneg * Ubias, precision);
+    else
+        A2 = cast(Apos * Umat + Aneg * Lmat, precision);
+        d2 = d + cast(Apos * Ubias, precision);
+    end
+end
+
+function [mIdx, decided, umax] = i_maxpool_relax(op, l, u)
+% Per output cell: m = flat input index of the window's argmax-LOWER element; decided = that
+% element dominates (its lower bound >= every other window upper => max is exactly it); umax =
+% max window upper. Unpadded windows (enforced at extraction); overlap allowed.
+    ish = op.inShape; osh = op.outShape;
+    H = ish(1); W = ish(2); C = ish(3); Ho = osh(1); Wo = osh(2);
+    kh = op.pool(1); kw = op.pool(2); sh = op.stride(1); sw = op.stride(2);
+    L = reshape(double(l), [H W C]); U = reshape(double(u), [H W C]);
+    n_out = prod(osh);
+    mIdx = ones(n_out, 1); decided = false(n_out, 1); umax = zeros(n_out, 1);
+    for c = 1:C
+        for ow = 1:Wo
+            rw = (ow-1)*sw + (1:kw);
+            for oh = 1:Ho
+                rh = (oh-1)*sh + (1:kh);
+                lw = L(rh, rw, c); uw = U(rh, rw, c);
+                [maxl, p] = max(lw(:));
+                [pr, pc] = ind2sub([kh kw], p);
+                o = sub2ind([Ho Wo C], oh, ow, c);
+                mIdx(o) = sub2ind([H W C], rh(pr), rw(pc), c);
+                uw2 = uw; uw2(p) = -inf;
+                decided(o) = maxl >= max(uw2(:));               % argmax-lower dominates others
+                umax(o) = max(uw(:));
+            end
+        end
+    end
 end
 
 function [A2, d2] = i_normaffine_backward(A, d, op, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -51,11 +51,14 @@ end
 
 function w = i_layer_width(ops, upto)
 % # outputs of ops[1..upto] = rows of the last affine in that prefix.
-    w = [];
     for k = upto:-1:1
-        if strcmp(ops{k}.type, 'affine'), w = size(ops{k}.W, 1); return; end
+        t = ops{k}.type;
+        if strcmp(t, 'affine'),         w = size(ops{k}.W, 1);     return;
+        elseif strcmp(t, 'conv'),       w = prod(ops{k}.outShape); return;
+        elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
+        end
     end
-    error('gpu_bab_crown_tight:noaffine', 'no affine op before index %d', upto);
+    error('gpu_bab_crown_tight:nolinear', 'no affine/conv op before index %d', upto);
 end
 
 function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
@@ -70,6 +73,10 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             d = d + A * b;
             A = A * W;
+        elseif strcmp(op.type, 'conv')
+            [A, d] = i_conv_backward(A, d, op, precision);
+        elseif strcmp(op.type, 'normaffine')
+            [A, d] = i_normaffine_backward(A, d, op, precision);
         else
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
@@ -89,6 +96,47 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
     else
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
+end
+
+function [A2, d2] = i_conv_backward(A, d, op, precision)
+% Exact CROWN backward through a conv (linear, NO relaxation): A_in = the conv ADJOINT
+% (dltranspconv) of A_out, d += <A_out, b>. The adjoint identity <A_out,conv(W,x)> =
+% <transpconv(A_out,W),x> holds EXACTLY -> sound (no over/under-approx). spec = batch dim.
+    nS = size(A, 1);
+    osh = op.outShape; ish = op.inShape;
+    W = cast(op.W, precision);
+    A4 = dlarray(reshape(A.', [osh(1) osh(2) osh(3) nS]), 'SSCB');
+    % Exact conv adjoint: reconstruct the adjoint on the PADDED input (Cropping=0), then
+    % crop to the original-input region (rows pad_t+1:pad_t+Hin, cols pad_l+1:pad_l+Win).
+    % This is the exact transpose of "pad-then-conv" for any stride/pad/dilation (a
+    % symmetric Cropping mis-sizes strided convs because the forward floor drops the
+    % unused bottom pad). Tail rows the floor never reached carry zero coefficient -> 0.
+    Afull = extractdata(dltranspconv(A4, W, 0, 'Stride', op.stride, 'Cropping', 0, 'DilationFactor', op.dil));
+    pt = op.pad(1); pl = op.pad(3);
+    Ain = zeros([ish(1) ish(2) ish(3) nS], 'like', Afull);
+    hi = min(ish(1), size(Afull,1) - pt);
+    wi = min(ish(2), size(Afull,2) - pl);
+    if hi > 0 && wi > 0
+        Ain(1:hi, 1:wi, :, :) = Afull(pt+(1:hi), pl+(1:wi), :, :);
+    end
+    A2 = reshape(Ain, [prod(ish) nS]).';                              % nS x prod(inShape)
+    bc = reshape(cast(op.b(:), precision), [1 1 osh(3)]);
+    dinc = squeeze(sum(extractdata(A4) .* bc, [1 2 3]));
+    d2 = d + dinc(:);
+end
+
+function [A2, d2] = i_normaffine_backward(A, d, op, precision)
+% Backward through y = s.*x + t (diagonal affine): A_in = A .* s_flat'; d += A * t_flat.
+    sh = op.shape;
+    sf = i_bcast_flat(op.scale, sh, precision);
+    tf = i_bcast_flat(op.shift, sh, precision);
+    A2 = A .* sf.';
+    d2 = d + A * tf;
+end
+
+function v = i_bcast_flat(x, sh, precision)
+% Broadcast x ([1 1 C] / [H W C] / scalar) to a flat [prod(sh) x 1] column (column-major).
+    v = reshape(zeros([sh(1) sh(2) sh(3)], precision) + cast(x, precision), [], 1);
 end
 
 function [au, bu, al] = i_relax(l, u, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -41,38 +41,58 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
 
     lb = cast(in_lb, precision);
     ub = cast(in_ub, precision);
+    nOps = numel(ops);
+    hasAdd = any(cellfun(@(o) strcmp(o.type, 'add'), ops));
 
-    for k = 1:numel(ops)
-        op = ops{k};
-        switch op.type
-            case 'affine'
-                W = cast(op.W, precision);
-                b = cast(op.b(:), precision);
-                Wp = max(W, 0);
-                Wn = min(W, 0);
-                new_lb = Wp * lb + Wn * ub + b;
-                new_ub = Wp * ub + Wn * lb + b;
-                lb = new_lb;
-                ub = new_ub;
-            case 'relu'
-                lb = max(lb, 0);
-                ub = max(ub, 0);
-            case 'conv'
-                [lb, ub] = i_conv_ibp(op, lb, ub, precision);
-            case 'normaffine'
-                [lb, ub] = i_normaffine_ibp(op, lb, ub, precision);
-            case 'avgpool'
-                [lb, ub] = i_avgpool_ibp(op, lb, ub, precision);
-            case 'maxpool'
-                [lb, ub] = i_maxpool_ibp(op, lb, ub, precision);
-            otherwise
-                error('gpu_bab_ibp:unsupportedOp', ...
-                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine/avgpool/maxpool).', op.type);
+    if ~hasAdd
+        % sequential (chain) net -- rolling bounds, no per-op cache.
+        for k = 1:nOps
+            [lb, ub] = i_apply_ibp(ops{k}, lb, ub, precision);
         end
+        out_lb = lb; out_ub = ub;
+        return;
     end
 
-    out_lb = lb;
-    out_ub = ub;
+    % DAG net (residual): cache each op's output bounds (index k+1 = op k; index 1 = op 0 =
+    % input), so an 'add' can sum two non-adjacent ops. Interval add is EXACT (sound + tight).
+    cl = cell(nOps + 1, 1); cu = cell(nOps + 1, 1);
+    cl{1} = lb; cu{1} = ub;
+    for k = 1:nOps
+        op = ops{k};
+        if strcmp(op.type, 'add')
+            a = op.inputs(1) + 1; b = op.inputs(2) + 1;
+            cl{k+1} = cl{a} + cl{b};
+            cu{k+1} = cu{a} + cu{b};
+        else
+            [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{k}, cu{k}, precision);
+        end
+    end
+    out_lb = cl{nOps + 1};
+    out_ub = cu{nOps + 1};
+end
+
+function [nlb, nub] = i_apply_ibp(op, lb, ub, precision)
+% Sound IBP for a single (single-input) op. 'add' is multi-input and handled by the caller.
+    switch op.type
+        case 'affine'
+            W = cast(op.W, precision); b = cast(op.b(:), precision);
+            Wp = max(W, 0); Wn = min(W, 0);
+            nlb = Wp * lb + Wn * ub + b;
+            nub = Wp * ub + Wn * lb + b;
+        case 'relu'
+            nlb = max(lb, 0); nub = max(ub, 0);
+        case 'conv'
+            [nlb, nub] = i_conv_ibp(op, lb, ub, precision);
+        case 'normaffine'
+            [nlb, nub] = i_normaffine_ibp(op, lb, ub, precision);
+        case 'avgpool'
+            [nlb, nub] = i_avgpool_ibp(op, lb, ub, precision);
+        case 'maxpool'
+            [nlb, nub] = i_maxpool_ibp(op, lb, ub, precision);
+        otherwise
+            error('gpu_bab_ibp:unsupportedOp', ...
+                'Unsupported op type "%s" (affine/relu/conv/normaffine/avgpool/maxpool/add).', op.type);
+    end
 end
 
 function [olb, oub] = i_conv_ibp(op, lb, ub, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -63,9 +63,11 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
                 [lb, ub] = i_normaffine_ibp(op, lb, ub, precision);
             case 'avgpool'
                 [lb, ub] = i_avgpool_ibp(op, lb, ub, precision);
+            case 'maxpool'
+                [lb, ub] = i_maxpool_ibp(op, lb, ub, precision);
             otherwise
                 error('gpu_bab_ibp:unsupportedOp', ...
-                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine/avgpool).', op.type);
+                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine/avgpool/maxpool).', op.type);
         end
     end
 
@@ -112,6 +114,18 @@ function [olb, oub] = i_avgpool_ibp(op, lb, ub, precision)
     U4 = dlarray(reshape(ub, [ish(1) ish(2) ish(3) B]), 'SSCB');
     Lo = avgpool(L4, op.pool, 'Stride', op.stride);
     Hi = avgpool(U4, op.pool, 'Stride', op.stride);
+    olb = reshape(extractdata(Lo), [prod(osh) B]);
+    oub = reshape(extractdata(Hi), [prod(osh) B]);
+end
+
+function [olb, oub] = i_maxpool_ibp(op, lb, ub, precision)
+% Max pool = per-channel max over each window: MONOTONE, so bounds map directly
+% (maxpool(lb), maxpool(ub)) -- exact interval, no relaxation. dlarray maxpool.
+    B = size(lb, 2); ish = op.inShape; osh = op.outShape;
+    L4 = dlarray(reshape(cast(lb, precision), [ish(1) ish(2) ish(3) B]), 'SSCB');
+    U4 = dlarray(reshape(cast(ub, precision), [ish(1) ish(2) ish(3) B]), 'SSCB');
+    Lo = maxpool(L4, op.pool, 'Stride', op.stride);
+    Hi = maxpool(U4, op.pool, 'Stride', op.stride);
     olb = reshape(extractdata(Lo), [prod(osh) B]);
     oub = reshape(extractdata(Hi), [prod(osh) B]);
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -57,12 +57,46 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
             case 'relu'
                 lb = max(lb, 0);
                 ub = max(ub, 0);
+            case 'conv'
+                [lb, ub] = i_conv_ibp(op, lb, ub, precision);
+            case 'normaffine'
+                [lb, ub] = i_normaffine_ibp(op, lb, ub, precision);
             otherwise
                 error('gpu_bab_ibp:unsupportedOp', ...
-                    'Unsupported op type "%s" (Phase 1 supports affine + relu).', op.type);
+                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine).', op.type);
         end
     end
 
     out_lb = lb;
     out_ub = ub;
+end
+
+function [olb, oub] = i_conv_ibp(op, lb, ub, precision)
+% Conv IBP = interval arithmetic over the LINEAR conv map: the SAME W+/W- split as the
+% affine op, with the matmul replaced by dlconv. Sound (tightest interval for a linear
+% map). Flat columns <-> [H W C B] (column-major) at the boundary; spec/batch = dim 4.
+    B = size(lb, 2);
+    ish = op.inShape; osh = op.outShape;
+    W = cast(op.W, precision);
+    bb = cast(op.b(:), precision);
+    Wp = max(W, 0); Wn = min(W, 0);
+    L4 = dlarray(reshape(lb, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    U4 = dlarray(reshape(ub, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    pad2 = [op.pad(1) op.pad(3); op.pad(2) op.pad(4)];   % [t l; b r] for dlconv
+    args = {'Stride', op.stride, 'Padding', pad2, 'DilationFactor', op.dil};
+    Lo = dlconv(L4, Wp, bb, args{:}) + dlconv(U4, Wn, 0, args{:});   % lower
+    Hi = dlconv(U4, Wp, bb, args{:}) + dlconv(L4, Wn, 0, args{:});   % upper
+    olb = reshape(extractdata(Lo), [prod(osh) B]);
+    oub = reshape(extractdata(Hi), [prod(osh) B]);
+end
+
+function [olb, oub] = i_normaffine_ibp(op, lb, ub, precision)
+% Per-element affine y = s.*x + t (s,t broadcast over [H W C]); sound interval map.
+    s = cast(op.scale, precision); t = cast(op.shift, precision);
+    sh = op.shape; B = size(lb, 2);
+    L4 = reshape(lb, [sh(1) sh(2) sh(3) B]);
+    U4 = reshape(ub, [sh(1) sh(2) sh(3) B]);
+    a = s .* L4 + t; c = s .* U4 + t;
+    olb = reshape(min(a, c), [prod(sh) B]);
+    oub = reshape(max(a, c), [prod(sh) B]);
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -61,9 +61,11 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
                 [lb, ub] = i_conv_ibp(op, lb, ub, precision);
             case 'normaffine'
                 [lb, ub] = i_normaffine_ibp(op, lb, ub, precision);
+            case 'avgpool'
+                [lb, ub] = i_avgpool_ibp(op, lb, ub, precision);
             otherwise
                 error('gpu_bab_ibp:unsupportedOp', ...
-                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine).', op.type);
+                    'Unsupported op type "%s" (supports affine/relu/conv/normaffine/avgpool).', op.type);
         end
     end
 
@@ -99,4 +101,17 @@ function [olb, oub] = i_normaffine_ibp(op, lb, ub, precision)
     a = s .* L4 + t; c = s .* U4 + t;
     olb = reshape(min(a, c), [prod(sh) B]);
     oub = reshape(max(a, c), [prod(sh) B]);
+end
+
+function [olb, oub] = i_avgpool_ibp(op, lb, ub, precision)
+% Average pool = per-channel mean over each window: all +weights -> MONOTONE, so the
+% bounds map directly (avgpool(lb), avgpool(ub)) with no W+/W- split. Non-overlapping,
+% unpadded (enforced at extraction). dlarray avgpool with Stride=pool.
+    B = size(lb, 2); ish = op.inShape; osh = op.outShape;
+    L4 = dlarray(reshape(lb, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    U4 = dlarray(reshape(ub, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    Lo = avgpool(L4, op.pool, 'Stride', op.stride);
+    Hi = avgpool(U4, op.pool, 'Stride', op.stride);
+    olb = reshape(extractdata(Lo), [prod(osh) B]);
+    oub = reshape(extractdata(Hi), [prod(osh) B]);
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
@@ -36,6 +36,16 @@ function [status, info] = gpu_bab_relu_split(ops, x_lb, x_ub, trueLabel, nClasse
     cexEvery  = i_get(opts, 'cexEvery', 25);   % per-node counterexample cadence (0 = off)
     intermediate = i_get(opts, 'intermediate', 'ibp');  % 'ibp' | 'tight' (CROWN intermediate bounds)
 
+    % SOUNDNESS GUARD: the 'ibp' (i_crown_clamped) and alpha-fix node-bound paths handle
+    % ONLY affine+relu; a conv/normaffine/avgpool op would fall through their else-branch
+    % and be silently treated as a ReLU -> wrong (possibly unsound) bounds -> false robust.
+    % gpu_bab_crown_tight is the only path that bounds those ops soundly, so force 'tight'
+    % whenever the net is not pure FC+ReLU.
+    hasNonFC = any(cellfun(@(o) ~any(strcmp(o.type, {'affine','relu'})), ops));
+    if hasNonFC && ~strcmp(intermediate, 'tight')
+        intermediate = 'tight';
+    end
+
     C = -eye(nClasses, precision);
     C(:, trueLabel) = C(:, trueLabel) + 1;
     C(trueLabel, :) = [];
@@ -121,8 +131,7 @@ function [margins, unstable] = i_crown_clamped(ops, x_lb, x_ub, C, precision, fi
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             Wp = max(W,0); Wn = min(W,0);
             nlb = Wp*lb + Wn*ub + b; nub = Wp*ub + Wn*lb + b; lb = nlb; ub = nub;
-        else
-            r = find(reluIdx == k, 1);
+        elseif strcmp(op.type, 'relu')
             fx = fixings{k};
             if ~isempty(fx)
                 lb(fx == 1)  = max(lb(fx == 1),  0);    % active: z >= 0
@@ -131,6 +140,9 @@ function [margins, unstable] = i_crown_clamped(ops, x_lb, x_ub, C, precision, fi
             preL{k} = lb; preU{k} = ub;
             unstable{k} = (lb < 0) & (ub > 0);
             lb = max(lb, 0); ub = max(ub, 0);
+        else
+            error('gpu_bab_relu_split:fcOnly', ...
+                'i_crown_clamped supports affine/relu only (got "%s"); use intermediate=''tight'' for conv/bn/pool.', op.type);
         end
     end
     % backward CROWN (single box, lower bound on C*f)
@@ -141,7 +153,7 @@ function [margins, unstable] = i_crown_clamped(ops, x_lb, x_ub, C, precision, fi
         if strcmp(op.type, 'affine')
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             d = d + A*b; A = A*W;
-        else
+        elseif strcmp(op.type, 'relu')
             l = preL{k}; u = preU{k}; m = numel(l);
             au = zeros(m,1,precision); bu = zeros(m,1,precision); al = zeros(m,1,precision);
             act = (l >= 0); au(act) = 1; al(act) = 1;
@@ -151,6 +163,8 @@ function [margins, unstable] = i_crown_clamped(ops, x_lb, x_ub, C, precision, fi
             Apos = max(A,0); Aneg = min(A,0);
             d = d + Aneg*bu;
             A = Apos .* al.' + Aneg .* au.';
+        else
+            error('gpu_bab_relu_split:fcOnly', 'i_crown_clamped backward supports affine/relu only (got "%s").', op.type);
         end
     end
     Apos = max(A,0); Aneg = min(A,0);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -30,31 +30,46 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     if nargin < 5, opts = struct(); end
     guardTol = i_optget(opts, 'guardTol', 1e-4);
 
-    % (1) extract ops; refuse-on-unsupported -> skip (caller's Star path)
-    try
-        ops = nn_to_ops(net);
-    catch ME
-        verdict = 'skip'; info.reason = ['nn_to_ops refused: ' ME.message]; return;
-    end
-
     inShape = i_input_shape(net);
     lb = double(lb(:)); ub = double(ub(:));
     if isempty(inShape) || prod(inShape) ~= numel(lb)
         verdict = 'skip'; info.reason = 'unknown/mismatched input shape'; return;
     end
 
-    % (2) orientation soundness guard: op-list eval == net.evaluate at the box center
-    c  = (lb + ub) / 2;
-    yo = gpu_bab_ibp(ops, c, c, 'double'); yo = yo(:);
-    yn = net.evaluate(reshape(c, inShape));  yn = yn(:);
-    if numel(yo) ~= numel(yn)
-        verdict = 'skip'; info.reason = 'output-size mismatch'; return;
+    % (1+2) extract ops AND auto-calibrate the conv->FC flatten order against net.evaluate at
+    % SEVERAL probe points. ONNX-imported nets flatten row-major while the engine views the
+    % conv output column-major; trying each order and keeping the one whose op-list matches
+    % net.evaluate (the soundness guard) handles both. A wrong order/extraction never matches
+    % the probes -> 'skip' (Star), never a -150. Multi-probe makes a coincidental match negligible.
+    c = (lb + ub) / 2;
+    probes  = [c, lb + 0.25*(ub - lb), lb + 0.75*(ub - lb)];
+    orders  = {'colmajor', 'chw_rowmajor', 'hwc_rowmajor'};
+    ops = []; nClasses = NaN;
+    for oi = 1:numel(orders)
+        try
+            cand = nn_to_ops(net, orders{oi});
+        catch ME0
+            if oi == 1, info.reason = ['nn_to_ops refused: ' ME0.message]; end
+            continue;                               % unsupported layer -> same for every order
+        end
+        ok = true; maxe = 0;
+        for pp = 1:size(probes, 2)
+            cp = probes(:, pp);
+            yo = gpu_bab_ibp(cand, cp, cp, 'double'); yo = yo(:);
+            yn = net.evaluate(reshape(cp, inShape)); yn = yn(:);
+            if numel(yo) ~= numel(yn), ok = false; break; end
+            e = max(abs(yo - yn)); maxe = max(maxe, e);
+            if e > guardTol * max(1, max(abs(yn))), ok = false; break; end
+        end
+        if ok
+            ops = cand; nClasses = numel(yn); info.guardErr = maxe;
+            info.reason = sprintf('flatten=%s', orders{oi}); break;
+        end
     end
-    info.guardErr = max(abs(yo - yn));
-    if info.guardErr > guardTol * max(1, max(abs(yn)))
-        verdict = 'skip'; info.reason = sprintf('orientation guard failed (%.2e)', info.guardErr); return;
+    if isempty(ops)
+        if isempty(info.reason), info.reason = 'no flatten order matched net.evaluate (guard)'; end
+        verdict = 'skip'; return;
     end
-    nClasses = numel(yn);
     if target < 1 || target > nClasses
         verdict = 'skip'; info.reason = 'target out of range'; return;
     end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -1,0 +1,100 @@
+function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
+% GPU_BAB_TRY_VERIFY  Sound, ADDITIVE GPU-BaB pre-check for argmax-robustness.
+%
+%   [verdict, info] = GPU_BAB_TRY_VERIFY(net, lb, ub, target, opts) attempts to decide
+%   whether every input in the box [lb, ub] keeps argmax(net(x)) == target, using the
+%   LP-free GPU-BaB engine (CROWN/IBP + ReLU-split branch-and-bound). It is designed to be
+%   wired in FRONT of NNV's Star reachability as a fast pre-check that can ONLY help:
+%
+%     verdict : 'robust'  -- PROVEN: a sound CROWN/BaB lower bound certifies all margins > 0
+%               'unsafe'  -- a concrete counterexample, RE-CONFIRMED against net.evaluate
+%               'unknown' -- engine could not decide within budget -> caller runs Star
+%               'skip'    -- architecture unsupported OR the soundness guard failed
+%                            -> caller runs Star (GPU-BaB contributes nothing, never harm)
+%
+%   SOUNDNESS (why this can never produce a wrong verdict / -150):
+%     (1) nn_to_ops REFUSES any layer it cannot bound soundly (errors) -> 'skip'.
+%     (2) ORIENTATION GUARD: the op-list is bounded over a flat [H W C] column-major box;
+%         reach may feed a permuted box (needReshape). We require the op-list evaluation at
+%         the box CENTER to equal net.evaluate(center) to tolerance, i.e. the op-list bounds
+%         the SAME function the verdict is about. A transposed/mis-ordered box fails this for
+%         a generic center -> 'skip'. So 'robust' is a bound on the right function.
+%     (3) gpu_bab_relu_split is sound-or-unknown (robust = every BaB leaf certified).
+%     (4) 'unsafe' is taken ONLY when a concrete witness ALSO misclassifies under
+%         net.evaluate (double-checked here) -> a real counterexample for the real net.
+%
+%   opts (all optional): .precision 'single'(def)|'double'  .maxNodes 300  .guardTol 1e-4
+%         .nSample 16  .cexEvery 25  (forwarded to gpu_bab_relu_split; intermediate forced 'tight')
+
+    info = struct('reason', '', 'nodes', 0, 'cex', [], 'guardErr', NaN);
+    if nargin < 5, opts = struct(); end
+    guardTol = i_optget(opts, 'guardTol', 1e-4);
+
+    % (1) extract ops; refuse-on-unsupported -> skip (caller's Star path)
+    try
+        ops = nn_to_ops(net);
+    catch ME
+        verdict = 'skip'; info.reason = ['nn_to_ops refused: ' ME.message]; return;
+    end
+
+    inShape = i_input_shape(net);
+    lb = double(lb(:)); ub = double(ub(:));
+    if isempty(inShape) || prod(inShape) ~= numel(lb)
+        verdict = 'skip'; info.reason = 'unknown/mismatched input shape'; return;
+    end
+
+    % (2) orientation soundness guard: op-list eval == net.evaluate at the box center
+    c  = (lb + ub) / 2;
+    yo = gpu_bab_ibp(ops, c, c, 'double'); yo = yo(:);
+    yn = net.evaluate(reshape(c, inShape));  yn = yn(:);
+    if numel(yo) ~= numel(yn)
+        verdict = 'skip'; info.reason = 'output-size mismatch'; return;
+    end
+    info.guardErr = max(abs(yo - yn));
+    if info.guardErr > guardTol * max(1, max(abs(yn)))
+        verdict = 'skip'; info.reason = sprintf('orientation guard failed (%.2e)', info.guardErr); return;
+    end
+    nClasses = numel(yn);
+    if target < 1 || target > nClasses
+        verdict = 'skip'; info.reason = 'target out of range'; return;
+    end
+
+    % (3) sound ReLU-split BaB; force the 'tight' intermediate path (the only one sound for
+    %     conv/bn/pool -- relu_split also self-forces this, set here for clarity).
+    bopts = opts; bopts.intermediate = 'tight';
+    if ~isfield(bopts, 'precision'), bopts.precision = 'single'; end
+    if ~isfield(bopts, 'maxNodes'),  bopts.maxNodes  = 300;      end
+    [status, binfo] = gpu_bab_relu_split(ops, lb, ub, target, nClasses, bopts);
+    info.nodes = binfo.nodes;
+
+    % (4) map verdict; re-confirm any counterexample against net.evaluate
+    switch status
+        case 'robust'
+            verdict = 'robust';
+        case 'unsafe'
+            yc = net.evaluate(reshape(double(binfo.cex), inShape)); yc = yc(:);
+            [~, pred] = max(yc);
+            if pred ~= target
+                verdict = 'unsafe'; info.cex = binfo.cex;        % confirmed real witness
+            else
+                verdict = 'unknown'; info.reason = 'BaB cex not confirmed by net.evaluate';
+            end
+        otherwise
+            verdict = 'unknown';
+    end
+end
+
+function s = i_input_shape(net)
+% Input [H W C] for an image net, or [n 1] for a feature/flat net, from the first layer.
+    s = [];
+    if isempty(net.Layers), return; end
+    L = net.Layers{1};
+    if isprop(L, 'InputSize') && ~isempty(L.InputSize)
+        is = double(L.InputSize(:)');
+        if numel(is) == 1, s = [is 1]; else, s = is; end
+    end
+end
+
+function v = i_optget(s, f, d)
+    if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -61,8 +61,14 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
 
     % (3) sound ReLU-split BaB; force the 'tight' intermediate path (the only one sound for
     %     conv/bn/pool -- relu_split also self-forces this, set here for clarity).
+    %     PRECISION/SOUNDNESS (research R1): FP32 bounds are NOT certified-sound without
+    %     outward (directed) rounding -- accumulated rounding can make a single-precision
+    %     margin wrongly positive (-150). Default 'double' here (FP64 rounding ~1e-15,
+    %     negligible for these nets). GPU 'single' is fast but for CERTIFIED competition use
+    %     it MUST be paired with per-op outward rounding (R1.a) or a proven FP error margin;
+    %     until then 'single' is dev/empirical only. See research/GPU_BAB_PLAN.md sec 3.4/R1.
     bopts = opts; bopts.intermediate = 'tight';
-    if ~isfield(bopts, 'precision'), bopts.precision = 'single'; end
+    if ~isfield(bopts, 'precision'), bopts.precision = 'double'; end   % sound default
     if ~isfield(bopts, 'maxNodes'),  bopts.maxNodes  = 300;      end
     [status, binfo] = gpu_bab_relu_split(ops, lb, ub, target, nClasses, bopts);
     info.nodes = binfo.nodes;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -42,7 +42,18 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     % net.evaluate (the soundness guard) handles both. A wrong order/extraction never matches
     % the probes -> 'skip' (Star), never a -150. Multi-probe makes a coincidental match negligible.
     c = (lb + ub) / 2;
-    probes  = [c, lb + 0.25*(ub - lb), lb + 0.75*(ub - lb)];
+    % SOUNDNESS (audit finding): the guard must DISTINGUISH a wrong conv->FC flatten
+    % permutation. COLLINEAR probes lb+s*(ub-lb) are BLIND to column permutations on a uniform
+    % L-inf box -- for any permutation P, (P-I)*ones=0, so the s-dependent error cancels and
+    % the standard L-inf query (ub-lb uniform) admits a wrong flatten that passes the guard
+    % => false robust. Use NON-uniform, distinct-per-coordinate probe points (low-discrepancy
+    % fractional ramps): the probe images are spatially varying, so the conv output differs at
+    % permuted positions and a wrong order cannot match net.evaluate. Deterministic (no rng).
+    n = numel(lb); idx = (1:n)';
+    f1 = mod(idx * 0.6180339887498949, 1);
+    f2 = mod(idx * 1.3247179572447460 + 0.37, 1);
+    f3 = mod(idx * 0.7548776662466927 + 0.11, 1);
+    probes  = [c, lb + f1.*(ub-lb), lb + f2.*(ub-lb), lb + f3.*(ub-lb), lb + (1-f1).*(ub-lb)];
     orders  = {'colmajor', 'chw_rowmajor', 'hwc_rowmajor'};
     ops = []; nClasses = NaN;
     for oi = 1:numel(orders)
@@ -83,7 +94,18 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     %     it MUST be paired with per-op outward rounding (R1.a) or a proven FP error margin;
     %     until then 'single' is dev/empirical only. See research/GPU_BAB_PLAN.md sec 3.4/R1.
     bopts = opts; bopts.intermediate = 'tight';
-    if ~isfield(bopts, 'precision'), bopts.precision = 'double'; end   % sound default
+    % R1 SOUNDNESS (audit finding): a caller-supplied precision='single' is NOT sound (FP32
+    % rounding can make a margin spuriously positive => false robust). FORCE 'double' unless
+    % the caller EXPLICITLY opts into unsound single (dev / GPU speed; a SOUND single path
+    % needs per-op outward rounding, R1.a, not yet implemented).
+    if isfield(opts, 'allowUnsoundSingle') && isequal(opts.allowUnsoundSingle, true)
+        if ~isfield(bopts, 'precision'), bopts.precision = 'single'; end
+    else
+        bopts.precision = 'double';
+    end
+    % a negative leaf margin would certify nodes whose true class does NOT strictly dominate
+    % (false robust); clamp to >= 0 (sound-or-unknown).
+    if isfield(bopts, 'margin') && bopts.margin < 0, bopts.margin = 0; end
     if ~isfield(bopts, 'maxNodes'),  bopts.maxNodes  = 300;      end
     [status, binfo] = gpu_bab_relu_split(ops, lb, ub, target, nClasses, bopts);
     info.nodes = binfo.nodes;

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -1,45 +1,139 @@
 function ops = nn_to_ops(nnvnet)
-% NN_TO_OPS  Flatten an NNV NN object into an affine/relu op list for the GPU-BaB
-%   engine. Phase 1 supports feedforward FullyConnected + ReLU nets (acasxu,
-%   MNIST-FC). Input/Flatten layers are skipped (no effect on a flat input box);
-%   any other layer ERRORS, so coverage is explicit rather than silently wrong.
+% NN_TO_OPS  Flatten an NNV NN object into an op list for the GPU-BaB engine.
+%   Phase 1: FullyConnected + ReLU. Phase 2 (this version): + Conv2D and the
+%   ImageInputLayer normalization (folded as a leading per-element affine op), so
+%   the engine covers feedforward conv nets (plain CNNs). BatchNorm / Pool /
+%   Addition(residual) are NOT yet handled and ERROR (sound-by-refusal: the
+%   dispatcher falls back to the Star path), so coverage is explicit, never
+%   silently wrong.
 %
 %   ops: cell array of structs consumed by gpu_bab_ibp / the CROWN pass:
-%     struct('type','affine','W',W,'b',b)   % y = W*x + b
-%     struct('type','relu')                 % y = max(0,x)
+%     struct('type','affine','W',W,'b',b)                       % y = W*x + b   (flat)
+%     struct('type','relu')                                     % y = max(0,x)
+%     struct('type','normaffine','scale',s,'shift',t,'shape',S) % y = s.*x + t  (per-element, [H W C])
+%     struct('type','conv','W',W,'b',b,'stride',..,'pad',..,'dil',..,'inShape',..,'outShape',..)
+%
+%   SHAPE: bounds/coeffs are carried FLAT by the engine; conv/normaffine ops reshape
+%   flat <-> [H W C (B/nSpec)] (column-major) at their boundary. nn_to_ops threads the
+%   running spatial shape `curShape` = [H W C] so each conv records inShape/outShape,
+%   and asserts prod(curShape)==size(firstFC.W,2) at the conv->FC (flatten) boundary.
+%   The reshape order is column-major; the caller MUST verify it matches reach by
+%   asserting gpu_bab_ibp(ops,center,center) ~= net.evaluate(center) (the input-order
+%   soundness guard) before trusting any verdict.
     ops = {};
+    curShape = [];   % [H W C] once an image/conv path is entered; [] for a flat FC net
     for i = 1:numel(nnvnet.Layers)
         L = nnvnet.Layers{i};
         cls = class(L);
         if contains(cls, 'FullyConnected')
-            ops{end+1} = struct('type', 'affine', 'W', L.Weights, 'b', L.Bias); %#ok<AGROW>
+            W = L.Weights;
+            if ~isempty(curShape)
+                % conv -> flatten -> FC boundary: the FC consumes the flattened conv
+                % output; its input width must equal prod(curShape) or the flatten
+                % order is inconsistent (caught here rather than producing wrong bounds).
+                if size(W,2) ~= prod(curShape)
+                    error('nn_to_ops:flattenMismatch', ...
+                        ['FC input width %d ~= prod(curShape) %d ([%s]); flatten order ' ...
+                         'inconsistent -- cannot map conv output to this FC soundly.'], ...
+                        size(W,2), prod(curShape), num2str(curShape));
+                end
+                curShape = [];   % flattened; back to flat-vector world
+            end
+            ops{end+1} = struct('type','affine','W',W,'b',L.Bias); %#ok<AGROW>
         elseif contains(cls, 'Relu') || contains(cls, 'ReLU')
-            ops{end+1} = struct('type', 'relu'); %#ok<AGROW>
-        elseif contains(cls, 'Input') || contains(cls, 'Flatten')
-            % skip -- identity on a flat input box. NOTE: a normalizing ImageInputLayer
-            % (e.g. zerocenter) is an AFFINE shift the caller must apply to the input
-            % (pre-normalize the image / box) since it is dropped here.
+            ops{end+1} = struct('type','relu'); %#ok<AGROW>
+        elseif contains(cls, 'ImageInput') || contains(cls, 'Image3DInput')
+            % seed the spatial shape from InputSize ([H W C]) and, if the layer
+            % normalizes, fold the normalization as the FIRST op (the -150 input-mismatch
+            % fix: the box must be bounded in the SAME normalized space reach feeds conv).
+            curShape = double(L.InputSize(:)');
+            [s, t, hasNorm] = i_input_norm(L);
+            if hasNorm
+                ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',curShape); %#ok<AGROW>
+            end
+        elseif contains(cls, 'Flatten')
+            % identity on values; the conv->FC boundary assert (above) enforces the order.
+        elseif contains(cls, 'Conv2D') || (contains(cls,'Conv') && ~contains(cls,'Transposed'))
+            if isempty(curShape)
+                error('nn_to_ops:noInputShape', ...
+                    'Conv layer %d reached without a known input [H W C] shape (need an ImageInputLayer).', i);
+            end
+            op = i_conv_op(L, curShape);
+            curShape = op.outShape;
+            ops{end+1} = op; %#ok<AGROW>
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
-            % Trailing output tail (softmax monotonic; classification/output identity on
-            % logits; Placeholder = matlab2nnv stand-in for the softmax/output it could not
-            % convert). Skippable for argmax-robustness ONLY if nothing computational
-            % follows -- guard against a mid-net unknown layer being silently dropped.
+            % trailing output tail -- skippable for argmax-robustness ONLY if nothing
+            % computational follows.
             for jj = i+1:numel(nnvnet.Layers)
                 c2 = class(nnvnet.Layers{jj});
                 if contains(c2,'FullyConnected') || contains(c2,'Relu') || contains(c2,'ReLU') ...
-                        || contains(c2,'Conv') || contains(c2,'BatchNorm') || contains(c2,'Pool')
+                        || contains(c2,'Conv') || contains(c2,'BatchNorm') || contains(c2,'Pool') ...
+                        || contains(c2,'Addition')
                     error('nn_to_ops:unsupported', ...
-                        ['Layer "%s" (layer %d) is not a trailing output layer ' ...
-                         '(computational layer "%s" follows); cannot skip.'], cls, i, c2);
+                        'Layer "%s" (layer %d) is not a trailing output layer ("%s" follows).', cls, i, c2);
                 end
             end
         else
             error('nn_to_ops:unsupported', ...
-                ['GPU-BaB Phase 1 supports FullyConnected + ReLU only; got "%s" ' ...
-                 '(layer %d). Add a backward rule for this layer type to extend coverage.'], ...
-                cls, i);
+                ['GPU-BaB Phase 2 supports ImageInput(norm)+Conv2D+FullyConnected+ReLU+Flatten; ' ...
+                 'got "%s" (layer %d). BatchNorm/Pool/Addition not yet handled -- refused for soundness.'], cls, i);
         end
     end
+end
+
+% ---- conv layer -> op (params copied in NNV-native [fh fw Cin Cout] form) -------------
+function op = i_conv_op(L, inShape)
+    W = L.Weights;
+    b = L.Bias;
+    if isempty(b), b = zeros(1,1,size(W,4), 'like', W); end
+    stride = i_pair(L.Stride, [1 1]);
+    pad    = i_quad(L.PaddingSize, [0 0 0 0]);     % [t b l r]
+    dil    = i_pair(L.DilationFactor, [1 1]);
+    ng = 1;
+    if isprop(L,'NumGroups') && ~isempty(L.NumGroups) && isnumeric(L.NumGroups)
+        ng = double(L.NumGroups);
+    end
+    if ng ~= 1
+        error('nn_to_ops:groupedConv', 'grouped conv (NumGroups=%g) not yet supported -- refused for soundness.', ng);
+    end
+    Hin = inShape(1); Win = inShape(2);
+    fh = size(W,1); fw = size(W,2);
+    Hout = floor((Hin + pad(1) + pad(2) - ((fh-1)*dil(1) + 1))/stride(1) + 1);
+    Wout = floor((Win + pad(3) + pad(4) - ((fw-1)*dil(2) + 1))/stride(2) + 1);
+    Cout = size(W,4);
+    op = struct('type','conv','W',W,'b',b,'stride',stride,'pad',pad,'dil',dil, ...
+                'inShape',inShape, 'outShape',[Hout Wout Cout]);
+end
+
+% ---- ImageInputLayer normalization -> per-element affine (scale, shift) ---------------
+function [s, t, hasNorm] = i_input_norm(L)
+    s = 1; t = 0; hasNorm = false;
+    if ~isprop(L,'Normalization') || isempty(L.Normalization), return; end
+    nrm = lower(char(string(L.Normalization)));
+    switch nrm
+        case {'none',''}
+            return;
+        case 'zerocenter'
+            t = -L.Mean; s = 1; hasNorm = true;
+        case 'zscore'
+            sd = L.StandardDeviation; s = 1 ./ sd; t = -L.Mean ./ sd; hasNorm = true;
+        case 'rescale-zero-one'
+            mn = L.Min; mx = L.Max; s = 1 ./ (mx - mn); t = -mn ./ (mx - mn); hasNorm = true;
+        case 'rescale-symmetric'
+            mn = L.Min; mx = L.Max; s = 2 ./ (mx - mn); t = -2*mn ./ (mx - mn) - 1; hasNorm = true;
+        otherwise
+            error('nn_to_ops:unknownNorm', 'unhandled ImageInputLayer Normalization "%s" -- refused for soundness.', nrm);
+    end
+end
+
+function v = i_pair(x, def)
+    if isempty(x), v = def; elseif isscalar(x), v = [x x]; else, v = double(x(:)'); v = v(1:2); end
+end
+function v = i_quad(x, def)
+    if isempty(x), v = def;
+    elseif isscalar(x), v = [x x x x];
+    elseif numel(x)==2, v = [x(1) x(1) x(2) x(2)];
+    else, v = double(x(:)'); v = v(1:4); end
 end

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -1,4 +1,12 @@
-function ops = nn_to_ops(nnvnet)
+function ops = nn_to_ops(nnvnet, flattenOrder)
+%   nn_to_ops(nnvnet, flattenOrder) -- flattenOrder controls how the conv output tensor
+%   [H W C] maps to the first FC's input columns (the conv->FC boundary). MATLAB-native
+%   dlnetworks flatten column-major ('colmajor', default); ONNX-imported nets flatten
+%   row-major, which mis-orders the FC columns vs the engine's column-major view (caught by
+%   the degenerate-IBP==evaluate guard). The dispatcher auto-calibrates: it tries each order
+%   and keeps the one whose op-list matches net.evaluate. Sound either way (wrong -> guard
+%   fails -> skip). Orders: 'colmajor' | 'chw_rowmajor' (ONNX [C H W]) | 'hwc_rowmajor'.
+    if nargin < 2 || isempty(flattenOrder), flattenOrder = 'colmajor'; end
 % NN_TO_OPS  Flatten an NNV NN object into an op list for the GPU-BaB engine.
 %   Phase 1: FullyConnected + ReLU. Phase 2 (this version): + Conv2D and the
 %   ImageInputLayer normalization (folded as a leading per-element affine op), so
@@ -37,6 +45,9 @@ function ops = nn_to_ops(nnvnet)
                          'inconsistent -- cannot map conv output to this FC soundly.'], ...
                         size(W,2), prod(curShape), num2str(curShape));
                 end
+                % reorder the FC weight columns from the net's flatten order to the engine's
+                % column-major [H W C] view (identity for 'colmajor'); validated by the guard.
+                W = i_flatten_permute(W, curShape, flattenOrder);
                 curShape = [];   % flattened; back to flat-vector world
             end
             ops{end+1} = struct('type','affine','W',W,'b',L.Bias); %#ok<AGROW>
@@ -193,6 +204,27 @@ function op = i_maxpool_op(L, inShape)
     Wout = floor((Win - pool(2))/stride(2) + 1);
     op = struct('type','maxpool','pool',pool,'stride',stride,'pad',pad, ...
                 'inShape',inShape, 'outShape',[Hout Wout C]);
+end
+
+% ---- conv->FC flatten: reorder FC weight columns to the engine's column-major view -----
+function W2 = i_flatten_permute(W, shape, order)
+% The engine flattens the conv output [H W C] COLUMN-MAJOR (H fastest). If the net flattens
+% it in another order, the FC weight columns are mis-aligned. Build the permutation that maps
+% each column-major position (h,w,c) to the net's flatten index, then reorder W's columns.
+    H = shape(1); Wd = shape(2); C = shape(3);
+    [hh, ww, cc] = ndgrid(1:H, 1:Wd, 1:C);              % linearized = column-major over [H W C]
+    h = hh(:); w = ww(:); c = cc(:);
+    switch order
+        case 'colmajor'
+            W2 = W; return;                              % already column-major -- no reorder
+        case 'chw_rowmajor'                              % ONNX [C H W] flattened row-major (W fastest)
+            netidx = (c-1)*H*Wd + (h-1)*Wd + w;
+        case 'hwc_rowmajor'                              % [H W C] row-major (C fastest)
+            netidx = (h-1)*Wd*C + (w-1)*C + c;
+        otherwise
+            error('nn_to_ops:flattenOrder', 'unknown flattenOrder "%s".', order);
+    end
+    W2 = W(:, netidx);
 end
 
 % ---- ImageInputLayer normalization -> per-element affine (scale, shift) ---------------

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -80,6 +80,14 @@ function ops = nn_to_ops(nnvnet)
             op = i_avgpool_op(L, curShape, cls);
             curShape = op.outShape;
             ops{end+1} = op; %#ok<AGROW>
+        elseif contains(cls, 'MaxPool') || contains(cls, 'MaxPooling')
+            if isempty(curShape)
+                error('nn_to_ops:poolFlat', ...
+                    'Pooling on a flat vector has no spatial shape -- refused for soundness.');
+            end
+            op = i_maxpool_op(L, curShape);
+            curShape = op.outShape;
+            ops{end+1} = op; %#ok<AGROW>
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
@@ -166,6 +174,24 @@ function op = i_avgpool_op(L, inShape, cls)
     Hout = floor((Hin - pool(1))/stride(1) + 1);
     Wout = floor((Win - pool(2))/stride(2) + 1);
     op = struct('type','avgpool','pool',pool,'stride',stride,'pad',pad, ...
+                'inShape',inShape, 'outShape',[Hout Wout C]);
+end
+
+% ---- Max pooling -> depthwise per-window max (NONLINEAR; sound relax in CROWN) --------
+function op = i_maxpool_op(L, inShape)
+% Per-channel max over each window. Monotone (exact IBP); CROWN uses a sound relaxation
+% from the window's input bounds. Overlapping (stride<pool) is allowed (the CROWN scatter
+% handles it). UNPADDED only -- padded max pooling (pads with -Inf) is refused for now.
+    Hin = inShape(1); Win = inShape(2); C = inShape(3);
+    pool   = i_pair(L.PoolSize, [1 1]);
+    stride = i_pair(L.Stride,   pool);
+    pad    = i_quad(L.PaddingSize, [0 0 0 0]);
+    if any(pad ~= 0)
+        error('nn_to_ops:maxpoolPad', 'padded max pooling not yet supported -- refused for soundness.');
+    end
+    Hout = floor((Hin - pool(1))/stride(1) + 1);
+    Wout = floor((Win - pool(2))/stride(2) + 1);
+    op = struct('type','maxpool','pool',pool,'stride',stride,'pad',pad, ...
                 'inShape',inShape, 'outShape',[Hout Wout C]);
 end
 

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -61,6 +61,25 @@ function ops = nn_to_ops(nnvnet)
             op = i_conv_op(L, curShape);
             curShape = op.outShape;
             ops{end+1} = op; %#ok<AGROW>
+        elseif contains(cls, 'BatchNorm')
+            % BatchNorm at inference is a per-CHANNEL affine y = s_c.*x + t_c (LINEAR ->
+            % exact, no relaxation): fold as a per-channel normaffine ([1 1 C] broadcast
+            % over [H W C], handled by the existing normaffine IBP/CROWN). Conv-path only;
+            % a post-flatten BN (curShape==[]) is refused (rare; sound-by-refusal).
+            if isempty(curShape)
+                error('nn_to_ops:bnFlat', ...
+                    'BatchNorm on a flat (post-flatten) vector not yet supported -- refused for soundness.');
+            end
+            [s, t] = i_bn_fold(L, curShape);
+            ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',curShape); %#ok<AGROW>
+        elseif contains(cls, 'AvgPool') || contains(cls, 'AveragePool') || contains(cls, 'GlobalAveragePool')
+            if isempty(curShape)
+                error('nn_to_ops:poolFlat', ...
+                    'Pooling on a flat vector has no spatial shape -- refused for soundness.');
+            end
+            op = i_avgpool_op(L, curShape, cls);
+            curShape = op.outShape;
+            ops{end+1} = op; %#ok<AGROW>
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
@@ -105,6 +124,49 @@ function op = i_conv_op(L, inShape)
     Cout = size(W,4);
     op = struct('type','conv','W',W,'b',b,'stride',stride,'pad',pad,'dil',dil, ...
                 'inShape',inShape, 'outShape',[Hout Wout Cout]);
+end
+
+% ---- BatchNorm (inference) -> per-channel affine fold -------------------------------
+function [s, t] = i_bn_fold(L, shape)
+% y = Scale.*(x - TrainedMean)./sqrt(TrainedVariance + Epsilon) + Offset = s_c.*x + t_c.
+% Per channel -> [1 1 C] (broadcast over [H W C] by the normaffine op). LINEAR -> exact.
+    C = shape(3);
+    mu = L.TrainedMean(:); v = L.TrainedVariance(:);
+    ga = L.Scale(:); be = L.Offset(:);
+    if isscalar(L.Epsilon), ep = L.Epsilon * ones(C,1); else, ep = L.Epsilon(:); end
+    if numel(mu)~=C || numel(v)~=C || numel(ga)~=C || numel(be)~=C
+        error('nn_to_ops:bnChannels', ...
+            'BatchNorm param lengths (mean %d var %d scale %d offset %d) ~= channels %d.', ...
+            numel(mu), numel(v), numel(ga), numel(be), C);
+    end
+    den = sqrt(v + ep);
+    s = reshape(ga ./ den, [1 1 C]);
+    t = reshape(be - ga .* mu ./ den, [1 1 C]);
+end
+
+% ---- Average pooling -> depthwise non-overlapping LINEAR pool ------------------------
+function op = i_avgpool_op(L, inShape, cls)
+% Per-channel mean over each window (all +weights -> monotone IBP, exact CROWN adjoint =
+% uniform distribute). NON-OVERLAPPING only (stride==pool) and UNPADDED -- padded /
+% overlapping avgpool is refused (sound-by-refusal); GlobalAvgPool is the whole H x W.
+    Hin = inShape(1); Win = inShape(2); C = inShape(3);
+    if contains(cls, 'Global')
+        pool = [Hin Win]; stride = [Hin Win]; pad = [0 0 0 0];
+    else
+        pool   = i_pair(L.PoolSize, [1 1]);
+        stride = i_pair(L.Stride,   pool);          % default stride = pool size
+        pad    = i_quad(L.PaddingSize, [0 0 0 0]);
+    end
+    if any(pad ~= 0)
+        error('nn_to_ops:avgpoolPad', 'padded average pooling not yet supported -- refused for soundness.');
+    end
+    if ~isequal(stride, pool)
+        error('nn_to_ops:avgpoolOverlap', 'overlapping average pooling (stride~=pool) not yet supported -- refused for soundness.');
+    end
+    Hout = floor((Hin - pool(1))/stride(1) + 1);
+    Wout = floor((Win - pool(2))/stride(2) + 1);
+    op = struct('type','avgpool','pool',pool,'stride',stride,'pad',pad, ...
+                'inShape',inShape, 'outShape',[Hout Wout C]);
 end
 
 % ---- ImageInputLayer normalization -> per-element affine (scale, shift) ---------------

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -30,6 +30,12 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
 %   soundness guard) before trusting any verdict.
     ops = {};
     curShape = [];   % [H W C] once an image/conv path is entered; [] for a flat FC net
+    % DAG support (residual Addition): NNV keeps Layers topologically ordered + a Connections
+    % table. layerOp maps a layer NAME -> the op index whose output equals that layer's output
+    % (0 = the engine input). An AdditionLayer reads its source op indices from here.
+    conns = [];
+    if isprop(nnvnet, 'Connections'), conns = nnvnet.Connections; end
+    layerOp = containers.Map('KeyType', 'char', 'ValueType', 'double');
     for i = 1:numel(nnvnet.Layers)
         L = nnvnet.Layers{i};
         cls = class(L);
@@ -99,6 +105,21 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
             op = i_maxpool_op(L, curShape);
             curShape = op.outShape;
             ops{end+1} = op; %#ok<AGROW>
+        elseif contains(cls, 'Addition')
+            % residual skip-add: y = out[a] + out[b] (LINEAR -> exact). Read the two source
+            % layers from Connections; map to op indices via layerOp (0 = engine input). Only
+            % 2 inputs supported (audit guard); N>2 refused for soundness.
+            srcs = i_layer_sources(conns, char(L.Name));
+            if numel(srcs) ~= 2
+                error('nn_to_ops:addNInputs', ...
+                    'Addition with %d inputs not supported (only 2) -- refused for soundness.', numel(srcs));
+            end
+            if ~isKey(layerOp, srcs{1}) || ~isKey(layerOp, srcs{2})
+                error('nn_to_ops:addSrc', 'Addition source layer not yet emitted -- unsupported DAG topology.');
+            end
+            a = layerOp(srcs{1}); b = layerOp(srcs{2});
+            ops{end+1} = struct('type','add','inputs',[a b],'shape',curShape); %#ok<AGROW>
+            % element-wise add preserves curShape (both inputs must share it; guard validates)
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
@@ -115,8 +136,13 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
             end
         else
             error('nn_to_ops:unsupported', ...
-                ['GPU-BaB Phase 2 supports ImageInput(norm)+Conv2D+FullyConnected+ReLU+Flatten; ' ...
-                 'got "%s" (layer %d). BatchNorm/Pool/Addition not yet handled -- refused for soundness.'], cls, i);
+                ['GPU-BaB supports ImageInput(norm)+Conv2D+FullyConnected+ReLU+Flatten+BatchNorm' ...
+                 '+Avg/Max-pool+Addition(2-input); got "%s" (layer %d) -- refused for soundness.'], cls, i);
+        end
+        % record this layer's output op index (0 if it emitted no op = input/identity), so a
+        % later AdditionLayer can resolve its skip source. Names are unique within a net.
+        if isprop(L, 'Name') && ~isempty(char(L.Name))
+            layerOp(char(L.Name)) = numel(ops);
         end
     end
 end
@@ -256,4 +282,20 @@ function v = i_quad(x, def)
     elseif isscalar(x), v = [x x x x];
     elseif numel(x)==2, v = [x(1) x(1) x(2) x(2)];
     else, v = double(x(:)'); v = v(1:4); end
+end
+
+% ---- source layer names feeding a destination layer (from the Connections table) -------
+function srcs = i_layer_sources(conns, name)
+% Return the Source layer names whose Destination is `name` or `name/inK` (the input ports
+% of a multi-input layer like AdditionLayer). Empty if no Connections (sequential net).
+    srcs = {};
+    if isempty(conns), return; end
+    for r = 1:height(conns)
+        dest = char(conns.Destination(r));
+        sl = strfind(dest, '/');
+        if ~isempty(sl), dest = dest(1:sl(1)-1); end   % strip the "/inK" port
+        if strcmp(dest, name)
+            srcs{end+1} = char(conns.Source(r)); %#ok<AGROW>
+        end
+    end
 end

--- a/code/nnv/examples/Submission/VNN_COMP2025/gpu_bab_first_pass.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/gpu_bab_first_pass.m
@@ -1,0 +1,72 @@
+function res = gpu_bab_first_pass(category, onnx, vnnlib, opts)
+% GPU_BAB_FIRST_PASS  Offline, READ-ONLY GPU-BaB first-pass on one vnncomp instance.
+%
+%   res = GPU_BAB_FIRST_PASS(category, onnx, vnnlib, opts) loads the instance with the
+%   SAME loaders run_vnncomp_instance uses (load_vnncomp_network + load_vnnlib), builds the
+%   net-order input box exactly as create_input_set would (replicating the needReshape
+%   permute), takes target = argmax(net(box center)) (the nominal class for an argmax-
+%   robustness benchmark), and runs the sound gpu_bab_try_verify pre-check. It returns the
+%   verdict ONLY -- it changes no production result and is meant to be COMPARED against gold
+%   (Star) to measure GPU-BaB coverage + agreement. A gpu='robust' that disagrees with a
+%   gold violation is a RED FLAG to investigate (extraction/orientation), never a verdict.
+%
+%   res fields: verdict ('robust'|'unsafe'|'unknown'|'skip'), target, nClasses, guardErr,
+%               nodes, reason. opts forwarded to gpu_bab_try_verify (maxNodes, precision...).
+
+    if nargin < 4, opts = struct(); end
+    res = struct('verdict','error','target',NaN,'nClasses',NaN,'guardErr',NaN,'nodes',0,'reason','');
+    try
+        [~, nnvnet, needReshape, ~, inputSize, ~, ~, ~] = load_vnncomp_network(category, onnx, vnnlib);
+        property = load_vnnlib(vnnlib);
+        lb = property.lb; ub = property.ub;
+        if iscell(lb), lb = lb{1}; ub = ub{1}; end           % first input set (first-pass)
+
+        [blb, bub] = i_netorder_box(lb, ub, inputSize, needReshape);
+        inShape = i_inshape(nnvnet, numel(blb));
+        c  = (double(blb) + double(bub)) / 2;
+        yc = nnvnet.evaluate(reshape(c, inShape)); yc = yc(:);
+        [~, tgt] = max(yc);
+
+        [verdict, info] = gpu_bab_try_verify(nnvnet, blb, bub, tgt, opts);
+        res.verdict  = char(verdict);
+        res.target   = tgt;
+        res.nClasses = numel(yc);
+        res.guardErr = info.guardErr;
+        res.nodes    = info.nodes;
+        res.reason   = char(info.reason);
+    catch ME
+        res.verdict = 'error'; res.reason = ME.message;
+    end
+end
+
+function [blb, bub] = i_netorder_box(lb, ub, inputSize, needReshape)
+% Reproduce create_input_set's box -> net-order [H W C] mapping, then flatten column-major.
+    if iscell(inputSize), inputSize = inputSize{1}; end
+    is_feature = isscalar(inputSize) || (numel(inputSize) <= 3 && nnz(inputSize > 1) <= 1);
+    if is_feature
+        blb = double(lb(:)); bub = double(ub(:)); return;    % flat feature input -- no permute
+    end
+    L = reshape(double(lb), inputSize); U = reshape(double(ub), inputSize);
+    if needReshape == 1
+        L = permute(L, [2 1 3]);            U = permute(U, [2 1 3]);
+    elseif needReshape == 2
+        ns = [inputSize(2) inputSize(1) inputSize(3:end)];
+        L = permute(reshape(double(lb), ns), [2 1 3 4]);
+        U = permute(reshape(double(ub), ns), [2 1 3 4]);
+    elseif needReshape == 3
+        L = permute(L, [3 2 1]);            U = permute(U, [3 2 1]);
+    end
+    blb = L(:); bub = U(:);
+end
+
+function s = i_inshape(nnvnet, n)
+    s = [];
+    if ~isempty(nnvnet.Layers)
+        L = nnvnet.Layers{1};
+        if isprop(L, 'InputSize') && ~isempty(L.InputSize)
+            is = double(L.InputSize(:)');
+            if numel(is) == 1, s = [is 1]; else, s = is; end
+        end
+    end
+    if isempty(s), s = [n 1]; end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2025/gpu_bab_first_pass_batch.m
+++ b/code/nnv/examples/Submission/VNN_COMP2025/gpu_bab_first_pass_batch.m
@@ -1,0 +1,90 @@
+function summary = gpu_bab_first_pass_batch(bench_root, subfolder, run_which, maxInst, goldCsv)
+% GPU_BAB_FIRST_PASS_BATCH  Offline, READ-ONLY GPU-BaB first-pass over a benchmark's instances.
+%
+%   summary = GPU_BAB_FIRST_PASS_BATCH(bench_root, subfolder, run_which, maxInst, goldCsv)
+%   resolves the (onnx, vnnlib) pairs with the SAME loader as the sweep
+%   (vnncomp_pick_instances), runs the sound gpu_bab_first_pass on each, and (if goldCsv is a
+%   sweep results_*.csv) classifies each instance vs gold:
+%     AGREE     -- gpu robust&gold unsat, or gpu unsafe&gold sat
+%     WIN       -- gpu robust/unsafe where gold was unknown/timeout/error (GPU-BaB verified
+%                  what Star could not)
+%     RED-FLAG  -- gpu robust but gold sat (a false-robust!), or gpu unsafe but gold unsat
+%                  -- MUST be investigated before trusting GPU-BaB on this benchmark
+%   It changes NO production result. RED-FLAG=0 is the soundness gate for this benchmark.
+%
+%   run_which: 'first' | 'all' (default 'all'); maxInst caps the count (default Inf).
+
+    if nargin < 3 || isempty(run_which), run_which = 'all'; end
+    if nargin < 4 || isempty(maxInst), maxInst = Inf; end
+    if nargin < 5, goldCsv = ''; end
+    cat = subfolder;   % category = folder name (matches run_all_benchmarks default routing)
+
+    inst_csv = fullfile(bench_root, subfolder, 'instances.csv');
+    if ~isfile(inst_csv)
+        a1 = fullfile(bench_root, subfolder, '1.0', 'instances.csv'); if isfile(a1), inst_csv = a1; end
+    end
+    assert(isfile(inst_csv), 'no instances.csv for %s', subfolder);
+    pairs = vnncomp_pick_instances(inst_csv, bench_root, subfolder, run_which);
+    n = min(numel(pairs), maxInst);
+
+    gold = containers.Map();
+    if ~isempty(goldCsv) && isfile(goldCsv)
+        G = readtable(goldCsv, 'TextType', 'string', 'Delimiter', ',');
+        for r = 1:height(G)
+            gold(char(G.onnx(r)) + "|" + char(G.vnnlib(r))) = lower(char(G.status_str(r)));
+        end
+    end
+
+    outcsv = sprintf('gpubab_firstpass_%s.csv', subfolder);
+    fid = fopen(outcsv, 'w');
+    fprintf(fid, 'onnx,vnnlib,gpu_verdict,reason,guardErr,nodes,time_s,gold,class\n');
+    cnt = struct('robust',0,'unsafe',0,'unknown',0,'skip',0,'error',0);
+    cls = struct('AGREE',0,'WIN',0,'REDFLAG',0,'NA',0);
+    opts = struct('precision','double','maxNodes',200,'nSample',20);
+
+    for k = 1:n
+        pr = pairs{k}; t0 = tic;
+        try
+            res = gpu_bab_first_pass(cat, pr.onnx, pr.vnnlib, opts);
+        catch ME
+            res = struct('verdict','error','reason',ME.message,'guardErr',NaN,'nodes',0);
+        end
+        ts = toc(t0);
+        v = res.verdict; if isfield(cnt, v), cnt.(v) = cnt.(v) + 1; end
+
+        gkey = pr.onnx_rel + "|" + pr.vnnlib_rel;
+        gv = ''; if isKey(gold, char(gkey)), gv = gold(char(gkey)); end
+        c = i_classify(v, gv);
+        if isfield(cls, c), cls.(c) = cls.(c) + 1; end
+
+        fprintf(fid, '%s,%s,%s,%s,%.2e,%d,%.1f,%s,%s\n', pr.onnx_rel, pr.vnnlib_rel, v, ...
+            strrep(res.reason, ',', ';'), res.guardErr, res.nodes, ts, gv, c);
+        fprintf('[%d/%d] %s -> gpu=%s gold=%s [%s] (%.1fs) %s\n', k, n, pr.onnx_rel, v, gv, c, ts, res.reason);
+    end
+    fclose(fid);
+
+    summary = struct('subfolder',subfolder,'n',n,'counts',cnt,'classes',cls,'csv',outcsv);
+    fprintf('\n=== GPU-BaB first-pass %s (%d instances) ===\n', subfolder, n);
+    fprintf('  verdicts: robust=%d unsafe=%d unknown=%d skip=%d error=%d\n', ...
+        cnt.robust, cnt.unsafe, cnt.unknown, cnt.skip, cnt.error);
+    if ~isempty(goldCsv)
+        fprintf('  vs gold: AGREE=%d  WIN(beat Star)=%d  RED-FLAG=%d  (RED-FLAG MUST be 0)\n', ...
+            cls.AGREE, cls.WIN, cls.REDFLAG, cls.NA);
+    end
+end
+
+function c = i_classify(gpu, gold)
+% Classify a GPU-BaB verdict against the gold (Star) status string.
+    c = 'NA';
+    if isempty(gold), return; end
+    holds = any(strcmp(gold, {'unsat','holds','robust','verified'}));
+    viol  = any(strcmp(gold, {'sat','violated','falsified','unsafe'}));
+    unc   = any(strcmp(gold, {'unknown','timeout','error'}));
+    if strcmp(gpu, 'robust')
+        if holds, c = 'AGREE'; elseif viol, c = 'REDFLAG'; elseif unc, c = 'WIN'; end
+    elseif strcmp(gpu, 'unsafe')
+        if viol, c = 'AGREE'; elseif holds, c = 'REDFLAG'; elseif unc, c = 'WIN'; end
+    else
+        c = 'NA';   % gpu unknown/skip -> no claim
+    end
+end

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_bn_pool.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_bn_pool.m
@@ -1,0 +1,86 @@
+% test_soundness_gpu_bab_bn_pool
+% Soundness tests for the GPU-BaB engine's BatchNorm + AveragePooling layer support.
+% BatchNorm (inference) folds to a per-channel affine; average/global-average pooling is
+% a per-channel uniform (monotone) linear map. Both are LINEAR -> exact CROWN, no
+% relaxation. Validated on a conv + BN + ReLU + avgpool + conv + BN + ReLU + GLOBAL-avgpool
+% + FC net (a resnet-style feedforward backbone), with non-trivial injected BN statistics.
+% To run: results = runtests('test_soundness_gpu_bab_bn_pool')
+%
+% NOTE: each %% section runs independently under runtests, so every shared quantity is
+% computed here in the shared-variables setup.
+
+% ---- shared setup: build the net, inject non-trivial BN stats, extract ops, MC truth ----
+rng(2);
+layers = [imageInputLayer([16 16 3],'Normalization','zscore', ...
+              'Mean',0.4*ones(16,16,3),'StandardDeviation',0.2*ones(16,16,3),'Name','in')
+          convolution2dLayer(3,6,'Padding',1,'Stride',1,'Name','c1')
+          batchNormalizationLayer('Name','bn1'); reluLayer('Name','r1')
+          averagePooling2dLayer(2,'Stride',2,'Name','ap1')             % 16 -> 8
+          convolution2dLayer(3,4,'Padding',1,'Stride',2,'Name','c2')   % 8 -> 4
+          batchNormalizationLayer('Name','bn2'); reluLayer('Name','r2')
+          globalAveragePooling2dLayer('Name','gap')                    % 4x4 -> 1x1
+          fullyConnectedLayer(5,'Name','fc')];
+net = dlnetwork(layers);
+S = net.State;                              % inject non-trivial BN running stats
+for i = 1:height(S)
+    if strcmp(S.Parameter{i},'TrainedMean'),     S.Value{i} = dlarray(0.3*randn(size(S.Value{i}),'single')); end
+    if strcmp(S.Parameter{i},'TrainedVariance'), S.Value{i} = dlarray(0.5+0.5*rand(size(S.Value{i}),'single')); end
+end
+net.State = S;
+Lr = net.Learnables;                        % inject non-trivial BN scale/offset
+for i = 1:height(Lr)
+    if contains(Lr.Layer{i},'bn')
+        if strcmp(Lr.Parameter{i},'Scale'),  Lr.Value{i} = dlarray(0.5+0.5*rand(size(Lr.Value{i}),'single')); end
+        if strcmp(Lr.Parameter{i},'Offset'), Lr.Value{i} = dlarray(0.2*randn(size(Lr.Value{i}),'single')); end
+    end
+end
+net.Learnables = Lr;
+
+nnvnet = matlab2nnv(net);
+ops    = nn_to_ops(nnvnet);
+Cspec  = [eye(4) -ones(4,1)];               % class-5 robustness margins out(c)-out(5)
+xc     = rand(16,16,3);
+lb     = xc(:) - 0.03;  ub = xc(:) + 0.03;
+Xs     = lb + (ub - lb) .* rand(768, 3000);
+tmp = inf(4,1);
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [16 16 3]));
+    tmp = min(tmp, Cspec * ys(:));
+end
+trueMin = tmp;
+
+%% Test 1: BN folds + avgpool extract; degenerate IBP == NNV evaluate (input ordering)
+xt = rand(16,16,3);
+yn = nnvnet.evaluate(xt); yn = yn(:);
+yo = gpu_bab_ibp(ops, xt(:), xt(:), 'double');
+assert(max(abs(yo(:) - yn)) < 1e-4, 'degenerate-box IBP must match NNV evaluate (BN fold + avgpool + ordering)');
+
+%% Test 2: BN + avgpool ops appear in the decomposition (no silent skip)
+types = cellfun(@(o) string(o.type), ops);
+assert(sum(types=="normaffine") >= 3, 'expected input-norm + 2 BatchNorm folds as normaffine ops');
+assert(sum(types=="avgpool") == 2, 'expected the averagePooling + globalAveragePooling ops');
+
+%% Test 3: IBP box is sound (contains every sampled output)
+[olb, oub] = gpu_bab_ibp(ops, lb, ub, 'double');
+ok = true;
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [16 16 3])); ys = ys(:);
+    if any(ys < olb - 1e-6) || any(ys > oub + 1e-6), ok = false; break; end
+end
+assert(ok, 'IBP box must contain all sampled outputs (BN + avgpool)');
+
+%% Test 4: CROWN backward is EXACT at a point (BN backward + avgpool repelem adjoint)
+xt = rand(16,16,3);
+md = gpu_bab_crown_tight(ops, xt(:), xt(:), Cspec, 'double');
+yn = nnvnet.evaluate(xt);
+assert(max(abs(md - Cspec * yn(:))) < 1e-4, 'degenerate CROWN must equal C*evaluate (exact BN + avgpool adjoints)');
+
+%% Test 5: CROWN-tight is sound and no looser than IBP
+mt = gpu_bab_crown_tight(ops, lb, ub, Cspec, 'double');
+assert(all(mt <= trueMin + 1e-4), 'CROWN-tight margin must be sound (<= true min)');
+[ilb, iub] = gpu_bab_ibp(ops, lb, ub, 'double');
+Cp = max(Cspec, 0); Cn = min(Cspec, 0);
+assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'CROWN-tight must be no looser than IBP');
+
+%% Summary
+disp('test_soundness_gpu_bab_bn_pool: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_conv.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_conv.m
@@ -55,5 +55,13 @@ assert(all(mt <= trueMin + 1e-4), 'conv CROWN-tight margin must be sound (<= tru
 Cp = max(Cspec, 0); Cn = min(Cspec, 0);
 assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'conv CROWN-tight must be no looser than IBP');
 
+%% Test 5: conv->FC flatten-order permute is non-trivial and column-major matches the net
+% (the dispatcher auto-calibrates this against net.evaluate for ONNX row-major flattens)
+xt = rand(10,10,2); yn = nnvnet.evaluate(xt); yn = yn(:);
+y_cm = gpu_bab_ibp(nn_to_ops(nnvnet, 'colmajor'),     xt(:), xt(:), 'double');
+y_rm = gpu_bab_ibp(nn_to_ops(nnvnet, 'chw_rowmajor'), xt(:), xt(:), 'double');
+assert(max(abs(y_cm(:) - yn)) < 1e-4, 'colmajor must match this native dlnetwork''s flatten');
+assert(max(abs(y_rm(:) - yn)) > 1e-3, 'a wrong flatten order must visibly differ (guard discriminates)');
+
 %% Summary
 disp('test_soundness_gpu_bab_conv: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_conv.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_conv.m
@@ -1,0 +1,59 @@
+% test_soundness_gpu_bab_conv
+% Soundness tests for the GPU-BaB engine's CONV layer support (Conv2D + folded
+% ImageInputLayer normalization). Validates the dlconv IBP (W+/W- split) and the EXACT
+% dltranspconv CROWN adjoint on a net with padding + stride + normalization -- the cases
+% that exercise the conv<->matrix reshape, the input-ordering, and the strided adjoint.
+% To run: results = runtests('test_soundness_gpu_bab_conv')
+%
+% NOTE: each %% section runs independently under runtests, so every shared quantity is
+% computed here in the shared-variables setup (not in a prior test).
+
+% ---- shared setup (deterministic): conv net (pad+stride+norm), ops, box, MC truth ----
+rng(1);
+layers = [imageInputLayer([10 10 2],'Normalization','zerocenter','Mean',0.3*ones(10,10,2),'Name','in')
+          convolution2dLayer(3,5,'Padding',1,'Stride',1,'Name','c1'); reluLayer('Name','r1')
+          convolution2dLayer(3,3,'Padding',1,'Stride',2,'Name','c2'); reluLayer('Name','r2')
+          fullyConnectedLayer(4,'Name','fc')];
+nnvnet = matlab2nnv(dlnetwork(layers));
+ops    = nn_to_ops(nnvnet);
+Cspec  = [1 -1 0 0; 1 0 -1 0; 1 0 0 -1];           % robustness spec for class 1
+xc     = rand(10,10,2);
+lb     = xc(:) - 0.05;  ub = xc(:) + 0.05;
+Xs     = lb + (ub - lb) .* rand(200, 3000);        % Monte-Carlo input samples
+tmp = inf(3,1);
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [10 10 2]));
+    tmp = min(tmp, Cspec * ys(:));
+end
+trueMin = tmp;
+
+%% Test 1: conv op-extraction + input-ordering guard (degenerate IBP == NNV evaluate)
+xt = rand(10,10,2);
+yn = nnvnet.evaluate(xt); yn = yn(:);
+yo = gpu_bab_ibp(ops, xt(:), xt(:), 'double');
+assert(max(abs(yo(:) - yn)) < 1e-4, 'degenerate-box conv IBP must match NNV evaluate (input ordering)');
+
+%% Test 2: conv IBP box is sound (contains every sampled output)
+[olb, oub] = gpu_bab_ibp(ops, lb, ub, 'double');
+ok = true;
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [10 10 2])); ys = ys(:);
+    if any(ys < olb - 1e-6) || any(ys > oub + 1e-6), ok = false; break; end
+end
+assert(ok, 'conv IBP box must contain all sampled outputs');
+
+%% Test 3: conv CROWN backward is EXACT at a point (== C*evaluate, the dltranspconv adjoint)
+xt = rand(10,10,2);
+md = gpu_bab_crown_tight(ops, xt(:), xt(:), Cspec, 'double');
+yn = nnvnet.evaluate(xt);
+assert(max(abs(md - Cspec * yn(:))) < 1e-4, 'degenerate conv CROWN must equal C*evaluate (exact adjoint)');
+
+%% Test 4: conv CROWN-tight is sound and no looser than IBP
+mt = gpu_bab_crown_tight(ops, lb, ub, Cspec, 'double');
+assert(all(mt <= trueMin + 1e-4), 'conv CROWN-tight margin must be sound (<= true min)');
+[ilb, iub] = gpu_bab_ibp(ops, lb, ub, 'double');
+Cp = max(Cspec, 0); Cn = min(Cspec, 0);
+assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'conv CROWN-tight must be no looser than IBP');
+
+%% Summary
+disp('test_soundness_gpu_bab_conv: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_dispatch.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_dispatch.m
@@ -61,5 +61,36 @@ for t = 1:6
 end
 fprintf('(%d unsafe verdicts, all witness-confirmed)\n', nUnsafe);
 
+%% Test 5: flatten guard distinguishes a WRONG order on a UNIFORM L-inf box (audit -150 fix)
+% Worst case: a constant image + uniform-eps box. Collinear probes lb+s*(ub-lb) were BLIND to
+% column permutations there ((P-I)*ones=0), so a wrong flatten order could pass and bound the
+% wrong function. The non-uniform (low-discrepancy) probes must REJECT the wrong orders.
+net2 = matlab2nnv(dlnetwork(mklayers()));
+x0 = 0.5*ones(6,6,1); ep = 0.05; lbf = x0(:)-ep; ubf = x0(:)+ep;   % constant image, uniform L-inf
+nn = numel(lbf); ii = (1:nn)';
+g1 = mod(ii*0.6180339887498949,1); g2 = mod(ii*1.3247179572447460+0.37,1); g3 = mod(ii*0.7548776662466927+0.11,1);
+pr = [(lbf+ubf)/2, lbf+g1.*(ubf-lbf), lbf+g2.*(ubf-lbf), lbf+g3.*(ubf-lbf), lbf+(1-g1).*(ubf-lbf)];
+ords = {'colmajor','chw_rowmajor','hwc_rowmajor'}; matchOrder = false(1,3);
+for oi = 1:3
+    ops2 = nn_to_ops(net2, ords{oi}); good = true;
+    for pp = 1:size(pr,2)
+        cp = pr(:,pp); yo = gpu_bab_ibp(ops2, cp, cp, 'double'); yn = net2.evaluate(reshape(cp,[6 6 1]));
+        if max(abs(yo(:)-yn(:))) > 1e-4*max(1,max(abs(yn(:)))), good = false; break; end
+    end
+    matchOrder(oi) = good;
+end
+assert(matchOrder(1), 'colmajor (the native flatten) must match at the non-uniform probes');
+assert(~matchOrder(2) && ~matchOrder(3), 'CARDINAL: wrong flatten orders must be REJECTED on the uniform-box worst case (else false-robust)');
+
+%% Test 6: a caller-supplied precision='single' must not yield an unsound robust (forced double)
+x = rand(6,6,1); y = net.evaluate(x); [~,tgt] = max(y(:));
+lb = max(x(:)-0.015,0); ub = min(x(:)+0.015,1);
+[vs, ~] = gpu_bab_try_verify(net, lb, ub, tgt, struct('precision','single','maxNodes',120));
+if strcmp(vs,'robust')
+    bad = false;
+    for s=1:3000, xs=lb+(ub-lb).*rand(36,1); ys=net.evaluate(reshape(xs,[6 6 1])); [~,p]=max(ys(:)); if p~=tgt, bad=true; break; end, end
+    assert(~bad, 'precision=single robust must still be MC-sound (engine forces double internally)');
+end
+
 %% Summary
 disp('test_soundness_gpu_bab_dispatch: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_dispatch.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_dispatch.m
@@ -1,0 +1,65 @@
+% test_soundness_gpu_bab_dispatch
+% Soundness tests for gpu_bab_try_verify -- the additive GPU-BaB pre-check. The cardinal
+% property: it must NEVER return 'robust' when the box contains a counterexample (a -150),
+% and any 'unsafe' must be a real witness. It must 'skip' unsupported architectures.
+% Small nets / modest budgets for speed.
+
+rng(11);
+mklayers = @() [imageInputLayer([6 6 1],'Normalization','none','Name','in')
+                convolution2dLayer(3,4,'Padding',1,'Name','c1'); reluLayer
+                maxPooling2dLayer(2,'Stride',2,'Name','mp')
+                fullyConnectedLayer(8,'Name','f1'); reluLayer
+                fullyConnectedLayer(3,'Name','fc')];
+net  = matlab2nnv(dlnetwork(mklayers()));
+opts = struct('precision','double','maxNodes',150,'nSample',24,'cexEvery',10);
+
+%% Test 1: a tiny box that is robust -> 'robust' or 'unknown'; if robust, NO MC counterexample
+x = rand(6,6,1); y = net.evaluate(x); [~,tgt] = max(y(:));
+lb = max(x(:)-0.015,0); ub = min(x(:)+0.015,1);
+[v, inf] = gpu_bab_try_verify(net, lb, ub, tgt, opts);
+assert(ismember(string(v), ["robust","unknown"]), 'tiny robust box must not be unsafe/skip');
+assert(inf.guardErr < 1e-4, 'orientation guard must pass on a correctly-extracted net');
+if strcmp(v,'robust')
+    bad = false;
+    for s=1:4000, xs=lb+(ub-lb).*rand(36,1); ys=net.evaluate(reshape(xs,[6 6 1])); [~,p]=max(ys(:)); if p~=tgt, bad=true; break; end, end
+    assert(~bad, 'CARDINAL: returned robust but MC found a counterexample');
+end
+
+%% Test 2: a box that CONTAINS a counterexample -> must NOT be 'robust'
+x = rand(6,6,1); y = net.evaluate(x); [~,tgt] = max(y(:));
+xp = x; found = false;
+for k=1:400
+    cand = min(max(x + 0.7*randn(6,6,1),0),1);
+    yp = net.evaluate(cand); [~,p] = max(yp(:));
+    if p ~= tgt, xp = cand; found = true; break; end
+end
+assert(found, 'test setup: could not find a flipping point');
+lb = min(x(:),xp(:)); ub = max(x(:),xp(:));        % box spans x and the counterexample xp
+[v2, ~] = gpu_bab_try_verify(net, lb, ub, tgt, opts);
+assert(~strcmp(v2,'robust'), 'CARDINAL: certified robust on a box that contains a counterexample (-150)');
+
+%% Test 3: unsupported architecture (tanh activation) -> 'skip'
+ulayers = [featureInputLayer(4,'Name','in'); fullyConnectedLayer(5,'Name','f1'); ...
+           tanhLayer('Name','t'); fullyConnectedLayer(3,'Name','out')];
+unet = matlab2nnv(dlnetwork(ulayers));
+[v3, i3] = gpu_bab_try_verify(unet, -ones(4,1), ones(4,1), 1, opts);
+assert(strcmp(v3,'skip'), 'unsupported arch (tanh) must skip, got %s', v3);
+
+%% Test 4: any 'unsafe' verdict carries a witness that truly misclassifies under net.evaluate
+% (sweep a few boxes; only assert when 'unsafe' actually fires)
+nUnsafe = 0;
+for t = 1:6
+    xx = rand(6,6,1); yy = net.evaluate(xx); [~,tt] = max(yy(:));
+    e = 0.2*t;
+    lbi = max(xx(:)-e,0); ubi = min(xx(:)+e,1);
+    [vi, ii] = gpu_bab_try_verify(net, lbi, ubi, tt, opts);
+    if strcmp(vi,'unsafe')
+        nUnsafe = nUnsafe + 1;
+        yc = net.evaluate(reshape(ii.cex,[6 6 1])); [~,pc] = max(yc(:));
+        assert(pc ~= tt, 'unsafe witness must misclassify under net.evaluate');
+    end
+end
+fprintf('(%d unsafe verdicts, all witness-confirmed)\n', nUnsafe);
+
+%% Summary
+disp('test_soundness_gpu_bab_dispatch: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_maxpool.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_maxpool.m
@@ -1,0 +1,60 @@
+% test_soundness_gpu_bab_maxpool
+% Soundness tests for the GPU-BaB engine's MaxPooling2D support. MaxPool is the only
+% NONLINEAR op besides ReLU: monotone -> exact IBP; CROWN uses a sound per-window
+% relaxation (lower bound = the window's argmax-LOWER input; upper bound = that input if it
+% DECIDES the max, else the window's max-upper constant). Validated on a conv + ReLU +
+% non-overlapping maxpool + conv + ReLU + OVERLAPPING maxpool + FC net.
+% Each %% section runs independently under runtests; net is kept small for speed.
+
+rng(3);
+layers = [imageInputLayer([8 8 2],'Normalization','none','Name','in')
+          convolution2dLayer(3,4,'Padding',1,'Name','c1'); reluLayer('Name','r1')
+          maxPooling2dLayer(2,'Stride',2,'Name','mp1')             % 8 -> 4 (non-overlap)
+          convolution2dLayer(3,3,'Padding',1,'Name','c2'); reluLayer('Name','r2')
+          maxPooling2dLayer(3,'Stride',1,'Name','mp2')             % 4 -> 2 (OVERLAPPING)
+          fullyConnectedLayer(5,'Name','fc')];
+nnvnet = matlab2nnv(dlnetwork(layers));
+ops    = nn_to_ops(nnvnet);
+Cspec  = [eye(4) -ones(4,1)];
+xc     = rand(8,8,2);
+lb     = xc(:) - 0.04;  ub = xc(:) + 0.04;
+Xs     = lb + (ub - lb) .* rand(128, 2000);
+tmp = inf(4,1);
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [8 8 2]));
+    tmp = min(tmp, Cspec * ys(:));
+end
+trueMin = tmp;
+
+%% Test 1: maxpool ops extracted; degenerate IBP == NNV evaluate
+xt = rand(8,8,2); yn = nnvnet.evaluate(xt); yn = yn(:);
+yo = gpu_bab_ibp(ops, xt(:), xt(:), 'double');
+assert(max(abs(yo(:) - yn)) < 1e-4, 'degenerate maxpool IBP must match NNV evaluate');
+
+%% Test 2: both maxpool ops present (incl. the overlapping one)
+types = cellfun(@(o) string(o.type), ops);
+assert(sum(types == "maxpool") == 2, 'expected 2 maxpool ops (one overlapping stride<pool)');
+
+%% Test 3: IBP box is sound (contains every sampled output)
+[olb, oub] = gpu_bab_ibp(ops, lb, ub, 'double');
+ok = true;
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s), [8 8 2])); ys = ys(:);
+    if any(ys < olb - 1e-6) || any(ys > oub + 1e-6), ok = false; break; end
+end
+assert(ok, 'maxpool IBP box must contain all sampled outputs');
+
+%% Test 4: degenerate CROWN is exact (every window decided at a point)
+xt = rand(8,8,2); md = gpu_bab_crown_tight(ops, xt(:), xt(:), Cspec, 'double');
+yn = nnvnet.evaluate(xt);
+assert(max(abs(md - Cspec * yn(:))) < 1e-4, 'degenerate maxpool CROWN must equal C*evaluate');
+
+%% Test 5: CROWN-tight is sound and no looser than IBP
+mt = gpu_bab_crown_tight(ops, lb, ub, Cspec, 'double');
+assert(all(mt <= trueMin + 1e-4), 'maxpool CROWN-tight margin must be sound (<= true min)');
+[ilb, iub] = gpu_bab_ibp(ops, lb, ub, 'double');
+Cp = max(Cspec, 0); Cn = min(Cspec, 0);
+assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'maxpool CROWN-tight must be no looser than IBP');
+
+%% Summary
+disp('test_soundness_gpu_bab_maxpool: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_residual.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_residual.m
@@ -1,0 +1,63 @@
+% test_soundness_gpu_bab_residual
+% Residual/DAG (AdditionLayer skip-add) soundness for the GPU-BaB engine. The add is LINEAR
+% (out = out[a]+out[b]) -> exact IBP (interval sum) + exact CROWN (the coefficient flows
+% UNCHANGED to both inputs via the skipA accumulation). The only risk is the DAG plumbing,
+% which the degenerate-CROWN==C*evaluate check pins down. Net: stem -> [conv-relu-conv + skip]
+% -> relu -> global-avg-pool -> fc, with the skip from an INTERNAL op (typical resnet block).
+% Each %% section runs independently; net kept small.
+
+rng(2);
+lg = layerGraph([
+  imageInputLayer([8 8 3],'Normalization','none','Name','in')
+  convolution2dLayer(3,5,'Padding',1,'Name','c0'); reluLayer('Name','r0')
+  convolution2dLayer(3,5,'Padding',1,'Name','c1'); reluLayer('Name','r1')
+  convolution2dLayer(3,5,'Padding',1,'Name','c2')
+  additionLayer(2,'Name','add'); reluLayer('Name','r2')
+  globalAveragePooling2dLayer('Name','gap')
+  fullyConnectedLayer(4,'Name','fc')]);
+lg = connectLayers(lg, 'r0', 'add/in2');             % skip from r0 (internal op, not input)
+nnvnet = matlab2nnv(dlnetwork(lg));
+ops    = nn_to_ops(nnvnet);
+Cspec  = [eye(3) -ones(3,1)];
+xc     = rand(8,8,3); lb = xc(:)-0.03; ub = xc(:)+0.03;
+Xs     = lb + (ub-lb).*rand(192, 2000);
+tmp = inf(3,1);
+for s = 1:size(Xs,2), ys = nnvnet.evaluate(reshape(Xs(:,s),[8 8 3])); tmp = min(tmp, Cspec*ys(:)); end
+trueMin = tmp;
+
+%% Test 1: add op extracted (internal skip); degenerate IBP == NNV evaluate
+types = cellfun(@(o) string(o.type), ops);
+assert(sum(types=="add")==1, 'expected one add op');
+xt = rand(8,8,3); yn = nnvnet.evaluate(xt); yn = yn(:);
+yo = gpu_bab_ibp(ops, xt(:), xt(:), 'double');
+assert(max(abs(yo(:)-yn)) < 1e-4, 'degenerate residual IBP must match NNV evaluate');
+
+%% Test 2: IBP box is sound (contains all MC outputs)
+[olb,oub] = gpu_bab_ibp(ops, lb, ub, 'double'); ok = true;
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s),[8 8 3])); ys = ys(:);
+    if any(ys < olb-1e-6) || any(ys > oub+1e-6), ok = false; break; end
+end
+assert(ok, 'residual IBP box must contain all MC outputs');
+
+%% Test 3: degenerate CROWN is exact (the DAG skipA backward)
+xt = rand(8,8,3); md = gpu_bab_crown_tight(ops, xt(:), xt(:), Cspec, 'double'); yn = nnvnet.evaluate(xt);
+assert(max(abs(md - Cspec*yn(:))) < 1e-4, 'degenerate residual CROWN must equal C*evaluate (skipA exact)');
+
+%% Test 4: CROWN-tight is sound and no looser than IBP
+mt = gpu_bab_crown_tight(ops, lb, ub, Cspec, 'double');
+assert(all(mt <= trueMin + 1e-4), 'residual CROWN-tight must be sound (<= true min)');
+[ilb,iub] = gpu_bab_ibp(ops, lb, ub, 'double'); Cp = max(Cspec,0); Cn = min(Cspec,0);
+assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'residual CROWN-tight must be no looser than IBP');
+
+%% Test 5: N>2 addition is refused (sound-by-refusal)
+lg3 = layerGraph([imageInputLayer([4 4 2],'Normalization','none','Name','in')
+  convolution2dLayer(3,2,'Padding',1,'Name','c1')
+  additionLayer(3,'Name','add3'); fullyConnectedLayer(2,'Name','fc')]);
+lg3 = connectLayers(lg3,'in','add3/in2'); lg3 = connectLayers(lg3,'in','add3/in3');
+net3 = matlab2nnv(dlnetwork(lg3));
+err = false; try, nn_to_ops(net3); catch, err = true; end
+assert(err, 'N=3 addition must be refused for soundness');
+
+%% Summary
+disp('test_soundness_gpu_bab_residual: all sections passed');


### PR DESCRIPTION
## What

Extends the LP-free GPU-BaB engine (#356, joint-α in #358) from **FullyConnected + ReLU** to **feedforward CONV nets**: `Conv2D` and the `ImageInputLayer` normalization (folded as a leading per-element affine). This is the foundation for the conv benchmarks (cifar, resnet-style feedforward CNNs).

BatchNorm / Pool / Addition(residual) still **ERROR** (sound-by-refusal → the dispatcher falls back to the Star path), so coverage stays explicit and never silently wrong. Those are the next increments.

## How (and why it's sound)

| op | IBP | CROWN backward |
|----|-----|----------------|
| `conv` | `W+/W-` interval split via `dlconv` (same as affine, tightest interval for a linear map) | **exact** adjoint via `dltranspconv` — zero relaxation (an equality, not an inequality) |
| `normaffine` (input norm) | per-element `s.*x+t` interval map | diagonal-affine backward |

The subtle part is the **strided** conv adjoint: a symmetric `Cropping` mis-sizes it because the forward `floor` drops the unused bottom pad. The fix reconstructs the adjoint on the *padded* input (`Cropping=0`) then crops to the original-input region `[pad_t+1 : pad_t+Hin]`; tail rows the floor never reached carry zero coefficient. This makes the backward the **exact** transpose of "pad-then-conv" for any stride/pad/dilation.

`nn_to_ops` threads the running `[H W C]` shape and **asserts** `prod(shape) == FC-input-width` at the conv→flatten boundary, so a wrong (non-column-major) flatten is caught rather than producing wrong bounds.

## Soundness validation

`tests/soundness/test_soundness_gpu_bab_conv.m` (5/5), on a net with **padding + stride + normalization**:

- degenerate-box IBP `==` `net.evaluate` to **1e-7** (the input-ordering / column-major guard — validates the conv↔matrix reshape)
- IBP box contains **3000** Monte-Carlo outputs
- degenerate CROWN `==` `C*evaluate` to **8e-8** (the adjoint is exact at a point)
- CROWN-tight margin is **sound** (`<=` true min) **and** no looser than IBP

## Scope

Additive engine code (like #356/#358) — no existing path changes. Dispatcher wiring (choosing GPU-BaB for a conv net) is deliberately **not** included here; it stays gated behind the existing soundness guard and a supervised review, so this PR is bound-engine-only.