### PR TITLE
fix(vnncomp): route nn4sys-mscn/test via Python manifest + Conv2DLayer 1-filter bias

### DIFF
--- a/code/nnv/engine/nn/layers/Conv2DLayer.m
+++ b/code/nnv/engine/nn/layers/Conv2DLayer.m
@@ -253,7 +253,12 @@ classdef Conv2DLayer < handle
                         error('Invalid weight matrix');
                     end
                     
-                    if length(b) ~= 3
+                    % A 1-filter conv has bias reshape(b,1,1,1), which MATLAB collapses
+                    % to size [1 1] (length 2); accept it when NumFilters==1, matching the
+                    % named-constructor path above (case 10). Without this, a single-output-
+                    % channel conv (e.g. soundnessbench model_residual's 1-filter blocks,
+                    % imported via the Python manifest) errored "Invalid biases array".
+                    if length(b) ~= 3 && ~(length(b) == 2 && obj.NumFilters == 1)
                         error('Invalid biases array');
                     else
                         obj.Bias = filter_bias;

--- a/code/nnv/examples/Submission/VNN_COMP2026/aws/overnight_sweep.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/aws/overnight_sweep.sh
@@ -22,11 +22,16 @@ if grep -qE "^[[:space:]]*'[,)]" "$RAB"; then
 fi
 echo "parse guard passed"
 
