### PR TITLE
gpu-bab: full-DAG nn_to_ops + opt-in GPU device option (projection-shortcut resnets)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -31,13 +31,14 @@ function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, 
     for k = 1:nOps
         tk = ops{k}.type;
         if strcmp(tk, 'relu') || strcmp(tk, 'maxpool')
-            % z_k (the input feeding this op) = output of ops[1..k-1]. Bound each of its
-            % elements via a backward CROWN pass over ops[1..k-1], which reuses preL/preU of
-            % the strictly-earlier ReLUs/maxpools (already computed -- sound by induction).
-            nk = i_layer_width(ops, k-1);
+            % z_k (the input feeding this op) = output of op `src` = ops{k}.src (the DAG input,
+            % not assumed k-1). Bound each of its elements via a backward DAG-CROWN pass over
+            % ops[1..src], reusing preL/preU of strictly-earlier ReLUs/maxpools (sound by induction).
+            src = ops{k}.src;
+            if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
             Ck = eye(nk, precision);
-            pu = i_backward(ops, k-1, Ck, x_lb, x_ub, preL, preU, precision, false);
-            pl = i_backward(ops, k-1, Ck, x_lb, x_ub, preL, preU, precision, true);
+            pu = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false);
+            pl = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true);
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
                 pl(fx == 1)  = max(pl(fx == 1),  0);
@@ -70,32 +71,39 @@ function w = i_layer_width(ops, upto)
 end
 
 function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
