### PR TITLE
fix(vnncomp/prepare): match net-cache filename to MATLAB side (Copilot #374)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -56,7 +56,11 @@ esac
 MATLAB_BIN="${MATLAB_BIN:-matlab}"
 build_netcache() {
     local cat="$1" onnx="$2" vnnlib="$3"
-    local cache="${onnx%.onnx}.netcache.mat"
+    # Name MUST match the MATLAB side exactly: i_load_vnncomp_network_cached writes/reads
+    # [char(onnx) '.netcache.mat'] -> "<onnx>.netcache.mat" (APPENDS; does not strip .onnx).
+    # A stripped name ("model.netcache.mat") would never match, so this skip-guard would never
+    # fire and prepare would relaunch MATLAB on every instance instead of once per onnx.
+    local cache="${onnx}.netcache.mat"
     [ -f "${cache}" ] && return
     echo "Pre-building NNV net cache: ${cache}"
     NNV_PREP_CACHE=1 "${MATLAB_BIN}" -batch \


### PR DESCRIPTION
Addresses the GitHub Copilot review comment on #374.

`prepare_instance.sh` built/checked the net cache as `${onnx%.onnx}.netcache.mat` (`model.netcache.mat`), but `i_load_vnncomp_network_cached` in `run_vnncomp_instance.m` writes/reads `[char(onnx) '.netcache.mat']` (`model.onnx.netcache.mat`). The skip-guard therefore never matched → prepare relaunched MATLAB for *every* instance instead of once per onnx.

No correctness/soundness impact (the prewarm still wrote the correct file the timed run reads; the timed run also lazily rebuilds on a miss), but it defeated the per-onnx skip and wasted untimed prepare work. Fix: use the same append convention as the MATLAB side, and comment the invariant so it can't drift again. The manifest path stays `${onnx%.onnx}.nnv.mat` (correct — the manifest convention strips `.onnx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)