### PR TITLE
feat(gpu_bab): nn_to_ops support for FeatureInputLayer + ElementwiseAffineLayer (unblocks safenlp FC pre-check)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -115,6 +115,25 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
                 [s, t] = i_bn_fold(L, inShape);
                 ops{end+1} = struct('type','normaffine','scale',s,'shift',t,'shape',inShape,'src',inOp); %#ok<AGROW>
             end
+        elseif contains(cls, 'ElementwiseAffine')
+            % ONNX ElementwiseAffineLayer y = (DoScale?Scale:1).*x + (DoOffset?Offset:0)
+            % (LINEAR -> exact). matlab2nnv emits this for a Gemm-without-bias followed by an
+            % Add (the FC bias split out), e.g. safenlp FC nets. Fold as a per-feature
+            % normaffine (Scale is typically scalar, Offset per-feature). Flat input -> [F 1 1];
+            % spatial input -> inShape. The IBP==evaluate orientation guard validates the fold.
+            sc = 1; of = 0;
+            if (~isprop(L,'DoScale')  || L.DoScale)  && isprop(L,'Scale'),  sc = double(L.Scale);  end
+            if (~isprop(L,'DoOffset') || L.DoOffset) && isprop(L,'Offset'), of = double(L.Offset); end
+            if isempty(inShape)
+                F = max(numel(sc), numel(of));
+                if F <= 1
+                    error('nn_to_ops:elemAffineFlatSize', ...
+                        'ElementwiseAffine with scalar params on an unknown-size flat input -- refused for soundness.');
+                end
+                ops{end+1} = struct('type','normaffine','scale',sc(:).*ones(F,1),'shift',of(:).*ones(F,1),'shape',[F 1 1],'src',inOp); %#ok<AGROW>
+            else
+                ops{end+1} = struct('type','normaffine','scale',sc,'shift',of,'shape',inShape,'src',inOp); %#ok<AGROW>
+            end
         elseif contains(cls, 'AvgPool') || contains(cls, 'AveragePool') || contains(cls, 'GlobalAveragePool')
             if isempty(inShape)
                 error('nn_to_ops:poolFlat', 'Pooling on a flat vector -- refused for soundness.');
@@ -135,6 +154,20 @@ function ops = nn_to_ops(nnvnet, flattenOrder)
                     'Addition with %d inputs not supported (only 2) -- refused for soundness.', numel(inOps));
             end
             ops{end+1} = struct('type','add','inputs',inOps,'shape',inShape,'src',inOps(1)); %#ok<AGROW>