-% Backward CROWN over ops[1..upto] with initial coefficient A0, using preL/preU for the
-% ReLU relaxations. lower=true -> lower bound (min); false -> upper bound (max).
-    A = A0;
+% Backward CROWN over the DAG ops[1..upto] with initial coefficient A0 (on op `upto`'s output).
+% FULL DAG: each op routes its backward coefficient to op.src (its input op), accumulated in
+% skipA{src}; an 'add' routes UNCHANGED to BOTH inputs (linear -> exact). skipA{k} = accumulated
+% coefficient on op k's OUTPUT; inputSkipA = coefficient on op 0 (the engine input). Ops are
+% topologically ordered, so k=upto:-1:1 visits every consumer of op k before op k itself, so
+% skipA{k} is complete when op k is processed (sound by induction). lower=true -> lower bound.
     nS = size(A0, 1);
     d = zeros(nS, 1, precision);
-    % DAG support: an 'add' op (out = out[a]+out[b]) sends its coefficient UNCHANGED to BOTH
-    % inputs (linear -> exact). skipA{k} accumulates the coefficient arriving at op k's OUTPUT
-    % from later adds; inputSkipA accumulates skips that target op 0 (the engine input).
-    hasAdd = any(cellfun(@(o) strcmp(o.type, 'add'), ops(1:upto)));
-    skipA = cell(upto, 1); inputSkipA = 0;
+    if upto == 0                              % A0 is already on the engine input (op 0)
+        Apos = max(A0, 0); Aneg = min(A0, 0);
+        if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
+        else,     bound = Apos*cast(x_ub,precision) + Aneg*cast(x_lb,precision); end
+        return;
+    end
+    skipA = cell(upto, 1);
+    skipA{upto} = A0;                         % seed: A0 is the coefficient on op `upto`'s output
+    inputSkipA = 0;
     for k = upto:-1:1
+        A = skipA{k};
+        if isempty(A), continue; end          % nothing routed to op k (dead w.r.t. the output)
         op = ops{k};
-        if hasAdd && ~isempty(skipA{k}), A = A + skipA{k}; end
-        if strcmp(op.type, 'add')
+        if strcmp(op.type, 'add')             % out = out[a]+out[b]: route UNCHANGED to both
             for ii = 1:numel(op.inputs)
-                src = op.inputs(ii);
-                if src == 0
-                    inputSkipA = inputSkipA + A;
-                elseif isempty(skipA{src})
-                    skipA{src} = A;
-                else
-                    skipA{src} = skipA{src} + A;
+                s = op.inputs(ii);
+                if s == 0,                inputSkipA = inputSkipA + A;
+                elseif isempty(skipA{s}), skipA{s} = A;
+                else,                     skipA{s} = skipA{s} + A;
                 end
             end
-            A = zeros(nS, size(A, 2), precision);   % fully distributed to its inputs
-        elseif strcmp(op.type, 'affine')
+            continue;
+        end
+        % single-input op: A (on op's OUTPUT) -> A (on op's INPUT)
+        if strcmp(op.type, 'affine')
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             d = d + A * b;
             A = A * W;
@@ -107,20 +115,25 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
             [A, d] = i_avgpool_backward(A, d, op, precision);
         elseif strcmp(op.type, 'maxpool')
             [A, d] = i_maxpool_backward(A, d, op, preL{k}, preU{k}, precision, lower);
-        else
+        else                                  % relu relaxation (sign-aware), preL/preU{k}
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
             Apos = max(A, 0); Aneg = min(A, 0);
             if lower
-                d = d + Aneg * bu;                 % min: +coeff->lower line(al), -coeff->upper line(au,bu)
+                d = d + Aneg * bu;
                 A = Apos .* al.' + Aneg .* au.';
             else
-                d = d + Apos * bu;                 % max: +coeff->upper line(au,bu), -coeff->lower line(al)
+                d = d + Apos * bu;
                 A = Apos .* au.' + Aneg .* al.';
             end
         end
+        s = op.src;                           % route the input coefficient to op.src
+        if s == 0,                inputSkipA = inputSkipA + A;
+        elseif isempty(skipA{s}), skipA{s} = A;
+        else,                     skipA{s} = skipA{s} + A;
+        end
     end
-    if hasAdd, A = A + inputSkipA; end   % coeff on the input = chain + skips-to-input
+    A = inputSkipA;                           % total coefficient on the engine input
     Apos = max(A, 0); Aneg = min(A, 0);
     if lower
         bound = Apos * cast(x_lb, precision) + Aneg * cast(x_ub, precision) + d;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -42,9 +42,9 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
     lb = cast(in_lb, precision);
     ub = cast(in_ub, precision);
     nOps = numel(ops);
-    hasAdd = any(cellfun(@(o) strcmp(o.type, 'add'), ops));
+    isDag = i_is_dag(ops);
 
-    if ~hasAdd
+    if ~isDag
         % sequential (chain) net -- rolling bounds, no per-op cache.
         for k = 1:nOps
             [lb, ub] = i_apply_ibp(ops{k}, lb, ub, precision);
@@ -53,8 +53,9 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
         return;
     end
 
-    % DAG net (residual): cache each op's output bounds (index k+1 = op k; index 1 = op 0 =
-    % input), so an 'add' can sum two non-adjacent ops. Interval add is EXACT (sound + tight).
+    % DAG net (residual / projection shortcut): cache each op's output bounds (index k+1 = op k;
+    % index 1 = op 0 = input). Each op consumes the output of its op.src (not the previous op),
+    % so conv-on-skip branches bound correctly; 'add' sums its two inputs. Interval ops EXACT.
     cl = cell(nOps + 1, 1); cu = cell(nOps + 1, 1);
     cl{1} = lb; cu{1} = ub;
     for k = 1:nOps
@@ -64,7 +65,8 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
             cl{k+1} = cl{a} + cl{b};
             cu{k+1} = cu{a} + cu{b};
         else
-            [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{k}, cu{k}, precision);
+            s = op.src + 1;
+            [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{s}, cu{s}, precision);
         end
     end
     out_lb = cl{nOps + 1};
@@ -92,6 +94,17 @@ function [nlb, nub] = i_apply_ibp(op, lb, ub, precision)
         otherwise
             error('gpu_bab_ibp:unsupportedOp', ...
                 'Unsupported op type "%s" (affine/relu/conv/normaffine/avgpool/maxpool/add).', op.type);
