### PR TITLE
fix(vnncomp/nn4sys): abstain mscn to unknown (false-SAT on multi-output cardinality specs)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -68,11 +68,19 @@ if contains(category, "smart_turn")
     return;
 end
 
-% nn4sys mscn_2048d_dual.onnx is corrupt upstream: it fails BOTH MATLAB's ONNX parser
-% AND onnx 1.20's ParseFromString ("Wire format was corrupt"), so no tool can load it.
-% Abstain cleanly to unknown (0 points -- never an error row, never a -150) rather than
-% crash. [2026-06-15: confirmed unparseable by matlab2nnv and the Python manifest importer.]
-if contains(category, "nn4sys") && contains(onnx, "mscn_2048d_dual")
+% nn4sys mscn: abstain ALL mscn models to unknown. Two distinct causes, one sound outcome:
+%   (1) mscn_2048d_dual.onnx is corrupt upstream -- fails BOTH MATLAB's ONNX parser AND onnx 1.20's
+%       ParseFromString ("Wire format was corrupt"); no tool can load it. [confirmed 2026-06-15]
+%   (2) mscn_128d / mscn_2048d produce FALSE-SAT on the cardinality_* specs. [confirmed 2026-06-16:
+%       10/10 NNV `sat` contradicted the abCROWN/NeuralSAT/PyRAT `unsat` consensus -- 10 x -150; NNV
+%       had 0 correct mscn solves.] Root cause: these specs are MULTI-OUTPUT, so the falsifier takes
+%       the ungated path and the onnxruntime SAT-witness replay (run_vnncomp_instance Pillar-2 gate)
+%       never runs -- it only wraps the single-Hg path; and the box's system python3 lacks
+%       onnxruntime regardless. So a spurious witness was emitted as a wrong verdict.
+% Abstaining to unknown (0 points, never -150) is the sound verdict and costs no real solves.
+% TODO durable fix: replay EVERY sat witness through the full vnnlib via the venv python before
+% emitting (gate the multi-output path too), then this mscn abstain can be lifted. See diagnosis doc.
+if contains(category, "nn4sys") && contains(onnx, "mscn")
     status = 2;            % unknown
     tTime = toc(t);
     fid = fopen(outputfile, 'w');


### PR DESCRIPTION
The 2026 overnight sweep surfaced **10 false-SAT** verdicts — all in **nn4sys mscn** (`mscn_128d`/`mscn_2048d` × `cardinality_*`): NNV emitted `sat` where abCROWN + NeuralSAT + PyRAT all prove `unsat` (−150 each).

**Root cause:** these specs are multi-output, so the falsifier takes the path that **bypasses** the Pillar-2 onnxruntime SAT-witness replay (which only wraps the single-`Hg` path). The witness NNV's `validate_witness` accepts doesn't actually violate the property, and nothing cross-checks it (the box's system `python3` lacks onnxruntime regardless). NNV had **0 correct mscn solves**.

**Fix:** abstain all nn4sys mscn to `unknown` (generalizes the existing `mscn_2048d_dual` corrupt-model abstain). Sound-or-unknown; costs no real solves; removes the −150 landmines. The abstain keys on the onnx path string before the network loads.

**Validated:** re-ran `mscn_128d/cardinality_0_1_128` with the fix → `unknown` (was `sat`); re-scored the full sweep → wrong-vs-2025-consensus = 0.

**Durable follow-up (separate PR):** replay every `sat` witness through the full vnnlib via the venv python so the multi-output path is gated too, then this abstain can be lifted. Full write-up in the status repo: `research/mscn_false_sat_2026-06-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)