### PR TITLE
chore(vnncomp/install): single-source onnx2nnv deps + import guard + preflight gate

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
@@ -68,11 +68,17 @@ matlab -batch "cd('${TOOLKIT}'); install" || \
 # manifests in prepare_instance.sh; onnxruntime also backs the SAT-witness replay gate that
 # prevents false-SAT (-150) verdicts. Pin a known-good set.
 apt-get install -y python3 python3-pip
-pip3 install --no-cache-dir onnx==1.20.0 onnxruntime==1.23.1 numpy scipy
-# onnx2nnv.py (the manifest importer for lsnc_relu/traffic_signs/cgan/soundnessbench)
-# hard-requires the simplifier stack; without these prepare_instance.sh fails to
-# generate manifests and every manifest-category instance errors (2026-06-12 dry run).
-pip3 install --no-cache-dir onnxsim onnxoptimizer
+# onnx2nnv.py (tools/onnx2nnv_python) needs the full simplifier stack -- onnx, onnxruntime,
+# numpy, scipy, onnxsim, onnxoptimizer. Missing ANY -> prepare_instance.sh cannot generate the
+# .nnv.mat manifests and every manifest-category instance errors (lsnc_relu/traffic_signs/cgan/
+# soundnessbench/nn4sys/vit). Single source of truth: tools/onnx2nnv_python/requirements.txt
+# (2026-06-15: a dev box whose python had onnx+onnxruntime but lacked onnxsim/onnxoptimizer/
+# scipy failed exactly this way). onnx2nnv.py also guards its imports with the same remediation.
+pip3 install --no-cache-dir -r "${TOOLKIT}/tools/onnx2nnv_python/requirements.txt"
+# PREFLIGHT GATE: verify the importer deps actually import in THIS python -- catches a
+# venv-vs-system mismatch BEFORE a sweep wastes hours erroring on every manifest benchmark.
+python3 -c "import numpy, scipy, onnx, onnxruntime, onnxsim, onnxoptimizer" \
+    || { echo "ERROR: onnx2nnv.py deps failed to import after install (check the active python vs ${TOOLKIT}/tools/onnx2nnv_python/requirements.txt)" >&2; exit 1; }
 
 # MATLAB Engine API for Python: execute.py (the run_instance.sh bridge) does
 # `import matlab.engine`; without it EVERY instance fails instantly (caught in

--- a/code/nnv/tools/onnx2nnv_python/onnx2nnv.py
+++ b/code/nnv/tools/onnx2nnv_python/onnx2nnv.py
@@ -41,12 +41,25 @@ Layer record types we emit (matching NNV layer classes):
 import argparse, os, sys, hashlib, re
 from dataclasses import dataclass, field
 from typing import Any
-import numpy as np
-import onnx
-from onnx import numpy_helper, shape_inference, version_converter
-import onnxsim
-import onnxoptimizer
-from scipy.io import savemat
+# Third-party deps (numpy/onnx/onnxsim/onnxoptimizer/scipy) -- guard the import so a box
+# whose python is missing any of them fails with an ACTIONABLE message instead of a raw
+# ModuleNotFoundError. Without this, a missing dep makes EVERY manifest-routed benchmark
+# (lsnc_relu/traffic_signs/cgan/soundnessbench/nn4sys/vit) error opaquely at prepare time.
+try:
+    import numpy as np
+    import onnx
+    from onnx import numpy_helper, shape_inference, version_converter
+    import onnxsim
+    import onnxoptimizer
+    from scipy.io import savemat
+except ImportError as _e:
+    _req = os.path.join(os.path.dirname(os.path.abspath(__file__)), "requirements.txt")
+    sys.stderr.write(
+        f"\nERROR: the ONNX->NNV manifest importer is missing a Python dependency: '{_e.name}'.\n"
+        f"  This python ({sys.executable}) cannot import the importer's deps, so manifest\n"
+        f"  generation (and every manifest-routed benchmark) will fail. Install them with:\n"
+        f"      {sys.executable} -m pip install -r {_req}\n\n")
+    sys.exit(3)
 
 
 # ---------- tensor-layout model ----------

--- a/code/nnv/tools/onnx2nnv_python/requirements.txt
+++ b/code/nnv/tools/onnx2nnv_python/requirements.txt
@@ -1,0 +1,21 @@
+# Python dependencies for the NNV VNN-COMP ONNX->NNV manifest importer
+# (tools/onnx2nnv_python/onnx2nnv.py) and the onnxruntime SAT-witness replay gate.
+#
+# Install these into the SAME python the dispatcher uses to run onnx2nnv.py -- the
+# system python3 that install_tool.sh provisions, OR a project venv if one is active.
+# If ANY is missing, prepare_instance.sh cannot generate the .nnv.mat manifests and
+# EVERY manifest-routed benchmark errors: lsnc_relu, traffic_signs_recognition, cgan,
+# soundnessbench, nn4sys, vit. onnx2nnv.py guards its imports and prints this file +
+# the exact install command if a dep is missing.
+#
+# Fix on any box:   <python> -m pip install -r requirements.txt
+#
+# (2026-06-15: a dev box whose python had onnx + onnxruntime but lacked
+#  onnxsim/onnxoptimizer/scipy failed exactly this way -- every manifest benchmark
+#  errored in a sweep. Hence this explicit, single-source list + the import guard.)
+numpy
+scipy
+onnx==1.20.0
+onnxruntime==1.23.1
+onnxsim
+onnxoptimizer


### PR DESCRIPTION
## Problem
The ONNX->NNV manifest importer (`tools/onnx2nnv_python/onnx2nnv.py`) needs `onnx` + `onnxruntime` + `numpy` + `scipy` + `onnxsim` + `onnxoptimizer`. On a dev box (2026-06-15) whose python had `onnx`+`onnxruntime` but **lacked** `onnxsim`/`onnxoptimizer`/`scipy`, manifest generation failed → **every** manifest-routed benchmark (lsnc_relu, traffic_signs, cgan, soundnessbench, nn4sys, vit) errored in a sweep, surfaced only as a raw `ModuleNotFoundError`.

## Fix (detect + remediate; no MATLAB/verdict change)
- **`requirements.txt`** (new) — single source of truth for the importer deps.
- **`onnx2nnv.py` import guard** — on `ImportError`, print the missing module + the exact `<sys.executable> -m pip install -r requirements.txt` command (names the active python, so a venv-vs-system mismatch is obvious) and `exit 3`, instead of a raw traceback.
- **`install_tool.sh`** — install from `requirements.txt` (single source) + a **preflight gate** that imports all six in the active python, so a missing/mismatched dep fails the install **loudly** rather than at sweep time on every manifest benchmark.

Setup-only. Python syntax validated on R2026a box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)