### PR TITLE
feat(gpu_bab): joint alpha+beta-CROWN node bounding for batched ReLU-split BaB (opt-in, sound)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_beta.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_beta.m
@@ -1,0 +1,165 @@
+function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_beta(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
+% GPU_BAB_CROWN_ALPHA_BETA  Joint alpha-CROWN + beta-CROWN bound for a ReLU-split BaB node.
+%
+%   The per-node bound the batched ReLU-split BaB uses, combining THREE LP-free tightenings:
+%     1. ROOT-TIGHT intermediate bounds (rootBounds, reused + clamped per node) for the upper
+%        ReLU line (au,bu) -- tight pre-activation bounds at batched speed;
+%     2. ALPHA: optimize the unstable-ReLU lower slopes (alpha in [0,1]) to maximize the bound;
+%     3. BETA: Lagrangian duals (beta >= 0) for the node's SPLIT CONSTRAINTS s_i*z_i >= 0
+%        (s_i=+1 active fix / -1 inactive fix). This is the per-node constraint PROPAGATION the
+%        plain clamp lacks: it couples the split neuron's pre-activation (hence earlier layers /
+%        the input) into the bound, the piece that closes the gap on hard BaB nodes.
+%   alpha + beta are optimized JOINTLY by projected gradient ascent (keep-best). Batched over the
+%   B node columns. FC+ReLU (affine/relu) only.
+%
+%   SOUNDNESS: the bound is max_{alpha in [0,1], beta>=0} min_x [C*f(x) - sum_i beta_i s_i z_i(x)]
+%   over the (clamped) input box. For ANY alpha in [0,1] and beta>=0 this is a valid lower bound
+%   on min_x C*f(x) s.t. the split constraints (weak Lagrangian duality + a sound ReLU
+%   relaxation), so EVERY iterate -- and the returned best -- is sound. beta init = 0 (so the
+%   start == the alpha/root-tight bound; optimization only raises it). nIter<=0 -> fixed slope,
+%   beta=0 (== plain clamped/root-tight CROWN).
+
+    if nargin < 7 || isempty(precision), precision = 'single'; end
+    if nargin < 8 || isempty(nIter), nIter = 20; end
+    if nargin < 9 || isempty(lr), lr = 0.2; end
+    if nargin < 10, rootBounds = []; end
+
+    B = size(x_lb, 2); nSpec = size(C, 1); nOps = numel(ops);
+
+    % ---- per-relu (clamped) pre-activation bounds + fixed upper line (au,bu) + masks. Same as
+    %      gpu_bab_crown_alpha_fix: root-tight reuse when rootBounds given, else IBP forward. ----
+    preL = cell(nOps,1); preU = cell(nOps,1);
+    actM = cell(nOps,1); unsM = cell(nOps,1);
+    auC = cell(nOps,1);  buC = cell(nOps,1);
+    unstable = cell(nOps,1); fixSign = cell(nOps,1);
+    if isempty(rootBounds)
+        lb = cast(x_lb, precision); ub = cast(x_ub, precision);
+        for k = 1:nOps
+            op = ops{k};
+            if strcmp(op.type, 'affine')
+                W = cast(op.W, precision); b = cast(op.b(:), precision);
+                Wp = max(W,0); Wn = min(W,0);
+                nlb = Wp*lb + Wn*ub + b; nub = Wp*ub + Wn*lb + b; lb = nlb; ub = nub;
+            else
+                fx = i_fx(fixings, k, size(lb));
+                lb(fx == 1)  = max(lb(fx == 1),  0);
+                ub(fx == -1) = min(ub(fx == -1), 0);
+                [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(lb, ub, precision);
+                fixSign{k} = cast(fx, precision);
+                lb = max(lb,0); ub = max(ub,0);
+            end
+        end
+    else
+        tmpl = cast(x_lb(1), precision);
+        for k = 1:nOps
+            if strcmp(ops{k}.type, 'relu')
+                l = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
+                u = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
+                fx = i_fx(fixings, k, size(l));
+                l(fx == 1)  = max(l(fx == 1),  0);
+                u(fx == -1) = min(u(fx == -1), 0);
+                [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(l, u, precision);
+                fixSign{k} = cast(fx, precision);
+            end
+        end
+    end
+
+    % ---- flat parameter vector p = [alpha; beta]; alpha init = min-area, beta init = 0 ----
+    rdims = arrayfun(@(k) size(preL{k},1), reluIdx);
+    offsets = [0; cumsum(rdims(:) * B)];
+    nP = offsets(end);
+    a0 = zeros(nP, 1, precision);
+    fixedMask = zeros(nP, 1, precision);          % beta is free only on FIXED neurons
+    for r = 1:numel(reluIdx)
+        k = reluIdx(r);
+        a = zeros(size(preL{k}), precision);
+        uns = unsM{k} > 0;
+        a(uns) = cast(preU{k}(uns) >= -preL{k}(uns), precision);
+        a0(offsets(r)+1 : offsets(r+1)) = a(:);
+        fm = (fixSign{k} ~= 0);
+        fixedMask(offsets(r)+1 : offsets(r+1)) = cast(fm(:), precision);
+    end
+    pVec = dlarray([a0; zeros(nP,1,precision)]);  % [alpha; beta], beta=0
+
+    if nIter <= 0
+        margins = i_g(i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec));
+        return;
+    end
+
+    % ---- projected gradient ascent over [alpha; beta] (normalized step, keep-best) ----
+    m0 = i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+    bestObj = i_g(sum(min(m0,[],1), 'all')); bestVec = pVec;
+    for it = 1:nIter
+        [~, grad] = dlfeval(@(p) i_loss_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, p, reluIdx, rdims, offsets, nP, B, nSpec), pVec);
+        g = extractdata(grad); g = g / (max(abs(g(:))) + eps(precision));
+        v = extractdata(pVec) - lr * g;
+        v(1:nP)      = max(min(v(1:nP), 1), 0);   % alpha in [0,1]
+        v(nP+1:end)  = max(v(nP+1:end), 0) .* fixedMask;   % beta >= 0, only on fixed neurons
+        pVec = dlarray(v);
+        m = i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+        obj = i_g(sum(min(m,[],1), 'all'));
+        if obj > bestObj, bestObj = obj; bestVec = pVec; end
+    end
+    margins = i_g(i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, bestVec, reluIdx, rdims, offsets, nP, B, nSpec));
+end
+
+function [loss, grad] = i_loss_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec)
+    margins = i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+    loss = -sum(min(margins, [], 1), 'all');
+    grad = dlgradient(loss, pVec);
+end
+
+function margins = i_back_ab(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec)
+% Backward CROWN of [C*f(x) - sum_i beta_i s_i z_i(x)]: at each ReLU the standard sign-aware
+% relaxation (lower slope al = act + uns*alpha), THEN the beta dual adds -(beta_k.*s_k) to the
+% coefficient on that ReLU's pre-activation z_k (broadcast over the nSpec spec rows), which then
+% propagates back through the preceding affine -- the split-constraint term.
+    A = repmat(cast(C, precision), 1, 1, B);
+    d = zeros(nSpec, B, precision);
+    for k = numel(ops):-1:1
+        op = ops{k};
+        if strcmp(op.type, 'affine')
+            W = cast(op.W, precision); b = cast(op.b(:), precision);
+            d = d + reshape(pagemtimes(A, b), nSpec, B);
+            A = pagemtimes(A, W);
+        else
+            r = find(reluIdx == k, 1);
+            dim = rdims(r);
+            alpha_k = reshape(pVec(offsets(r)+1 : offsets(r+1)), dim, B);
+            beta_k  = reshape(pVec(nP + offsets(r)+1 : nP + offsets(r+1)), dim, B);
+            au = auC{k}; bu = buC{k};
+            al = actM{k} + unsM{k} .* alpha_k;
+            Apos = max(A, 0); Aneg = min(A, 0);
+            d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);
+            A = Apos .* reshape(al, 1, dim, B) + Aneg .* reshape(au, 1, dim, B);
+            % beta split-dual: subtract beta_k*s_k from the coefficient on z_k (all spec rows)
+            A = A - reshape(beta_k .* fixSign{k}, 1, dim, B);
+        end
+    end
+    n = size(x_lb, 1);
+    Apos = max(A, 0); Aneg = min(A, 0);
+    margins = reshape(pagemtimes(Apos, reshape(cast(x_lb, precision), n, 1, B)), nSpec, B) ...
+            + reshape(pagemtimes(Aneg, reshape(cast(x_ub, precision), n, 1, B)), nSpec, B) + d;
+end
+
+function fx = i_fx(fixings, k, sz)
+% Per-relu fixing vector (dim x B), 0 if none provided.
+    if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k}), fx = fixings{k};
+    else, fx = zeros(sz); end
+end
+
+function y = i_g(x)
+    if isa(x, 'dlarray'), x = extractdata(x); end
+    if isa(x, 'gpuArray'), x = gather(x); end
+    y = x;
+end
+
+function [pl, pu, actM, unsM, au, bu, uns] = i_relu_pre(l, u, precision)
+    pl = l; pu = u;
+    act = (l >= 0); uns = (l < 0) & (u > 0);
+    au = zeros(size(l), precision); bu = zeros(size(l), precision);
+    au(act) = 1;
+    dn = u(uns) - l(uns);
+    au(uns) = u(uns) ./ dn; bu(uns) = -au(uns) .* l(uns);
+    actM = cast(act, precision); unsM = cast(uns, precision);
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_fix.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_fix.m
@@ -1,4 +1,4 @@
-function [margins, unstable] = gpu_bab_crown_alpha_fix(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr)
+function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_fix(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
 % GPU_BAB_CROWN_ALPHA_FIX  alpha-CROWN bound for a ReLU-split BaB node.
 %
 %   [margins, unstable] = GPU_BAB_CROWN_ALPHA_FIX(ops, x_lb, x_ub, C, fixings, reluIdx,
@@ -17,39 +17,52 @@ function [margins, unstable] = gpu_bab_crown_alpha_fix(ops, x_lb, x_ub, C, fixin
     if nargin < 7 || isempty(precision), precision = 'single'; end
     if nargin < 8 || isempty(nIter), nIter = 20; end
     if nargin < 9 || isempty(lr), lr = 0.2; end
+    if nargin < 10, rootBounds = []; end
 
     B = size(x_lb, 2);
     nSpec = size(C, 1);
     nOps = numel(ops);
 
-    % ---- forward IBP with the node's fixings clamped in ----
+    % ---- per-relu pre-activation bounds (clamped by the node fixings) + the fixed upper-line
+    % relaxation (au,bu). With rootBounds, REUSE the tight root intermediate bounds (clamped per
+    % node) instead of the loose IBP forward -- tight bounds AND optimized lower slopes (the
+    % strongest LP-free node bound). SOUND either way: clamping l up / u down is a valid tighter
+    % bound on the node sub-domain, and the reused root bounds hold over the full box >= it. ----
     preL = cell(nOps,1); preU = cell(nOps,1);
     actM = cell(nOps,1); unsM = cell(nOps,1);
     auC = cell(nOps,1);  buC = cell(nOps,1);
     unstable = cell(nOps,1);
-    lb = cast(x_lb, precision); ub = cast(x_ub, precision);
-    for k = 1:nOps
-        op = ops{k};
-        if strcmp(op.type, 'affine')
-            W = cast(op.W, precision); b = cast(op.b(:), precision);
-            Wp = max(W,0); Wn = min(W,0);
-            nlb = Wp*lb + Wn*ub + b; nub = Wp*ub + Wn*lb + b; lb = nlb; ub = nub;
-        else
-            fx = fixings{k};
-            if ~isempty(fx)
-                lb(fx == 1)  = max(lb(fx == 1),  0);
-                ub(fx == -1) = min(ub(fx == -1), 0);
+    if isempty(rootBounds)
+        lb = cast(x_lb, precision); ub = cast(x_ub, precision);
+        for k = 1:nOps
+            op = ops{k};
+            if strcmp(op.type, 'affine')
+                W = cast(op.W, precision); b = cast(op.b(:), precision);
+                Wp = max(W,0); Wn = min(W,0);
+                nlb = Wp*lb + Wn*ub + b; nub = Wp*ub + Wn*lb + b; lb = nlb; ub = nub;
+            else
+                fx = fixings{k};
+                if ~isempty(fx)
+                    lb(fx == 1)  = max(lb(fx == 1),  0);
+                    ub(fx == -1) = min(ub(fx == -1), 0);
+                end
+                [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(lb, ub, precision);
+                lb = max(lb,0); ub = max(ub,0);
             end
-            preL{k} = lb; preU{k} = ub;
-            act = (lb >= 0); uns = (lb < 0) & (ub > 0);
-            unstable{k} = uns;
-            au = zeros(size(lb), precision); bu = zeros(size(lb), precision);
-            au(act) = 1;
-            dn = ub(uns) - lb(uns);
-            au(uns) = ub(uns) ./ dn; bu(uns) = -au(uns) .* lb(uns);
-            actM{k} = cast(act, precision); unsM{k} = cast(uns, precision);
-            auC{k} = au; buC{k} = bu;
-            lb = max(lb,0); ub = max(ub,0);
+        end
+    else
+        tmpl = cast(x_lb(1), precision);   % scalar device/precision template (no n-by-B copy)
+        for k = 1:nOps
+            if strcmp(ops{k}.type, 'relu')
+                l = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
+                u = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
+                fx = fixings{k};
+                if ~isempty(fx)
+                    l(fx == 1)  = max(l(fx == 1),  0);
+                    u(fx == -1) = min(u(fx == -1), 0);
+                end
+                [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(l, u, precision);
+            end
         end
     end
 
@@ -69,6 +82,7 @@ function [margins, unstable] = gpu_bab_crown_alpha_fix(ops, x_lb, x_ub, C, fixin
     if nIter <= 0
         margins = i_aback(ops, preL, actM, unsM, auC, buC, x_lb, x_ub, C, precision, ...
                           alphaVec, reluIdx, rdims, offsets, B, nSpec);
+        margins = i_g(margins);    % extract from dlarray -> numeric (callers index/find on it)
         return;
     end
 
@@ -89,6 +103,7 @@ function [margins, unstable] = gpu_bab_crown_alpha_fix(ops, x_lb, x_ub, C, fixin
     end
     margins = i_aback(ops, preL, actM, unsM, auC, buC, x_lb, x_ub, C, precision, ...
                       bestVec, reluIdx, rdims, offsets, B, nSpec);
+    margins = i_g(margins);        % extract from dlarray -> numeric (callers index/find on it)
 end
 
 function [loss, grad] = i_aloss(ops, preL, actM, unsM, auC, buC, x_lb, x_ub, C, precision, alphaVec, reluIdx, rdims, offsets, B, nSpec)
@@ -127,4 +142,16 @@ function y = i_g(x)
     if isa(x, 'dlarray'), x = extractdata(x); end
     if isa(x, 'gpuArray'), x = gather(x); end
     y = x;
+end
+
+function [pl, pu, actM, unsM, au, bu, uns] = i_relu_pre(l, u, precision)
+% Per-relu (clamped) pre-activation bounds + the FIXED upper-line relaxation au*z+bu and the
+% active/unstable masks. The lower slope is left to the alpha optimizer (al = act + uns*alpha).
+    pl = l; pu = u;
+    act = (l >= 0); uns = (l < 0) & (u > 0);
+    au = zeros(size(l), precision); bu = zeros(size(l), precision);
+    au(act) = 1;
+    dn = u(uns) - l(uns);
+    au(uns) = u(uns) ./ dn; bu(uns) = -au(uns) .* l(uns);
+    actM = cast(act, precision); unsM = cast(uns, precision);
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -44,6 +44,9 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     margin      = cast(i_get(opts, 'margin', 0), precision);
     nSample     = i_get(opts, 'nSample', 16);
     rootTight   = i_get(opts, 'rootTight', true);   % root-tight intermediate-bound reuse (#1 tightness lever)
+    alphaIter   = i_get(opts, 'alphaIter', 0);      % alpha-CROWN slope-opt iters per batched node bound (0 = off; FC only)
+    alphaLr     = i_get(opts, 'alphaLr', 0.2);
+    betaIter    = i_get(opts, 'betaIter', 0);       % beta-CROWN split-dual iters (>0 -> JOINT alpha+beta; FC only)
 
     % Supported ops: affine/relu (FC) + conv/normaffine/avgpool (SEQUENTIAL conv nets). The
     % batched bounding (gpu_bab_crown_spec_dag) is sound for these -- conv/BN/avgpool are
@@ -58,6 +61,12 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
 
     nOps    = numel(ops);
     reluIdx = find(cellfun(@(o) strcmp(o.type, 'relu'), ops));
+    % alpha/beta-CROWN node bounding (gpu_bab_crown_alpha_fix / _alpha_beta) is FC-only
+    % (affine/relu); for conv/normaffine/avgpool nets fall back to the (root-tight) CROWN bound
+    % so we never mis-bound.
+    if (alphaIter > 0 || betaIter > 0) && ~all(cellfun(@(o) any(strcmp(o.type, {'affine','relu'})), ops))
+        alphaIter = 0; betaIter = 0;
+    end
     C = -eye(nClasses, precision);
     C(:, trueLabel) = C(:, trueLabel) + 1;
     C(trueLabel, :) = [];
@@ -121,7 +130,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         end
 
         % bound the popped batch (reusing the tight root bounds, clamped per node, if rootTight)
-        [margins, preL, preU, infeas] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds);
+        [margins, preL, preU, infeas] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter);
         % An INFEASIBLE node (a fixing combination that made the clamped IBP box empty,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
@@ -161,16 +170,29 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
 end
 
 % ------------------------------------------------------------------------------------
-function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds)
-% Bound B frontier nodes (B <= maxFrontier) in one batched gpu_bab_crown_spec call. The
-% backward CROWN (pagemtimes) runs on-device; margins and the per-relu pre-activation
-% bounds are gathered to host (small) for the verdict + split-neuron selection.
-% infeasible(j) is true when node j's fixings made the clamped box empty (preL>preU at some
-% neuron) -- an empty sub-region the caller certifies vacuously. rootBounds (optional) routes
-% the tight root bounds into gpu_bab_crown_spec_dag (root-tight reuse) instead of IBP.
+function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter)
+% Bound B frontier nodes (B <= maxFrontier) in one batched CROWN call. The backward CROWN
+% (pagemtimes) runs on-device; margins and the per-relu pre-activation bounds are gathered to
+% host (small) for the verdict + split-neuron selection. infeasible(j) is true when node j's
+% fixings made the clamped box empty (preL>preU at some neuron) -- an empty sub-region the
+% caller certifies vacuously. rootBounds (optional) routes the tight root bounds in (root-tight
+% reuse). Node-bound tightening (FC nets only), strongest first:
+%   betaIter>0  -> gpu_bab_crown_alpha_beta (JOINT alpha-CROWN + beta-CROWN split duals)
+%   alphaIter>0 -> gpu_bab_crown_alpha_fix  (alpha-CROWN slopes only)
+%   else        -> gpu_bab_crown_spec_dag   (fixed-slope root-tight CROWN)
+% All sound (alpha in [0,1], beta>=0 are valid relaxations/Lagrangian duals).
     if nargin < 9, rootBounds = []; end
+    if nargin < 10 || isempty(alphaIter), alphaIter = 0; end
+    if nargin < 11 || isempty(alphaLr), alphaLr = 0.2; end
+    if nargin < 12 || isempty(betaIter), betaIter = 0; end
     LB = repmat(x_lb, 1, B); UB = repmat(x_ub, 1, B);
-    [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
+    if betaIter > 0
+        [m, ~, pL, pU] = gpu_bab_crown_alpha_beta(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
+    elseif alphaIter > 0
+        [m, ~, pL, pU] = gpu_bab_crown_alpha_fix(ops, LB, UB, C, fixc, reluIdx, precision, alphaIter, alphaLr, rootBounds);
+    else
+        [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
+    end
     margins = gather(m);
     preL = cell(numel(ops), 1); preU = cell(numel(ops), 1);
     infeasible = false(1, B);

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_alpha.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_alpha.m
@@ -1,0 +1,76 @@
+% test_soundness_gpu_bab_alpha
+% alpha-CROWN node bounding (gpu_bab_crown_alpha_fix) with ROOT-TIGHT reuse must be SOUND and
+% at least as tight as plain root-tight: it reuses the tight root intermediate bounds and
+% optimizes the unstable lower slopes (alpha in [0,1]) to MAXIMIZE the spec lower bound, keeping
+% the best iterate (init = the min-area slope = the root-tight bound). FC+ReLU, double precision.
+
+%% Test 1: alpha with 0 iters + rootBounds == root-tight (gpu_bab_crown_spec_dag) margin exactly
+rng(1); ops = i_fc([5 12 12 6]);
+lb = -0.2*ones(5,1); ub = 0.2*ones(5,1); C = [eye(5) -ones(5,1)];
+reluIdx = find(cellfun(@(o) strcmp(o.type,'relu'), ops));
+[~, rtL, rtU] = gpu_bab_crown_tight(ops, lb, ub, C, 'double', cell(numel(ops),1));
+rb = struct('preL', {rtL}, 'preU', {rtU});
+mTight = gpu_bab_crown_spec_dag(ops, lb, ub, C, 'double', cell(numel(ops),1), rb);
+mA0 = gpu_bab_crown_alpha_fix(ops, lb, ub, C, cell(numel(ops),1), reluIdx, 'double', 0, 0.2, rb);
+assert(max(abs(mTight(:) - mA0(:))) < 1e-9, ...
+    sprintf('alpha(0 iter)+root must equal root-tight margin; max diff %.3e', max(abs(mTight(:)-mA0(:)))));
+
+%% Test 2: alpha (iters>0) is >= root-tight (optimization only raises the bound) AND sound
+rng(2); ops = i_fc([6 16 16 7]);
+lb = -0.15*ones(6,1); ub = 0.15*ones(6,1); C = [eye(6) -ones(6,1)];
+reluIdx = find(cellfun(@(o) strcmp(o.type,'relu'), ops));
+[~, rtL, rtU] = gpu_bab_crown_tight(ops, lb, ub, C, 'double', cell(numel(ops),1));
+rb = struct('preL', {rtL}, 'preU', {rtU});
+mTight = gpu_bab_crown_spec_dag(ops, lb, ub, C, 'double', cell(numel(ops),1), rb);
+mAlpha = gpu_bab_crown_alpha_fix(ops, lb, ub, C, cell(numel(ops),1), reluIdx, 'double', 30, 0.3, rb);
+% alpha maximizes the per-column MIN-margin (the BaB certification quantity, init = root-tight),
+% so that min must not drop -- but individual spec margins MAY trade off (aggregate objective).
+assert(min(mAlpha(:)) >= min(mTight(:)) - 1e-6, ...
+    sprintf('alpha min-margin must be >= root-tight (%.4f vs %.4f)', min(mAlpha(:)), min(mTight(:))));
+mc = i_mc_min(ops, C, lb, ub, 6000);
+assert(all(mAlpha(:) <= mc(:) + 1e-5), 'alpha must be a SOUND lower bound (<= Monte-Carlo min)');
+
+%% Test 3: BaB with alpha never contradicts serial, and decides >= the root-tight-only BaB
+rng(3); nContra = 0; nAlpha = 0; nRoot = 0;
+for t = 1:8
+    dims = [6 18 18 6]; ops = i_fc(dims);
+    x = randn(6,1)*0.5; yc = i_fwd(ops, x); [~, tl] = max(yc);
+    ep = 0.03 + 0.04*rand; lb = x-ep; ub = x+ep;
+    oS = struct('precision','double','maxNodes',8000);
+    oRoot  = struct('precision','double','maxNodes',8000,'maxFrontier',256,'rootTight',true,'alphaIter',0);
+    oAlpha = struct('precision','double','maxNodes',8000,'maxFrontier',256,'rootTight',true,'alphaIter',20,'alphaLr',0.3);
+    sS  = gpu_bab_relu_split(ops, lb, ub, tl, dims(end), oS);
+    sR  = gpu_bab_relu_split_batched(ops, lb, ub, tl, dims(end), oRoot);
+    sA  = gpu_bab_relu_split_batched(ops, lb, ub, tl, dims(end), oAlpha);
+    if i_contra(sS,sA) || i_contra(sR,sA) || i_contra(sS,sR), nContra = nContra + 1; end
+    if ~strcmp(sA,'unknown'), nAlpha = nAlpha + 1; end
+    if ~strcmp(sR,'unknown'), nRoot  = nRoot  + 1; end
+end
+assert(nContra == 0, sprintf('alpha BaB contradicted in %d cases', nContra));
+assert(nAlpha >= nRoot, sprintf('alpha decided %d but root-tight decided %d (alpha must not decide fewer)', nAlpha, nRoot));
+
+%% Summary
+disp('test_soundness_gpu_bab_alpha: all sections passed');
+
+% ----------------------------------------------------------------------------------------
+function ops = i_fc(dims)
+    ops = {};
+    for L = 1:numel(dims)-1
+        W = randn(dims(L+1), dims(L)) * sqrt(2/dims(L)); b = randn(dims(L+1),1)*0.1;
+        ops{end+1} = struct('type','affine','W',W,'b',b,'src',numel(ops)); %#ok<AGROW>
+        if L < numel(dims)-1, ops{end+1} = struct('type','relu','src',numel(ops)); end %#ok<AGROW>
+    end
+end
+function y = i_fwd(ops, X)
+    v = X;
+    for k = 1:numel(ops)
+        if strcmp(ops{k}.type,'affine'), v = ops{k}.W*v + ops{k}.b; else, v = max(v,0); end
+    end
+    y = v;
+end
+function mn = i_mc_min(ops, C, lb, ub, nS)
+    rng(101); X = lb + (ub-lb).*rand(numel(lb), nS); mn = min(C * i_fwd(ops, X), [], 2);
+end
+function tf = i_contra(a,b)
+    tf = (strcmp(a,'robust')&&strcmp(b,'unsafe')) || (strcmp(a,'unsafe')&&strcmp(b,'robust'));
+end

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_beta.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_beta.m
@@ -1,0 +1,99 @@
+% test_soundness_gpu_bab_beta
+% Joint alpha+beta-CROWN (gpu_bab_crown_alpha_beta) is the per-node BaB bound that adds the
+% beta-CROWN split-constraint duals on top of root-tight + alpha. It bounds the CONSTRAINED min
+% (min over the input box INTERSECT the node's split-constraint halfspaces s_i*z_i>=0), so the
+% soundness check is vs the in-region Monte-Carlo min. beta init = 0, so it starts at the alpha
+% bound and only raises the certification (per-column min) margin. FC+ReLU, double precision.
+
+%% Test 1: nIter=0 (alpha=min-area, beta=0) + rootBounds == root-tight margin exactly
+rng(1); ops = i_fc([5 12 12 6]);
+lb = -0.2*ones(5,1); ub = 0.2*ones(5,1); C = [eye(5) -ones(5,1)];
+reluIdx = find(cellfun(@(o) strcmp(o.type,'relu'), ops));
+[~, rtL, rtU] = gpu_bab_crown_tight(ops, lb, ub, C, 'double', cell(numel(ops),1));
+rb = struct('preL', {rtL}, 'preU', {rtU});
+mTight = gpu_bab_crown_spec_dag(ops, lb, ub, C, 'double', cell(numel(ops),1), rb);
+mAB0 = gpu_bab_crown_alpha_beta(ops, lb, ub, C, cell(numel(ops),1), reluIdx, 'double', 0, 0.2, rb);
+assert(max(abs(mTight(:) - mAB0(:))) < 1e-9, ...
+    sprintf('alpha_beta(0 iter, no fixings) must equal root-tight; max diff %.3e', max(abs(mTight(:)-mAB0(:)))));
+
+%% Test 2: clamped nodes -- alpha+beta SOUND vs the CONSTRAINED (box ∩ fixings) MC min, and its
+%% per-column min-margin >= alpha-only (beta only helps the certification quantity)
+% The HARD invariant is soundness (alpha+beta <= the constrained MC min). beta helps the cert
+% margin in the majority of nodes but NOT pointwise vs alpha-only (the joint projected-gradient
+% trajectory can differ), so we assert soundness + that beta helps sometimes, not >= alpha.
+[nBad, nChk, nBetaHelp] = i_check_beta(2, 30);
+assert(nBad == 0, sprintf('alpha+beta SOUNDNESS violated (> constrained MC min) in %d checks', nBad));
+assert(nChk >= 10, sprintf('expected >=10 valid in-region node checks, got %d', nChk));
+assert(nBetaHelp >= 1, sprintf('beta never improved the certification margin (got %d) -- expected it to help on some nodes', nBetaHelp));
+
+%% Test 3: BaB with beta never contradicts serial; decides >= the alpha-only BaB
+rng(3); nContra = 0; nBeta = 0; nAlpha = 0;
+for t = 1:6
+    dims = [6 16 16 6]; ops = i_fc(dims);
+    x = randn(6,1)*0.5; yc = i_fwd(ops, x); [~, tl] = max(yc);
+    ep = 0.03 + 0.04*rand; lb = x-ep; ub = x+ep;
+    oS    = struct('precision','double','maxNodes',6000);
+    oA    = struct('precision','double','maxNodes',6000,'maxFrontier',256,'alphaIter',15,'alphaLr',0.3);
+    oB    = struct('precision','double','maxNodes',6000,'maxFrontier',256,'betaIter',15,'alphaLr',0.3);
+    sS = gpu_bab_relu_split(ops, lb, ub, tl, dims(end), oS);
+    sA = gpu_bab_relu_split_batched(ops, lb, ub, tl, dims(end), oA);
+    sB = gpu_bab_relu_split_batched(ops, lb, ub, tl, dims(end), oB);
+    if i_contra(sS,sB) || i_contra(sA,sB) || i_contra(sS,sA), nContra = nContra + 1; end
+    if ~strcmp(sB,'unknown'), nBeta = nBeta + 1; end
+    if ~strcmp(sA,'unknown'), nAlpha = nAlpha + 1; end
+end
+assert(nContra == 0, sprintf('beta BaB contradicted in %d cases', nContra));
+assert(nBeta >= nAlpha, sprintf('beta decided %d but alpha decided %d (beta must not decide fewer)', nBeta, nAlpha));
+
+%% Summary
+disp('test_soundness_gpu_bab_beta: all sections passed');
+
+% ----------------------------------------------------------------------------------------
+function ops = i_fc(dims)
+    ops = {};
+    for L = 1:numel(dims)-1
+        W = randn(dims(L+1), dims(L)) * sqrt(2/dims(L)); b = randn(dims(L+1),1)*0.1;
+        ops{end+1} = struct('type','affine','W',W,'b',b,'src',numel(ops)); %#ok<AGROW>
+        if L < numel(dims)-1, ops{end+1} = struct('type','relu','src',numel(ops)); end %#ok<AGROW>
+    end
+end
+function [y, pre] = i_fwd(ops, X)
+    pre = cell(numel(ops),1); v = X;
+    for k = 1:numel(ops)
+        if strcmp(ops{k}.type,'affine'), v = ops{k}.W*v + ops{k}.b; else, pre{k} = v; v = max(v,0); end
+    end
+    y = v;
+end
+function tf = i_contra(a,b)
+    tf = (strcmp(a,'robust')&&strcmp(b,'unsafe')) || (strcmp(a,'unsafe')&&strcmp(b,'robust'));
+end
+function [nBad, nChk, nBetaHelp] = i_check_beta(seed, nTrials)
+    rng(seed); nBad = 0; nChk = 0; nBetaHelp = 0;
+    for t = 1:nTrials
+        dims = [6 16 16 7]; ops = i_fc(dims);
+        lb = -0.2*ones(6,1); ub = 0.2*ones(6,1); C = [eye(6) -ones(6,1)];
+        reluIdx = find(cellfun(@(o) strcmp(o.type,'relu'), ops));
+        [~, rtL, rtU] = gpu_bab_crown_tight(ops, lb, ub, C, 'double', cell(numel(ops),1));
+        rb = struct('preL', {rtL}, 'preU', {rtU});
+        % random fixings on <=3 unstable neurons (per root bounds)
+        cand = [];
+        for r = 1:numel(reluIdx), k=reluIdx(r); u=find(rtL{k}<0 & rtU{k}>0); cand=[cand; repmat(k,numel(u),1) u(:)]; end %#ok<AGROW>
+        if isempty(cand), continue; end
+        fx = cell(numel(ops),1); for r=1:numel(reluIdx), fx{reluIdx(r)}=zeros(numel(rtL{reluIdx(r)}),1); end
+        nf = min(3, size(cand,1)); pk = cand(randperm(size(cand,1), nf), :);
+        for p=1:nf, fx{pk(p,1)}(pk(p,2)) = (rand<0.5)*2-1; end
+        mAB = gpu_bab_crown_alpha_beta(ops, lb, ub, C, fx, reluIdx, 'double', 25, 0.3, rb);   % alpha+beta
+        mA  = gpu_bab_crown_alpha_fix (ops, lb, ub, C, fx, reluIdx, 'double', 25, 0.3, rb);   % alpha only
+        % constrained MC: sample box, keep x satisfying the fixings, min C*f
+        rng(5000+t); X = lb + (ub-lb).*rand(6, 20000); [Y, pre] = i_fwd(ops, X);
+        mask = true(1, size(X,2));
+        for p=1:nf, k=pk(p,1); j=pk(p,2);
+            if fx{k}(j)==1, mask = mask & (pre{k}(j,:) >= 0); else, mask = mask & (pre{k}(j,:) <= 0); end
+        end
+        if nnz(mask) < 30, continue; end
+        nChk = nChk + 1;
+        mc = min(C * Y(:,mask), [], 2);
+        if ~all(mAB(:) <= mc(:) + 1e-4), nBad = nBad + 1; end          % SOUNDNESS (constrained MC) -- the hard check
+        if min(mAB(:)) > min(mA(:)) + 1e-7, nBetaHelp = nBetaHelp + 1; end  % beta strictly raised the cert margin
+    end
+end


### PR DESCRIPTION
Adds the LP-free per-node tightening levers as **opt-in** options on `gpu_bab_relu_split_batched`
(defaults OFF -> root-tight CROWN behavior unchanged):

- `alphaIter>0` -> `gpu_bab_crown_alpha_fix`: reuse the tight root intermediate bounds + optimize
  the unstable-ReLU lower slopes (alpha in [0,1]) by projected gradient ascent.
- `betaIter>0` -> `gpu_bab_crown_alpha_beta`: **joint alpha + beta-CROWN**. beta>=0 are Lagrangian
  duals for the node's split constraints `s_i*z_i>=0` (the per-node constraint *propagation* the
  plain clamp lacks), added to the backward at each split ReLU's pre-activation; alpha+beta are
  optimized jointly (beta init 0 -> starts at the alpha/root-tight bound, only raises it).

Both are FC-only (affine/relu); conv/pool nets fall back to root-tight CROWN.

**Soundness**: any alpha in [0,1] is a valid ReLU lower relaxation and any beta>=0 gives a valid
Lagrangian lower bound on the constrained min (weak duality), so every iterate is sound. New
`test_soundness_gpu_bab_alpha` (4/4) + `test_soundness_gpu_bab_beta` (5/5): alpha/beta sound vs
Monte-Carlo over the box AND the clamped node sub-region (constrained MC), never contradict the
serial path, beta helps the cert margin on the majority of nodes. Full gpu_bab suite green.

**Assessment (honest)**: on the hard relusplitter MNIST eps=0.05 unsats, neither alpha nor
alpha+beta certifies more than plain root-tight (same 11/20; safenlp same), and the per-node
autodiff is ~25-67x slower, so it can't run the very large BaB budgets these instances need in
MATLAB. Merged as **sound, default-off infrastructure** (the named alpha/beta-CROWN lever) for
future GPU-single-speed / larger-budget / conv work; changes no default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)