### PR TITLE
fix(vnncomp): robust onnx/onnxruntime python discovery (cctsdb_yolo 39->0 regression)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -617,18 +617,45 @@ end
 % 'python' often does not exist on the competition VM; run_instance.sh itself
 % uses python3), 'python' on Windows dev boxes.
 function py = python_exe()
-    if ispc
-        py = 'python';
-    else
-        py = 'python3';
-    end
+%PYTHON_EXE  Return a quoted python interpreter that can import the verification stack
+%   (onnx + onnxruntime), discovered ROBUSTLY across machine configs -- a venv OR a
+%   direct/system python (lambda dev box has the stack in ~/taylor_venv; install_tool.sh
+%   provisions it into system python3 on the eval box). Used by the python verifiers that
+%   need onnxruntime: the cctsdb_yolo complete-enumeration shell-out (cctsdb_enumerate.py)
+%   and the witness-replay helpers. The old version returned bare python3/pyenv, which on a
+%   box whose system python3 lacks onnx/ort made cctsdb_enumerate.py fail -> all-unknown
+%   (the cctsdb_yolo 39->0 regression). Probe order: $NNV_ORT_PYTHON -> MATLAB pyenv ->
+%   common venv -> python3 -> python; pick the first that imports onnx+onnxruntime; if none
+%   has the stack, fall back to a plain interpreter so non-ort callers still run. Cached.
+    persistent cached
+    if ~isempty(cached), py = cached{1}; return; end
+    cands = {};
+    e = strtrim(getenv('NNV_ORT_PYTHON'));
+    if ~isempty(e), cands{end+1} = e; end
     try
         pe = pyenv;
-        if ~isempty(pe.Executable) && isfile(pe.Executable)
-            py = ['"' char(pe.Executable) '"'];
-        end
+        if ~isempty(pe.Executable) && isfile(pe.Executable), cands{end+1} = char(pe.Executable); end
     catch
     end
+    home = getenv('HOME');
+    if ~isempty(home), cands{end+1} = fullfile(home, 'taylor_venv', 'bin', 'python'); end
+    if ispc
+        cands = [cands, {'python', 'python3'}];
+    else
+        cands = [cands, {'python3', 'python'}];
+    end
+    found = '';
+    for i = 1:numel(cands)
+        c = cands{i};
+        if isempty(c), continue; end
+        [st, ~] = system(sprintf('"%s" -c "import onnx, onnxruntime"', c));
+        if st == 0, found = ['"' c '"']; break; end
+    end
+    if isempty(found)
+        if ispc, found = 'python'; else, found = 'python3'; end   % no stack found -> plain fallback
+    end
+    cached = {found};
+    py = found;
 end
 
 function IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar)


### PR DESCRIPTION
`run_vnncomp_instance.m`'s `python_exe()` returned bare `python3` on Linux (overriding only if MATLAB's `pyenv` pointed at an ort-capable interpreter). On a box whose **system python3 lacks the onnx/onnxruntime stack** (it's in a venv), the cctsdb_yolo complete-enumeration shell-out (`cctsdb_enumerate.py`, imports onnx+onnxruntime) failed with `ModuleNotFoundError: No module named 'onnx'` → printed UNKNOWN → **all 39 cctsdb_yolo instances regressed to `unknown`** (they were 39 solved before).

Fix: mirror the #377 `ort_python` discovery — probe `$NNV_ORT_PYTHON` → pyenv → common venv → python3 → python, pick the first that imports `onnx`+`onnxruntime` (cached), fall back to a plain interpreter only if none has the stack.

**Verified on the box:** a cctsdb_yolo instance that returned `unknown` now returns `unsat` in 4 s. Sound-or-unknown unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)