+    end
+end
+
+function tf = i_is_dag(ops)
+% Needs the cached DAG path if any op is an 'add' OR consumes a NON-previous op (src != k-1):
+% a residual / projection-shortcut branch. Pure chains (every src == k-1) use the rolling path.
+    tf = false;
+    for k = 1:numel(ops)
+        o = ops{k};
+        if strcmp(o.type, 'add'), tf = true; return; end
+        if isfield(o, 'src') && o.src ~= k-1, tf = true; return; end
     end
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
@@ -196,7 +196,7 @@ function [cex, lab] = i_find_cex(ops, LB, UB, trueLabel, nSample, precision)
     cex = []; lab = [];
     X = (LB + UB) / 2;
     for s = 1:max(0, nSample)
-        X = [X, LB + (UB - LB) .* rand(size(LB), precision)]; %#ok<AGROW>
+        X = [X, LB + (UB - LB) .* rand(size(LB), 'like', LB)]; %#ok<AGROW>  % 'like' LB keeps cex samples on-device for the GPU path (no host->GPU transfer); IBP casts to precision
     end
     Y = gpu_bab_ibp(ops, X, X, precision);
     [~, pred] = max(Y, [], 1);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split.m
@@ -93,6 +93,8 @@ function [status, info] = gpu_bab_relu_split(ops, x_lb, x_ub, trueLabel, nClasse
         if isempty(kop)
             status = 'unknown'; return;                 % no unstable left, still not certified
         end
+        j = gather(j);   % split-neuron index -> host (the fixing vectors are host -1/0/+1); the
+                         % large bounds stayed on device -- only this scalar index crosses back
         fa = node.fix; if isempty(fa{kop}), fa{kop} = zeros(i_dim(unstable,kop),1); end; fa{kop}(j) = 1;
         fi = node.fix; if isempty(fi{kop}), fi{kop} = zeros(i_dim(unstable,kop),1); end; fi{kop}(j) = -1;
         stack{end+1} = struct('fix', {fa}, 'depth', node.depth+1); %#ok<AGROW>

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -107,6 +107,25 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     % (false robust); clamp to >= 0 (sound-or-unknown).
     if isfield(bopts, 'margin') && bopts.margin < 0, bopts.margin = 0; end
     if ~isfield(bopts, 'maxNodes'),  bopts.maxNodes  = 300;      end
+    % DEVICE (opts.device 'cpu' default | 'gpu'): run the whole BaB on the GPU by moving the ops'
+    % weight tensors + the input box to gpuArray ONCE here. The IBP/CROWN passes are gpuArray-
+    % overloaded pure linear algebra, so all heavy compute + the per-node intermediate bounds stay
+    % RESIDENT on device; only tiny scalars (the certified test, the split-neuron index, a witness)
+    % cross back -- no per-iteration bound transfers. GPU implies single precision (T4 FP64 is
+    % ~1/16 rate), so it requires the explicit allowUnsoundSingle opt-in (FP32 is dev/empirical,
+    % not certified-sound without outward rounding -- R1). CPU path is unchanged (the default).
+    if isfield(opts, 'device') && strcmp(opts.device, 'gpu')
+        if gpuDeviceCount < 1
+            verdict = 'skip'; info.reason = 'device=gpu requested but no GPU available'; return;
+        end
+        if ~(isfield(opts, 'allowUnsoundSingle') && isequal(opts.allowUnsoundSingle, true))
+            verdict = 'skip'; info.reason = 'device=gpu needs allowUnsoundSingle (FP32 not certified-sound)'; return;
+        end
+        bopts.precision = 'single';
+        ops = i_ops_to_gpu(ops);
+        lb = gpuArray(single(lb)); ub = gpuArray(single(ub));
+        info.device = 'gpu';
+    end
     [status, binfo] = gpu_bab_relu_split(ops, lb, ub, target, nClasses, bopts);
     info.nodes = binfo.nodes;
 
@@ -140,4 +159,20 @@ end
 
 function v = i_optget(s, f, d)
     if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end
+
+function ops = i_ops_to_gpu(ops)
+% Move each op's numeric DATA tensors (weights/bias/scale/shift) to gpuArray(single) so the
+% bound passes run on device. Leaves dlconv hyperparameters (pool/stride/pad/dil) and metadata
+% (type/src/inputs/shapes) on the host -- they are scalars/small index vectors dlconv expects on
+% the host, and moving them would not help. Done ONCE per query (not per BaB node).
+    for k = 1:numel(ops)
+        o = ops{k};
+        for f = {'W', 'b', 'scale', 'shift'}
+            if isfield(o, f{1}) && isnumeric(o.(f{1}))
+                o.(f{1}) = gpuArray(single(o.(f{1})));
+            end
+        end
+        ops{k} = o;
+    end
 end

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -58,6 +58,16 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
                 inOps(q) = layerOp(srcs{q});
             end
         end
+        % SOUNDNESS (Copilot #364): AdditionLayer is the ONLY supported multi-input op. Any other
+        % layer that resolves to >1 Connections source would be silently mis-extracted below (only
+        % inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors -> caller runs Star),
+        % never emit a wrong graph. This can only turn a previously-silent mis-extraction into a
+        % sound refusal; supported single-input layers always resolve to exactly one source.
+        if numel(inOps) > 1 && ~contains(cls, 'Addition')
+            error('nn_to_ops:multiInputUnsupported', ...
+                'layer "%s" (%s) has %d inputs but only AdditionLayer is multi-input-supported -- refused for soundness.', ...
+                name, cls, numel(inOps));
+        end
         inOp = inOps(1);
         inShape = shapeOf(inOp);
         emitted = true; outShape = inShape;           % outShape default = inShape (relu/bn/add)

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -29,102 +29,99 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
 %   asserting gpu_bab_ibp(ops,center,center) ~= net.evaluate(center) (the input-order
 %   soundness guard) before trusting any verdict.
     ops = {};
-    curShape = [];   % [H W C] once an image/conv path is entered; [] for a flat FC net
-    % DAG support (residual Addition): NNV keeps Layers topologically ordered + a Connections
-    % table. layerOp maps a layer NAME -> the op index whose output equals that layer's output
-    % (0 = the engine input). An AdditionLayer reads its source op indices from here.
+    % FULL-DAG extraction: resolve EACH layer's input op(s) from the Connections table (not the
+    % assumed previous op), so projection-shortcut resnets (conv/BN ON a skip branch) extract
+    % correctly. layerOp: layer NAME -> output op index (0 = engine input). shapeOf: op index ->
+    % [H W C] output shape ([] = flat). Every emitted op carries src = its input op index
+    % ('add' carries inputs=[a b]); the IBP/CROWN route through src. Sequential nets (empty
+    % Connections) fall back to the chain (src = previous op) -> unchanged behavior.
     conns = [];
     if isprop(nnvnet, 'Connections'), conns = nnvnet.Connections; end
     layerOp = containers.Map('KeyType', 'char', 'ValueType', 'double');
+    shapeOf = containers.Map('KeyType', 'double', 'ValueType', 'any');
+    shapeOf(0) = [];                                  % engine input shape (set by input layer)
     for i = 1:numel(nnvnet.Layers)
         L = nnvnet.Layers{i};
         cls = class(L);
+        name = ''; if isprop(L, 'Name'), name = char(L.Name); end
+        % --- resolve this layer's input op(s): from Connections, else previous op (chain) ---
+        srcs = i_layer_sources(conns, name);
+        if isempty(srcs)
+            inOps = numel(ops);                       % chain default (0 if no op emitted yet)
+        else
+            inOps = zeros(1, numel(srcs));
+            for q = 1:numel(srcs)
+                if ~isKey(layerOp, srcs{q})
+                    error('nn_to_ops:srcNotEmitted', ...
+                        'layer "%s" input "%s" not yet emitted (non-topological DAG?).', name, srcs{q});
+                end
+                inOps(q) = layerOp(srcs{q});
+            end
+        end
+        inOp = inOps(1);
+        inShape = shapeOf(inOp);
+        emitted = true; outShape = inShape;           % outShape default = inShape (relu/bn/add)
         if contains(cls, 'FullyConnected')
             W = L.Weights;
-            if ~isempty(curShape)
-                % conv -> flatten -> FC boundary: the FC consumes the flattened conv
-                % output; its input width must equal prod(curShape) or the flatten
-                % order is inconsistent (caught here rather than producing wrong bounds).
-                if size(W,2) ~= prod(curShape)
+            if ~isempty(inShape)                      % conv -> FC flatten boundary
+                if size(W,2) ~= prod(inShape)
                     error('nn_to_ops:flattenMismatch', ...
-                        ['FC input width %d ~= prod(curShape) %d ([%s]); flatten order ' ...
+                        ['FC input width %d ~= prod(inShape) %d ([%s]); flatten order ' ...
                          'inconsistent -- cannot map conv output to this FC soundly.'], ...
-                        size(W,2), prod(curShape), num2str(curShape));
+                        size(W,2), prod(inShape), num2str(inShape));
                 end
-                % reorder the FC weight columns from the net's flatten order to the engine's
-                % column-major [H W C] view (identity for 'colmajor'); validated by the guard.
-                W = i_flatten_permute(W, curShape, flattenOrder);
-                curShape = [];   % flattened; back to flat-vector world
+                W = i_flatten_permute(W, inShape, flattenOrder);
             end
-            ops{end+1} = struct('type','affine','W',W,'b',L.Bias); %#ok<AGROW>
+            ops{end+1} = struct('type','affine','W',W,'b',L.Bias,'src',inOp); outShape = []; %#ok<AGROW>
         elseif contains(cls, 'Relu') || contains(cls, 'ReLU')
-            ops{end+1} = struct('type','relu'); %#ok<AGROW>
+            ops{end+1} = struct('type','relu','src',inOp); %#ok<AGROW>
         elseif contains(cls, 'ImageInput') || contains(cls, 'Image3DInput')
-            % seed the spatial shape from InputSize ([H W C]) and, if the layer
-            % normalizes, fold the normalization as the FIRST op (the -150 input-mismatch
-            % fix: the box must be bounded in the SAME normalized space reach feeds conv).
-            curShape = double(L.InputSize(:)');
+            ishape = double(L.InputSize(:)');
             [s, t, hasNorm] = i_input_norm(L);
             if hasNorm
-                ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',curShape); %#ok<AGROW>
+                ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',ishape,'src',0); %#ok<AGROW>
+                outShape = ishape;
+            else
+                emitted = false; shapeOf(0) = ishape;  % the engine input itself
             end
         elseif contains(cls, 'Flatten')
-            % identity on values; the conv->FC boundary assert (above) enforces the order.
+            emitted = false;                           % identity on values (order at FC permute)
         elseif contains(cls, 'Conv2D') || (contains(cls,'Conv') && ~contains(cls,'Transposed'))
-            if isempty(curShape)
-                error('nn_to_ops:noInputShape', ...
-                    'Conv layer %d reached without a known input [H W C] shape (need an ImageInputLayer).', i);
+            if isempty(inShape)
+                error('nn_to_ops:noInputShape', 'Conv layer %d without a known [H W C] input shape.', i);
             end
-            op = i_conv_op(L, curShape);
-            curShape = op.outShape;
-            ops{end+1} = op; %#ok<AGROW>
+            op = i_conv_op(L, inShape); op.src = inOp;
+            ops{end+1} = op; outShape = op.outShape; %#ok<AGROW>
         elseif contains(cls, 'BatchNorm')
-            % BatchNorm at inference is a per-CHANNEL affine y = s_c.*x + t_c (LINEAR ->
-            % exact, no relaxation): fold as a per-channel normaffine ([1 1 C] broadcast
-            % over [H W C], handled by the existing normaffine IBP/CROWN). Conv-path only;
-            % a post-flatten BN (curShape==[]) is refused (rare; sound-by-refusal).
-            if isempty(curShape)
-                error('nn_to_ops:bnFlat', ...
-                    'BatchNorm on a flat (post-flatten) vector not yet supported -- refused for soundness.');
+            if isempty(inShape)
+                error('nn_to_ops:bnFlat', 'BatchNorm on a flat (post-flatten) vector -- refused for soundness.');
             end
-            [s, t] = i_bn_fold(L, curShape);
-            ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',curShape); %#ok<AGROW>
+            [s, t] = i_bn_fold(L, inShape);
+            ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',inShape,'src',inOp); %#ok<AGROW>
         elseif contains(cls, 'AvgPool') || contains(cls, 'AveragePool') || contains(cls, 'GlobalAveragePool')
-            if isempty(curShape)
-                error('nn_to_ops:poolFlat', ...
-                    'Pooling on a flat vector has no spatial shape -- refused for soundness.');
+            if isempty(inShape)
+                error('nn_to_ops:poolFlat', 'Pooling on a flat vector -- refused for soundness.');
             end
-            op = i_avgpool_op(L, curShape, cls);
-            curShape = op.outShape;
-            ops{end+1} = op; %#ok<AGROW>
+            op = i_avgpool_op(L, inShape, cls); op.src = inOp;
+            ops{end+1} = op; outShape = op.outShape; %#ok<AGROW>
         elseif contains(cls, 'MaxPool') || contains(cls, 'MaxPooling')
-            if isempty(curShape)
-                error('nn_to_ops:poolFlat', ...
-                    'Pooling on a flat vector has no spatial shape -- refused for soundness.');
+            if isempty(inShape)
+                error('nn_to_ops:poolFlat', 'Pooling on a flat vector -- refused for soundness.');
             end
-            op = i_maxpool_op(L, curShape);
-            curShape = op.outShape;
-            ops{end+1} = op; %#ok<AGROW>
+            op = i_maxpool_op(L, inShape); op.src = inOp;
+            ops{end+1} = op; outShape = op.outShape; %#ok<AGROW>
         elseif contains(cls, 'Addition')
-            % residual skip-add: y = out[a] + out[b] (LINEAR -> exact). Read the two source
-            % layers from Connections; map to op indices via layerOp (0 = engine input). Only
-            % 2 inputs supported (audit guard); N>2 refused for soundness.
-            srcs = i_layer_sources(conns, char(L.Name));
-            if numel(srcs) ~= 2
+            % residual skip-add: y = out[a]+out[b] (LINEAR -> exact). The DAG resolution above
+            % already mapped both inputs (incl. conv-on-skip branches). 2 inputs only.
+            if numel(inOps) ~= 2
                 error('nn_to_ops:addNInputs', ...
-                    'Addition with %d inputs not supported (only 2) -- refused for soundness.', numel(srcs));
+                    'Addition with %d inputs not supported (only 2) -- refused for soundness.', numel(inOps));
             end
-            if ~isKey(layerOp, srcs{1}) || ~isKey(layerOp, srcs{2})
-                error('nn_to_ops:addSrc', 'Addition source layer not yet emitted -- unsupported DAG topology.');
-            end
-            a = layerOp(srcs{1}); b = layerOp(srcs{2});
-            ops{end+1} = struct('type','add','inputs',[a b],'shape',curShape); %#ok<AGROW>
-            % element-wise add preserves curShape (both inputs must share it; guard validates)
+            ops{end+1} = struct('type','add','inputs',inOps,'shape',inShape,'src',inOps(1)); %#ok<AGROW>
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
-            % trailing output tail -- skippable for argmax-robustness ONLY if nothing
-            % computational follows.
+            emitted = false;                           % trailing output tail (skippable if nothing follows)
             for jj = i+1:numel(nnvnet.Layers)
                 c2 = class(nnvnet.Layers{jj});
                 if contains(c2,'FullyConnected') || contains(c2,'Relu') || contains(c2,'ReLU') ...
@@ -139,10 +136,12 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
                 ['GPU-BaB supports ImageInput(norm)+Conv2D+FullyConnected+ReLU+Flatten+BatchNorm' ...
                  '+Avg/Max-pool+Addition(2-input); got "%s" (layer %d) -- refused for soundness.'], cls, i);
         end
-        % record this layer's output op index (0 if it emitted no op = input/identity), so a
-        % later AdditionLayer can resolve its skip source. Names are unique within a net.
-        if isprop(L, 'Name') && ~isempty(char(L.Name))
-            layerOp(char(L.Name)) = numel(ops);
+        % record this layer's output op + shape (identity/no-op layers pass through to inOp)
+        if emitted
+            shapeOf(numel(ops)) = outShape;
+            if ~isempty(name), layerOp(name) = numel(ops); end
+        else
+            if ~isempty(name), layerOp(name) = inOp; end
         end
     end
 end

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_projshortcut.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_projshortcut.m
@@ -1,0 +1,65 @@
+% test_soundness_gpu_bab_projshortcut
+% Projection-shortcut (conv-on-skip) DAG soundness for the GPU-BaB FULL-DAG engine. Unlike a
+% direct identity skip (test_soundness_gpu_bab_residual), the skip branch here carries a 1x1
+% conv whose input is the BLOCK INPUT (the stem r0), several ops BEFORE the add -- NOT the
+% immediately-preceding op. master's chain extractor would feed that conv the wrong tensor
+% (the previous op's output); the full-DAG per-op `src` routing resolves it from Connections.
+% The degenerate-CROWN == C*evaluate check pins the DAG backward routing exactly. This is the
+% synthetic analogue of the VNN-COMP cifar100 CIFAR100_resnet_medium block.
+% Each %% section runs independently; net kept small.
+
+rng(3);
+lg = layerGraph([
+  imageInputLayer([8 8 3],'Normalization','none','Name','in')
+  convolution2dLayer(3,5,'Padding',1,'Name','c0'); reluLayer('Name','r0')
+  convolution2dLayer(3,5,'Padding',1,'Name','c1'); reluLayer('Name','r1')
+  convolution2dLayer(3,5,'Padding',1,'Name','c2')
+  convolution2dLayer(1,5,'Name','cskip')               % skip-branch projection (1x1 conv)
+  additionLayer(2,'Name','add'); reluLayer('Name','r2')
+  globalAveragePooling2dLayer('Name','gap')
+  fullyConnectedLayer(4,'Name','fc')]);
+% Rewire so cskip is a true projection shortcut: its input is the STEM r0 (the block input),
+% NOT c2 (the op placed before it in the array); the main branch c2 feeds add/in1.
+lg = disconnectLayers(lg, 'c2', 'cskip');
+lg = disconnectLayers(lg, 'cskip', 'add/in1');
+lg = connectLayers(lg, 'r0', 'cskip');         % skip from the block input (src != previous op)
+lg = connectLayers(lg, 'c2', 'add/in1');       % main branch -> add first input
+lg = connectLayers(lg, 'cskip', 'add/in2');    % skip branch -> add second input
+nnvnet = matlab2nnv(dlnetwork(lg));
+ops    = nn_to_ops(nnvnet);
+Cspec  = [eye(3) -ones(3,1)];
+xc     = rand(8,8,3); lb = xc(:)-0.03; ub = xc(:)+0.03;
+Xs     = lb + (ub-lb).*rand(192, 2000);
+tmp = inf(3,1);
+for s = 1:size(Xs,2), ys = nnvnet.evaluate(reshape(Xs(:,s),[8 8 3])); tmp = min(tmp, Cspec*ys(:)); end
+trueMin = tmp;
+
+%% Test 1: a conv-on-skip op routes to a NON-previous src; degenerate IBP == NNV evaluate
+types = cellfun(@(o) string(o.type), ops);
+assert(sum(types=="add")==1, 'expected one add op');
+assert(any(arrayfun(@(k) isfield(ops{k},'src') && ops{k}.src ~= k-1, 1:numel(ops))), ...
+    'expected at least one op whose src ~= k-1 (the conv-on-skip projection branch)');
+xt = rand(8,8,3); yn = nnvnet.evaluate(xt); yn = yn(:);
+yo = gpu_bab_ibp(ops, xt(:), xt(:), 'double');
+assert(max(abs(yo(:)-yn)) < 1e-4, 'degenerate projection-shortcut IBP must match NNV evaluate');
+
+%% Test 2: IBP box is sound (contains every sampled output)
+[olb,oub] = gpu_bab_ibp(ops, lb, ub, 'double'); ok = true;
+for s = 1:size(Xs,2)
+    ys = nnvnet.evaluate(reshape(Xs(:,s),[8 8 3])); ys = ys(:);
+    if any(ys < olb-1e-6) || any(ys > oub+1e-6), ok = false; break; end
+end
+assert(ok, 'projection-shortcut IBP box must contain all MC outputs');
+
+%% Test 3: degenerate CROWN is exact (the DAG skipA backward through the conv-on-skip)
+xt = rand(8,8,3); md = gpu_bab_crown_tight(ops, xt(:), xt(:), Cspec, 'double'); yn = nnvnet.evaluate(xt);
+assert(max(abs(md - Cspec*yn(:))) < 1e-4, 'degenerate projection-shortcut CROWN must equal C*evaluate (DAG skipA exact)');
+
+%% Test 4: CROWN-tight is sound and no looser than IBP
+mt = gpu_bab_crown_tight(ops, lb, ub, Cspec, 'double');
+assert(all(mt <= trueMin + 1e-4), 'projection-shortcut CROWN-tight must be sound (<= true min)');
+[ilb,iub] = gpu_bab_ibp(ops, lb, ub, 'double'); Cp = max(Cspec,0); Cn = min(Cspec,0);
+assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'projection-shortcut CROWN-tight must be no looser than IBP');
+
+%% Summary
+disp('test_soundness_gpu_bab_projshortcut: all sections passed');


### PR DESCRIPTION
**Held for review** — engine change, not for auto-merge. Built on current master (post-#363); touches only `engine/nn/gpu_bab/` (5 files) + one new soundness test. Zero deletions of master-owned files.

## What

1. **Full-DAG op extraction + bound routing** (`nn_to_ops`, `gpu_bab_ibp`, `gpu_bab_crown_tight`). Generalizes master's chain+AdditionLayer model to a full DAG: every op consumes its `Connections`-resolved input op(s) via an explicit per-op `src`, not implicitly the previous op. Unlocks **projection-shortcut ResNets** (1×1 conv-BN on the skip branch) — e.g. the VNN-COMP cifar100 `CIFAR100_resnet_medium`, which the chain extractor soundly *refuses* (FC-width mismatch). Strict generalization: chain/identity-skip cases behave identically (master's soundness suite still passes), all per-op backward/relax rules reused verbatim.

2. **Opt-in GPU device option** (`gpu_bab_try_verify`, `gpu_bab_relu_split`). `opts.device='gpu'` (default `'cpu'`, unchanged) moves the ops' weight tensors + the input box to gpuArray **once**; the IBP/CROWN passes are gpuArray-overloaded pure linear algebra, so all heavy compute + every per-node intermediate bound stay **resident on device** — only tiny scalars cross back (the certified test, the split-neuron index, a witness). No per-iteration bound transfers. GPU implies single precision (T4 FP64 ~1/16 rate), gated on explicit `allowUnsoundSingle` (FP32 is dev/empirical, not certified-sound without outward rounding — R1).

3. **`test_soundness_gpu_bab_projshortcut`** — synthetic conv-on-skip block (skip input = stem, `src != k-1`); asserts degenerate IBP==evaluate, IBP sound, degenerate CROWN==C\*evaluate (the exact DAG skipA backward), CROWN-tight sound & ≤ IBP.

## Validation (on a g4dn T4)

- Existing gpu_bab soundness suite **31/31** + new projection-shortcut test **5/5** pass.
- gpuArray IBP/CROWN match CPU to ~1e-6.
- **cifar100 `resnet_medium` runs end-to-end on the GPU** (386 s / 21 BaB nodes, verdict `unknown` = node budget, guardErr 4e-6) — the same net is hopeless on host CPU (never finishes one verdict). GPU ~**3.7× faster per node** than CPU-single (18 s vs 67 s/node).

## Notes / follow-ups

- GPU single is **dev/empirical** until per-op outward rounding (R1) lands; the certified path is CPU double (default, untouched).
- Next perf levers (not in this PR): batched intermediate CROWN bounds (the O(L²) per-node bottleneck), and GPU-resident alpha-CROWN (currently gathers to host) for tighter bounds / fewer nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)