-# regenerate ALL manifest-category .nnv.mat (incl. vit, post-#345)
-for b in lsnc_relu traffic_signs_recognition_2023 cgan_2023 cgan2026 soundnessbench soundnessbench_2026 vit_2023; do
-  for gz in ~/vnncomp2026_benchmarks/benchmarks/$b/1.0/onnx/*.onnx.gz; do
-    [ -f "$gz" ] || continue; gunzip -kf "$gz"
-    onnx="${gz%.gz}"
+# regenerate ALL manifest-category .nnv.mat (incl. vit post-#345; nn4sys-mscn + test
+# post-error-fix). Handles both .onnx and .onnx.gz, and 1.0/2.0 version dirs.
+for b in lsnc_relu traffic_signs_recognition_2023 cgan_2023 cgan2026 soundnessbench soundnessbench_2026 vit_2023 nn4sys test; do
+  for f in ~/vnncomp2026_benchmarks/benchmarks/$b/*/onnx/*.onnx ~/vnncomp2026_benchmarks/benchmarks/$b/*/onnx/*.onnx.gz; do
+    [ -f "$f" ] || continue
+    onnx="$f"; case "$f" in *.gz) gunzip -kf "$f"; onnx="${f%.gz}";; esac
+    if [ "$b" = "nn4sys" ]; then
+      # only mscn routes via the manifest; mscn_2048d_dual is corrupt upstream (skip)
+      case "$onnx" in *mscn_2048d_dual*) continue;; *mscn*) ;; *) continue;; esac
+    fi
     [ -f "${onnx%.onnx}.nnv.mat" ] || python3 ~/nnv/code/nnv/tools/onnx2nnv_python/onnx2nnv.py "$onnx" "${onnx%.onnx}.nnv.mat" > /dev/null 2>&1 || echo "WARN manifest: $onnx"
   done
 done

--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -21,15 +21,28 @@ pkill -f -q matlab 2>/dev/null
 # (~1-3 s/model, far under the 10 min prepare cap). The forward pass of each manifest is
 # cross-validated vs onnxruntime; any SAT witness is replayed through onnxruntime before
 # being emitted, so a mis-import degrades to error/unknown, never an unsound verdict.
+NNV_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"   # VNN_COMP2026 -> .../code/nnv
+gen_manifest() {
+    local onnx="$1"
+    local manifest="${onnx%.onnx}.nnv.mat"
+    if [ ! -f "${manifest}" ]; then
+        echo "Generating NNV manifest: ${manifest}"
+        python3 "${NNV_ROOT}/tools/onnx2nnv_python/onnx2nnv.py" "${onnx}" "${manifest}" \
+            || echo "WARN: manifest generation failed; run_instance will report error/unknown."
+    fi
+}
 case "$2" in
-    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*|*vit*)
-        NNV_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"   # VNN_COMP2026 -> .../code/nnv
-        MANIFEST="${3%.onnx}.nnv.mat"
-        if [ ! -f "${MANIFEST}" ]; then
-            echo "Generating NNV manifest: ${MANIFEST}"
-            python3 "${NNV_ROOT}/tools/onnx2nnv_python/onnx2nnv.py" "$3" "${MANIFEST}" \
-                || echo "WARN: manifest generation failed; run_instance will report error/unknown."
-        fi
+    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*|*vit*|*test*)
+        gen_manifest "$3"
+        ;;
+    *nn4sys*)
+        # Only the mscn models route via the manifest (lindex/pensieve use MATLAB's
+        # importNetworkFromONNX). mscn_2048d_dual.onnx is corrupt upstream and abstains
+        # to unknown in run_vnncomp_instance, so don't waste time trying to convert it.
+        case "$3" in
+            *mscn_2048d_dual*) : ;;
+            *mscn*) gen_manifest "$3" ;;
+        esac
         ;;
 esac
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -68,6 +68,19 @@ if contains(category, "smart_turn")
     return;
 end
 
+% nn4sys mscn_2048d_dual.onnx is corrupt upstream: it fails BOTH MATLAB's ONNX parser
+% AND onnx 1.20's ParseFromString ("Wire format was corrupt"), so no tool can load it.
+% Abstain cleanly to unknown (0 points -- never an error row, never a -150) rather than
+% crash. [2026-06-15: confirmed unparseable by matlab2nnv and the Python manifest importer.]
+if contains(category, "nn4sys") && contains(onnx, "mscn_2048d_dual")
+    status = 2;            % unknown
+    tTime = toc(t);
+    fid = fopen(outputfile, 'w');
+    fprintf(fid, 'unknown \n');
+    fclose(fid);
+    return;
+end
+
 %% 1) Load components
 
 % Load networks
@@ -971,7 +984,21 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         % error("Not supported");
 
     elseif contains(category, "nn4sys")
-        if contains(onnx, "lindex")
+        if contains(onnx, "mscn")
+            % nn4sys mscn: MATLAB's importNetworkFromONNX cannot parse these models
+            % (Gather/embedding + elementwise product/division). Route via the
+            % Python-importer manifest (forward pass cross-validated vs onnxruntime).
+            % The net has NONLINEAR ElementwiseProduct/Division layers with no sound
+            % approx/cp-star reach, so run FALSIFICATION-ONLY (reachOptionsList = {}): a
+            % validated SAT witness (replayed through onnxruntime in falsify_single) or
+            % unknown -- never an unsound unsat. mscn_2048d_dual.onnx is corrupt upstream
+            % (fails MATLAB AND onnx 1.20 parsers) and abstains to unknown earlier in
+            % run_vnncomp_instance.
+            nnvnet = load_manifest_net(onnx);
+            net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+            inputSize = nnvnet.Layers{1}.InputSize;
+            reachOptionsList = {};
+        elseif contains(onnx, "lindex")
             net = importNetworkFromONNX(onnx, "InputDataFormats", "BC");
             nnvnet = matlab2nnv(net);
             reachOptions = struct;
@@ -988,18 +1015,6 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
                 inputFormat = "UU";
                 X = dlarray(rand(12,8), inputFormat);
                 needReshape = 1;
-            elseif contains(onnx, "mscn")
-                % if contains(onnx, "dual")
-                %     inputSize = [1,22,14];
-                %     inputFormat = "UUU";
-                %     X = dlarray(rand(1,22,14), inputFormat);
-                % else
-                %     needReshape = 2;
-                %     inputSize = [1,11,14];
-                %     inputFormat = "UUU";
-                %     X = dlarray(rand(1,11,14), inputFormat);
-                % end
-                error("These are not supported yet.")
             else
                 inputSize = [1,6,8];
                 inputFormat = "UUU";
@@ -1183,6 +1198,18 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         reachOptions.surrogate_dim = [-1,-1];
         reachOptions.threshold_normal = 1e-5;
         reachOptions.reachMethod = 'cp-star'; % default parameters
+        reachOptionsList{1} = reachOptions;
+
+    elseif contains(category, "test")
+        % VNN-COMP 'test' sanity benchmark: tiny FC/ReLU nets that MATLAB's
+        % importNetworkFromONNX rejects ("ONNX model not supported"). Route via the
+        % Python-importer manifest (forward pass cross-validated vs onnxruntime); the
+        % nets are small enough that approx-star decides them soundly.
+        nnvnet = load_manifest_net(onnx);
+        net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+        inputSize = nnvnet.Layers{1}.InputSize;
+        reachOptions = struct;
+        reachOptions.reachMethod = 'approx-star';
         reachOptionsList{1} = reachOptions;
 
     else % all other benchmarks


### PR DESCRIPTION
## Summary
Fixes the 3 erroring benchmarks from the 2026-06-14 sweep so every benchmark is **runnable** (no error rows). All **sound-or-unknown**.

| benchmark | was | now |
|---|---|---|
| nn4sys mscn | `error("These are not supported yet")` | Python-importer manifest + **falsification-only** (nonlinear product/division layers → no sound reach) |
| nn4sys mscn_2048d_dual | error (corrupt onnx) | clean **unknown abstain** (fails MATLAB *and* onnx 1.20 parsers) |
| soundnessbench_2026 model_residual | `Invalid biases array` | fixed latent `Conv2DLayer` bug (1-filter conv bias) |
| test | `ONNX model not supported` | manifest + approx-star |

## The Conv2DLayer fix
The 5-arg constructor rejected any bias whose `size` isn't length-3, but a **1-filter conv** has `reshape(b,1,1,1)` which MATLAB collapses to `[1 1]` (length 2). The named (case 10) path already allows this when `NumFilters==1`; case 5 just lacked the same exception. `model_residual` is the first manifest net with a 1-filter conv.

## Soundness
- mscn = falsification-only → never an unsound unsat; SAT witnesses replayed through onnxruntime before emission.
- test/soundnessbench = sound over-approx reach on a cross-validated import.

## Validation (2026-06-15, m5)
- onnx2nnv.py imports mscn_128d (51 layers), model_residual (40 layers), test_* cleanly.
- Further m5 end-to-end validation (load + run + xval + conv soundness) posted as a follow-up comment before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)