+        elseif contains(cls, 'FeatureInput') && isempty(ops)
+            % LEADING FeatureInputLayer: a flat [n] feature-vector input (e.g. sat_relu /
+            % safenlp FC nets imported with InputDataFormats="BC"). It carries no learnable
+            % transform on the values, so treat it as the engine-input passthrough (like a
+            % leading Placeholder / Flatten / ImageInput-without-norm), which UNBLOCKS these
+            % FC nets for the GPU-BaB pre-check (they previously errored -> Star). SOUNDNESS:
+            % a FeatureInputLayer WITH normalization would change the values, so refuse that
+            % (the mandatory IBP==evaluate orientation guard would also catch it) -- only the
+            % no-normalization case becomes an op-list; sound-by-refusal otherwise.
+            if isprop(L, 'Normalization') && ~isempty(L.Normalization) && ~strcmpi(string(L.Normalization), 'none')
+                error('nn_to_ops:featureInputNorm', ...
+                    'FeatureInputLayer Normalization "%s" is not folded yet -- refused for soundness.', string(L.Normalization));
+            end
+            emitted = false;
         elseif contains(cls, 'Placeholder') && isempty(ops)
             % LEADING input-adapter Placeholder: matlab2nnv maps a SequenceInputLayer (the
             % 'BCT' ONNX import of a flat MNIST FC net) / an unmappable input cast to a

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_featureinput.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_featureinput.m
@@ -1,0 +1,47 @@
+% test_soundness_gpu_bab_featureinput
+% nn_to_ops must accept a leading FeatureInputLayer (flat [n] feature input, e.g. the FC nets
+% in sat_relu / safenlp imported with InputDataFormats="BC") as an engine-input passthrough,
+% and the resulting op-list must compute the SAME function as net.evaluate -- the orientation
+% guard's soundness invariant (gpu_bab_ibp on a degenerate box == net.evaluate). This is the
+% import-correctness check that gates the GPU-BaB FC unsat pre-check on these benchmarks.
+
+%% Test 1: FeatureInputLayer FC+ReLU net -> nn_to_ops op-list == net.evaluate (degenerate IBP)
+rng(1);
+layers = [featureInputLayer(8,'Name','in')
+          fullyConnectedLayer(16,'Name','fc1'); reluLayer('Name','r1')
+          fullyConnectedLayer(12,'Name','fc2'); reluLayer('Name','r2')
+          fullyConnectedLayer(5,'Name','fc3')];
+net = dlnetwork(layers);
+nnvnet = matlab2nnv(net);
+assert(any(cellfun(@(L) contains(class(L),'FeatureInput'), nnvnet.Layers)), ...
+    'expected a FeatureInputLayer in the nnv net');
+ops = nn_to_ops(nnvnet, 'colmajor');         % must not error on FeatureInputLayer
+maxe = 0;
+for s = 1:8
+    x = randn(8,1);
+    yo = gpu_bab_ibp(ops, x, x, 'double'); yo = yo(:);
+    yn = nnvnet.evaluate(x); yn = yn(:);
+    maxe = max(maxe, max(abs(yo - yn)));
+end
+assert(maxe < 1e-6, sprintf('op-list (FeatureInput) must match net.evaluate; max err %.3e', maxe));
+
+%% Test 2: a flat normaffine (the ElementwiseAffine / flat-BN fold) is exact in the op-list
+% Build an op-list by hand: affine -> flat normaffine -> relu -> affine, and check the
+% normaffine (y = s.*x + t) is applied exactly by the IBP/degenerate eval.
+rng(2);
+W1 = randn(6,4); b1 = randn(6,1); s = randn(6,1); t = randn(6,1); W2 = randn(3,6); b2 = randn(3,1);
+ops = {struct('type','affine','W',W1,'b',b1,'src',0), ...
+       struct('type','normaffine','scale',s,'shift',t,'shape',[6 1 1],'src',1), ...
+       struct('type','relu','src',2), ...
+       struct('type','affine','W',W2,'b',b2,'src',3)};
+maxe = 0;
+for k = 1:8
+    x = randn(4,1);
+    ref = W2 * max(s.*(W1*x+b1)+t, 0) + b2;          % the exact composed function
+    yo = gpu_bab_ibp(ops, x, x, 'double'); yo = yo(:);
+    maxe = max(maxe, max(abs(yo - ref)));
+end
+assert(maxe < 1e-9, sprintf('flat normaffine must be exact in the op-list; max err %.3e', maxe));
+
+%% Summary
+disp('test_soundness_gpu_bab_featureinput: all sections passed');


### PR DESCRIPTION
Extends `nn_to_ops` so the FC argmax-robustness GPU-BaB pre-check (root-tight, #367/#369) works
on more benchmarks:

- **FeatureInputLayer** (flat `[n]` feature input, e.g. `InputDataFormats="BC"` FC nets):
  treated as the engine-input passthrough (like a leading Placeholder/Flatten). Refuses if it
  carries a Normalization (the runtime IBP==evaluate orientation guard also catches it).
- **ElementwiseAffineLayer** `y = (DoScale?Scale:1).*x + (DoOffset?Offset:0)` (LINEAR -> exact):
  folded as a per-feature `normaffine`. matlab2nnv emits this when a Gemm-without-bias is
  followed by an Add (the FC bias split out), e.g. the safenlp nets.

**Soundness**: both validated by the existing runtime orientation guard (op-list IBP ==
net.evaluate at multiple probes -> a wrong fold fails the guard -> `skip`) plus a new
`test_soundness_gpu_bab_featureinput`. Full gpu_bab soundness suite **17/17**.

**Impact** (vs abCROWN gold, double/CPU, root-tight pre-check): **safenlp now certifies 7/12
gold-unsat + detects 4/18 sat, 0 contradictions** (previously refused at the input/affine
layer). sat_relu stays out of scope (SAT-encoding specs, not argmax-robustness -> sound skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)