### PR TITLE
GPU-BaB: cifar conv certification + general-halfspace disjunctive BaB

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_alpha_dag_parity_test.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_alpha_dag_parity_test.m
@@ -78,6 +78,34 @@ function gpu_bab_alpha_dag_parity_test()
             ni, min(minTrue - mB), sum(ok), nMC);
     end
 
+    % ============ WORST-SPEC path (nSpec>16) — the cifar-scale memory mode ============
+    % Large nSpec triggers useWorst: find-worst-once gradient + 1-spec keep-best + min-area fallback.
+    % Verify (a) it runs, (b) no-worse than min-area (the per-node fallback guard), and (c) the BETA
+    % bound stays a valid lower bound under split fixings via Monte Carlo (the -150 gate, many specs).
+    for ni = 1:numel(nets)
+        net = nets{ni}; ops = net.ops; reluIdx = net.reluIdx; n = net.nIn; nOut = net.nOut;
+        c = randn(n,1); rad = 0.4*(0.5+rand(n,1)); lb = c-rad; ub = c+rad;
+        C = randn(40, nOut);                                 % 40 > 16 -> worst-spec mode
+        % (b) no-worse than min-area (no fixings): the fallback guard must hold per node.
+        mW0 = gpu_bab_crown_alpha_dag(ops, lb, ub, C, {}, reluIdx, prec, 0, [], []);
+        mWo = gpu_bab_crown_alpha_dag(ops, lb, ub, C, {}, reluIdx, prec, 20, 0.1, []);
+        reg = min(min(mWo,[],1) - min(mW0,[],1));
+        assert(reg >= -1e-7, '[worst-spec %d] REGRESSED below min-area by %.3e (fallback guard failed)', ni, -reg);
+        % (c) beta MC soundness with many specs (worst-spec gradient under split constraints).
+        [fixings, x0] = i_make_fixings(ops, lb, ub, reluIdx, prec);
+        mB = gpu_bab_crown_alpha_dag(ops, lb, ub, C, fixings, reluIdx, prec, 20, 0.1, []);
+        mB = min(mB, [], 2);
+        nMC = 40000; X = [x0, lb + (ub - lb) .* rand(n, nMC-1)];
+        [Y, Z] = i_forward(ops, X, reluIdx);
+        ok = i_satisfies(Z, fixings, reluIdx, 0);
+        assert(any(ok), '[worst-spec beta %d] no MC sample satisfied the split fixings', ni);
+        minTrue = min(C * Y(:, ok), [], 2);
+        viol = max(mB - minTrue);
+        assert(viol <= 1e-6, '[worst-spec beta %d] UNSOUND: bound exceeds MC true-min by %.3e', ni, viol);
+        fprintf('[worst-spec %d] OK (no-worse gain %.3e + beta sound; slack %.3e; %d/%d feasible)\n', ...
+            ni, reg, min(minTrue - mB), sum(ok), nMC);
+    end
+
     fprintf('\nALL PARITY + BETA-SOUNDNESS TESTS PASSED\n');
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_alpha_dag_parity_test.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_alpha_dag_parity_test.m
@@ -1,0 +1,264 @@
+function gpu_bab_alpha_dag_parity_test()
+% GPU_BAB_ALPHA_DAG_PARITY_TEST  Soundness gate for gpu_bab_crown_alpha_dag.
+%   Asserts gpu_bab_crown_alpha_dag(nIter=0) == gpu_bab_crown_spec_dag BOUND-FOR-BOUND on
+%   synthetic conv DAGs (conv/relu/avgpool/affine/normaffine/add). At min-area alpha the two
+%   backwards are op-for-op identical, so any mismatch is a fused-backward bug -- this MUST pass
+%   before alpha_dag is trusted for a 'robust' emit. Also checks (a) nIter>0 runs and is
+%   sound-AND-no-worse than min-area, and (b) the rootBounds-reuse path matches too.
+%
+%   Run: results = runtests('gpu_bab_alpha_dag_parity_test')  OR  gpu_bab_alpha_dag_parity_test
+    here = fileparts(mfilename('fullpath'));
+    addpath(here);
+    rng(7, 'twister');
+    prec = 'double';                                  % double: parity should be ~exact
+    tol = 1e-9;
+
+    nets = {i_net_chain(), i_net_residual()};
+    names = {'chain conv->relu->avgpool->fc', 'normaffine->conv->relu->conv->add->relu->fc'};
+
+    for ni = 1:numel(nets)
+        net = nets{ni}; ops = net.ops; reluIdx = net.reluIdx;
+        n = net.nIn; nOut = net.nOut; B = 3;
+        % random input box + spec
+        c  = randn(n, B);
+        rad = 0.3 * (0.5 + rand(n, B));
+        lb = c - rad; ub = c + rad;
+        C  = randn(4, nOut);
+
+        % ---- IBP path: alpha_dag(nIter=0) vs spec_dag ----
+        mSpec = gpu_bab_crown_spec_dag(ops, lb, ub, C, prec, {}, []);
+        mA0   = gpu_bab_crown_alpha_dag(ops, lb, ub, C, {}, reluIdx, prec, 0, [], []);
+        e = max(abs(mSpec(:) - mA0(:)));
+        assert(e < tol, '[%s] IBP parity FAILED: max|spec-alpha0| = %.3e (tol %.1e)', names{ni}, e, tol);
+        fprintf('[%s] IBP parity OK (max diff %.2e)\n', names{ni}, e);
+
+        % ---- rootBounds-reuse path: build root bounds from the IBP forward, compare ----
+        rb = i_root_bounds(ops, lb, ub, reluIdx, prec);
+        mSpecR = gpu_bab_crown_spec_dag(ops, lb, ub, C, prec, {}, rb);
+        mA0R   = gpu_bab_crown_alpha_dag(ops, lb, ub, C, {}, reluIdx, prec, 0, [], rb);
+        eR = max(abs(mSpecR(:) - mA0R(:)));
+        assert(eR < tol, '[%s] rootBounds parity FAILED: %.3e', names{ni}, eR);
+        fprintf('[%s] rootBounds parity OK (max diff %.2e)\n', names{ni}, eR);
+
+        % ---- nIter>0: runs + sound-AND-no-worse than min-area (per-spec lower bound) ----
+        mOpt = gpu_bab_crown_alpha_dag(ops, lb, ub, C, {}, reluIdx, prec, 15, 0.2, []);
+        worst0  = min(mA0, [], 1);                    % the certified (worst-spec) margin per node
+        worstOpt = min(mOpt, [], 1);
+        gain = min(worstOpt - worst0);
+        % SOUNDNESS: keep-best guarantees alpha-opt is never worse than min-area.
+        assert(all(worstOpt >= worst0 - 1e-7), ...
+            '[%s] alpha-opt REGRESSED below min-area (unsound keep-best?): %.3e', names{ni}, gain);
+        % ROUTE-B REGRESSION GUARD: with the traceable conv/pool backward, dlgradient must reach
+        % alpha and IMPROVE the bound on these nets (gain>0). gain==0 => the autodiff tape broke
+        % again (extractdata / indexed-assign crept back in) -> optimizer is a silent no-op.
+        assert(gain > 1e-4, ...
+            '[%s] alpha-opt did NOT improve (gain %.3e) -- autodiff tape likely severed (Route B).', names{ni}, gain);
+        fprintf('[%s] nIter>0 sound + OPTIMIZING OK (worst-margin gain %.3e)\n', names{ni}, gain);
+    end
+
+    % ============ BETA soundness (Monte Carlo) — the -150 gate for the BaB path ============
+    % With BaB split fixings, alpha_dag optimizes [alpha;beta]. The returned bound MUST be a valid
+    % lower bound on min C*f(x) over inputs x in the box that SATISFY the split constraints. Sample
+    % such inputs, eval the true margin C*f, and assert bound <= the MC true-min (mB <= true_min <=
+    % MC_min). A violation means the beta dual is mis-implemented (wrong sign/neuron) -> false robust.
+    for ni = 1:numel(nets)
+        net = nets{ni}; ops = net.ops; reluIdx = net.reluIdx; n = net.nIn; nOut = net.nOut;
+        c = randn(n,1); rad = 0.4*(0.5+rand(n,1)); lb = c-rad; ub = c+rad; C = randn(3, nOut);
+        [fixings, x0] = i_make_fixings(ops, lb, ub, reluIdx, prec);
+        mB = gpu_bab_crown_alpha_dag(ops, lb, ub, C, fixings, reluIdx, prec, 20, 0.1, []); % alpha+beta
+        mB = min(mB, [], 2);                                  % per-spec bound (B=1)
+        nMC = 40000; X = [x0, lb + (ub - lb) .* rand(n, nMC-1)];   % witness x0 -> >=1 feasible sample
+        [Y, Z] = i_forward(ops, X, reluIdx);
+        ok = i_satisfies(Z, fixings, reluIdx, 0);
+        assert(any(ok), '[beta %d] no MC sample satisfied the split fixings (bad test setup)', ni);
+        minTrue = min(C * Y(:, ok), [], 2);                  % per-spec true min over feasible samples
+        viol = max(mB - minTrue);                            % must be <= 0 (sound)
+        assert(viol <= 1e-6, '[beta %d] BETA UNSOUND: bound exceeds MC true-min by %.3e', ni, viol);
+        fprintf('[beta soundness %d] OK (bound <= MC true-min; slack %.3e; %d/%d feasible)\n', ...
+            ni, min(minTrue - mB), sum(ok), nMC);
+    end
+
+    fprintf('\nALL PARITY + BETA-SOUNDNESS TESTS PASSED\n');
+end
+
+% =====================================================================================
+function rb = i_root_bounds(ops, lb, ub, reluIdx, prec)
+% Pack a rootBounds struct (per-relu preL/preU, dim_k x 1) from the IBP forward over the full
+% box -- a valid (loose) "tight" bound for the reuse-path parity check.
+    nOps = numel(ops);
+    cl = cell(nOps+1,1); cu = cell(nOps+1,1);
+    cl{1} = cast(lb(:,1), prec); cu{1} = cast(ub(:,1), prec);
+    preL = cell(nOps,1); preU = cell(nOps,1);
+    for k = 1:nOps
+        op = ops{k};
+        if strcmp(op.type,'add')
+            a = op.inputs(1)+1; b = op.inputs(2)+1;
+            cl{k+1} = cl{a}+cl{b}; cu{k+1} = cu{a}+cu{b}; continue;
+        end
+        s = op.src+1; l = cl{s}; u = cu{s};
+        switch op.type
+            case 'affine'
+                W = op.W; bb = op.b(:); Wp = max(W,0); Wn = min(W,0);
+                cl{k+1} = Wp*l + Wn*u + bb; cu{k+1} = Wp*u + Wn*l + bb;
+            case 'conv'
+                [cl{k+1}, cu{k+1}] = i_conv_ibp_local(op, l, u, prec);
+            case 'normaffine'
+                sf = i_bcast(op.scale, op.shape); tf = i_bcast(op.shift, op.shape);
+                pos = sf>=0;
+                cl{k+1} = (sf.*l).*pos + (sf.*u).*(~pos) + tf;
+                cu{k+1} = (sf.*u).*pos + (sf.*l).*(~pos) + tf;
+            case 'avgpool'
+                [cl{k+1}, cu{k+1}] = i_avgpool_ibp_local(op, l, u, prec);
+            case 'relu'
+                preL{k} = l; preU{k} = u; cl{k+1} = max(l,0); cu{k+1} = max(u,0);
+        end
+    end
+    rb = struct('preL', {preL}, 'preU', {preU});
+end
+
+% ---- synthetic nets (hand-built ops; shapes verified consistent with dlconv) -------------
+function net = i_net_chain()
+    ops = {};
+    ops{end+1} = i_conv([4 4 2], 3, 3, [1 1], [1 1 1 1], 0);     % op1: [4 4 2]->[4 4 3]
+    ops{end+1} = struct('type','relu','src',1);                  % op2
+    ops{end+1} = i_avgpool([4 4 3], [2 2], 2);                   % op3: ->[2 2 3]
+    ops{end+1} = i_affine(5, prod([2 2 3]), 3);                  % op4: 12->5
+    net = struct('ops', {ops}, 'reluIdx', 2, 'nIn', prod([4 4 2]), 'nOut', 5);
+end
+
+function net = i_net_residual()
+    ops = {};
+    ops{end+1} = i_normaffine([4 4 2], 0);                        % op1
+    ops{end+1} = i_conv([4 4 2], 3, 3, [1 1], [1 1 1 1], 1);      % op2: ->[4 4 3]
+    ops{end+1} = struct('type','relu','src',2);                  % op3
+    ops{end+1} = i_conv([4 4 3], 3, 3, [1 1], [1 1 1 1], 3);      % op4: ->[4 4 3]
+    ops{end+1} = struct('type','add','inputs',[3 4],'shape',[4 4 3],'src',3); % op5: op3+op4
+    ops{end+1} = struct('type','relu','src',5);                  % op6
+    ops{end+1} = i_affine(5, prod([4 4 3]), 6);                  % op7: 48->5
+    net = struct('ops', {ops}, 'reluIdx', [3 6], 'nIn', prod([4 4 2]), 'nOut', 5);
+end
+
+function op = i_conv(inShape, fh, Cout, stride, pad, src)
+    Cin = inShape(3);
+    W = 0.3*randn(fh, fh, Cin, Cout); b = 0.1*randn(1,1,Cout);
+    Hout = floor((inShape(1)+pad(1)+pad(2)-fh)/stride(1)+1);
+    Wout = floor((inShape(2)+pad(3)+pad(4)-fh)/stride(2)+1);
+    op = struct('type','conv','W',W,'b',b,'stride',stride,'pad',pad,'dil',[1 1], ...
+                'inShape',inShape,'outShape',[Hout Wout Cout],'src',src);
+end
+function op = i_avgpool(inShape, pool, src)
+    Hout = floor(inShape(1)/pool(1)); Wout = floor(inShape(2)/pool(2));
+    op = struct('type','avgpool','pool',pool,'stride',pool,'pad',[0 0 0 0], ...
+                'inShape',inShape,'outShape',[Hout Wout inShape(3)],'src',src);
+end
+function op = i_affine(nOut, nIn, src)
+    op = struct('type','affine','W',0.3*randn(nOut,nIn),'b',0.1*randn(nOut,1),'src',src);
+end
+function op = i_normaffine(shape, src)
+    C = shape(3);
+    op = struct('type','normaffine','scale',0.5+rand(1,1,C),'shift',0.2*randn(1,1,C),'shape',shape,'src',src);
+end
+
+% ---- local IBP helpers for i_root_bounds (mirror the engine's) ---------------------------
+function [olb, oub] = i_conv_ibp_local(op, lb, ub, prec)
+    ish = op.inShape; osh = op.outShape; B = size(lb,2);
+    W = cast(op.W, prec); Wp = max(W,0); Wn = min(W,0);
+    bb = reshape(cast(op.b(:), prec), [1 1 osh(3)]);
+    L4 = dlarray(reshape(lb, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    U4 = dlarray(reshape(ub, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    pad2 = [op.pad(1) op.pad(3); op.pad(2) op.pad(4)];
+    args = {'Stride', op.stride, 'Padding', pad2, 'DilationFactor', op.dil};
+    Lo = dlconv(L4, Wp, bb, args{:}) + dlconv(U4, Wn, 0, args{:});
+    Hi = dlconv(U4, Wp, bb, args{:}) + dlconv(L4, Wn, 0, args{:});
+    olb = reshape(extractdata(Lo), [prod(osh) B]); oub = reshape(extractdata(Hi), [prod(osh) B]);
+end
+function [olb, oub] = i_avgpool_ibp_local(op, lb, ub, prec)
+    ish = op.inShape; osh = op.outShape; B = size(lb,2); kh = op.pool(1); kw = op.pool(2);
+    L4 = reshape(cast(lb,prec), [ish(1) ish(2) ish(3) B]); U4 = reshape(cast(ub,prec), [ish(1) ish(2) ish(3) B]);
+    olb = zeros([osh prod(1) B]); olb = reshape(i_pm(L4,osh,kh,kw,op.stride), [prod(osh) B]);
+    oub = reshape(i_pm(U4,osh,kh,kw,op.stride), [prod(osh) B]);
+end
+function Y = i_pm(X, osh, kh, kw, stride)
+    B = size(X,4); Y = zeros([osh(1) osh(2) osh(3) B], 'like', X);
+    for oh=1:osh(1), for ow=1:osh(2)
+        rh=(oh-1)*stride(1)+(1:kh); rw=(ow-1)*stride(2)+(1:kw);
+        Y(oh,ow,:,:)=mean(mean(X(rh,rw,:,:),1),2);
+    end, end
+end
+function v = i_bcast(x, sh)
+    v = reshape(zeros([sh(1) sh(2) sh(3)]) + x, [], 1);
+end
+
+% ---- beta-soundness helpers: split fixings + exact forward eval + constraint satisfaction -----
+function [fixings, x0] = i_make_fixings(ops, lb, ub, reluIdx, prec)
+% Fix up to 4 unstable neurons of the FIRST relu layer to a WITNESS point x0's actual signs, so the
+% split region is guaranteed non-empty (x0 satisfies it). IBP-unstable != forward-straddling, so
+% fixing by a real eval (not by sign alternation) is what keeps the constraints feasible.
+    rb = i_root_bounds(ops, lb, ub, reluIdx, prec);
+    nOps = numel(ops); fixings = cell(nOps,1);
+    k = reluIdx(1); l = rb.preL{k};
+    u = rb.preU{k};
+    uns = find(l < 0 & u > 0);
+    x0 = (lb + ub) / 2;
+    [~, Z0] = i_forward(ops, x0, reluIdx);
+    z0 = Z0{k};
+    fx = zeros(numel(l), 1, prec);
+    for i = 1:min(4, numel(uns))
+        j = uns(i); s = sign(z0(j)); if s == 0, s = 1; end
+        fx(j) = s;                              % fix to x0's actual sign -> x0 satisfies it
+    end
+    fixings{k} = fx;
+end
+
+function [Y, Z] = i_forward(ops, X, reluIdx) %#ok<INUSD>
+% Exact forward eval of the op list on columns of X (n x m). Y = output (nOut x m); Z{k} = the
+% pre-activation at each relu op (for the split-constraint check).
+    nOps = numel(ops); co = cell(nOps+1,1); co{1} = X; Z = cell(nOps,1);
+    for k = 1:nOps
+        op = ops{k};
+        if strcmp(op.type,'add')
+            a = op.inputs(1)+1; b = op.inputs(2)+1; co{k+1} = co{a} + co{b}; continue;
+        end
+        x = co{op.src+1};
+        switch op.type
+            case 'affine',     co{k+1} = op.W*x + op.b(:);
+            case 'conv',       co{k+1} = i_conv_fwd(op, x);
+            case 'normaffine', co{k+1} = i_bcast(op.scale,op.shape).*x + i_bcast(op.shift,op.shape);
+            case 'avgpool',    co{k+1} = i_avgpool_fwd(op, x);
+            case 'relu',       Z{k} = x; co{k+1} = max(x,0);
+        end
+    end
+    Y = co{nOps+1};
+end
+
+function y = i_conv_fwd(op, x)
+    ish=op.inShape; osh=op.outShape; m=size(x,2); bb=reshape(op.b(:),[1 1 osh(3)]);
+    X4=dlarray(reshape(x,[ish(1) ish(2) ish(3) m]),'SSCB');
+    pad2=[op.pad(1) op.pad(3); op.pad(2) op.pad(4)];
+    Y4=dlconv(X4,op.W,bb,'Stride',op.stride,'Padding',pad2,'DilationFactor',op.dil);
+    y=reshape(extractdata(Y4),[prod(osh) m]);
+end
+
+function y = i_avgpool_fwd(op, x)
+    ish=op.inShape; osh=op.outShape; m=size(x,2); kh=op.pool(1); kw=op.pool(2);
+    X4=reshape(x,[ish(1) ish(2) ish(3) m]); Y=zeros([osh(1) osh(2) osh(3) m]);
+    for oh=1:osh(1)
+        for ow=1:osh(2)
+            rh=(oh-1)*op.stride(1)+(1:kh); rw=(ow-1)*op.stride(2)+(1:kw);
+            Y(oh,ow,:,:)=mean(mean(X4(rh,rw,:,:),1),2);
+        end
+    end
+    y=reshape(Y,[prod(osh) m]);
+end
+
+function ok = i_satisfies(Z, fixings, reluIdx, tol)
+% Logical (1 x m): each sample satisfies every split constraint (active fix z>=0, inactive z<=0).
+    m = size(Z{reluIdx(1)}, 2); ok = true(1,m);
+    for r = 1:numel(reluIdx)
+        k = reluIdx(r);
+        if isempty(fixings) || numel(fixings)<k || isempty(fixings{k}), continue; end
+        fx = fixings{k}(:,1); z = Z{k};
+        if any(fx==1),  ok = ok & all(z(fx==1,:)  >= -tol, 1); end
+        if any(fx==-1), ok = ok & all(z(fx==-1,:) <=  tol, 1); end
+    end
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
@@ -1,4 +1,7 @@
-function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
+function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
+%   alphaOut (5th out): the optimized per-relu lower slopes as cell(nOps,1) of dim_k x 1 vectors
+%     (column 1 of the batch). Pass this as gpu_bab_crown_spec_dag's alphaCell to bound a whole
+%     BaB frontier with these fixed root slopes -- AMORTIZED alpha-CROWN (no per-node autodiff).
 % GPU_BAB_CROWN_ALPHA_DAG  alpha-CROWN lower bound on a linear spec C*f(x) for CONV/DAG nets.
 %   The fusion of gpu_bab_crown_alpha_fix (the FC alpha-CROWN harness) onto the full DAG
 %   backward of gpu_bab_crown_spec_dag (affine/conv/normaffine/avgpool/relu/add). It optimizes
@@ -77,6 +80,7 @@ function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_
         margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
                              pVec, reluIdx, rdims, offsets, nP, B, nSpec);
         margins = i_g(margins);
+        alphaOut = i_alpha_cell(pVec, nP, nOps, reluIdx, rdims, offsets);
         return;
     end
 
@@ -91,10 +95,24 @@ function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_
     bestObj = i_g(sum(min(m0,[],1), 'all')); bestVec = pVec;
     mt = zeros(2*nP, 1, precision); vt = zeros(2*nP, 1, precision);
     b1 = 0.9; b2 = 0.999; epsA = cast(1e-8, precision);
+    % WORST-SPEC gradient (the cifar-scale memory fix): the objective sum(min_spec margin) has a
+    % gradient that flows ONLY through each node's ARGMIN spec, so the autodiff tape needs just that
+    % ONE spec row per node (1 x featureMap x B) instead of all nSpec -> ~nSpec x less memory ->
+    % large frontier with full alpha+beta. For small nSpec (cheap) keep the exact full gradient.
+    useWorst = (nSpec > 16);
     try
         for it = 1:nIter
-            [~, grad] = dlfeval(@(p) i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, ...
-                                x_lb, x_ub, C, precision, p, reluIdx, rdims, offsets, nP, B, nSpec), pVec);
+            if useWorst
+                mF = i_g(i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                                    pVec, reluIdx, rdims, offsets, nP, B, nSpec));   % all specs, NO tape
+                [~, wIdx] = min(mF, [], 1);                       % worst spec per node (1 x B)
+                Cw = i_worst_C(C, wIdx, precision);              % 1 x nOut x B (per-node worst row)
+                [~, grad] = dlfeval(@(p) i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, ...
+                                    x_lb, x_ub, Cw, precision, p, reluIdx, rdims, offsets, nP, B, 1), pVec);
+            else
+                [~, grad] = dlfeval(@(p) i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, ...
+                                    x_lb, x_ub, C, precision, p, reluIdx, rdims, offsets, nP, B, nSpec), pVec);
+            end
             g = extractdata(grad);
             if ~any(g(:)), break; end                  % zero gradient (tape didn't reach params) -> stop
             mt = b1*mt + (1-b1)*g;
@@ -119,6 +137,28 @@ function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_
     margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
                          bestVec, reluIdx, rdims, offsets, nP, B, nSpec);
     margins = i_g(margins);
+    alphaOut = i_alpha_cell(bestVec, nP, nOps, reluIdx, rdims, offsets);
+end
+
+% =====================================================================================
+function ac = i_alpha_cell(pVec, nP, nOps, reluIdx, rdims, offsets)
+% Extract the optimized alpha (first nP entries of [alpha;beta]) as a per-relu cell(nOps,1) of
+% dim_k x 1 column-1 slopes, for reuse as gpu_bab_crown_spec_dag's fixed alphaCell.
+    v = i_g(pVec(1:nP));
+    ac = cell(nOps, 1);
+    for r = 1:numel(reluIdx)
+        k = reluIdx(r);
+        a = reshape(v(offsets(r)+1 : offsets(r+1)), rdims(r), []);   % dim_k x B
+        ac{k} = a(:, 1);                                             % root: B=1 (or first column)
+    end
+end
+
+% =====================================================================================
+function Cw = i_worst_C(C, wIdx, precision)
+% Per-node worst spec for the memory-efficient gradient: 1 x nOut x B, where column b is the
+% wIdx(b)-th row of the full spec C (the argmin spec for node b).
+    nOut = size(C, 2); B = numel(wIdx);
+    Cw = reshape(cast(C(wIdx, :), precision).', 1, nOut, B);   % (B x nOut).' = nOut x B -> 1 x nOut x B
 end
 
 % =====================================================================================
@@ -136,7 +176,12 @@ function margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_
 % op-for-op identical to gpu_bab_crown_spec_dag.
     nOps = numel(ops); n = size(x_lb, 1);
     skipA = cell(nOps, 1);
-    skipA{nOps} = repmat(cast(C, precision), 1, 1, B);
+    if ndims(C) == 3
+        skipA{nOps} = cast(C, precision);            % per-NODE spec (nSpec x nOut x B), e.g. worst-spec
+    else
+        skipA{nOps} = repmat(cast(C, precision), 1, 1, B);   % shared spec
+    end
+    nSpec = size(skipA{nOps}, 1);                    % derive (1 for worst-spec gradient, else full)
     d = zeros(nSpec, B, precision);
     inputSkipA = [];
     for k = nOps:-1:1

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
@@ -1,4 +1,4 @@
-function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
+function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds, alphaInit)
 %   alphaOut (5th out): the optimized per-relu lower slopes as cell(nOps,1) of dim_k x 1 vectors
 %     (column 1 of the batch). Pass this as gpu_bab_crown_spec_dag's alphaCell to bound a whole
 %     BaB frontier with these fixed root slopes -- AMORTIZED alpha-CROWN (no per-node autodiff).
@@ -44,6 +44,7 @@ function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops
     if nargin < 8 || isempty(nIter), nIter = 20; end
     if nargin < 9 || isempty(lr), lr = 0.2; end
     if nargin < 10, rootBounds = []; end
+    if nargin < 11, alphaInit = {}; end             % optional per-relu warm-start slopes (dim_k x 1)
 
     B = size(x_lb, 2); nSpec = size(C, 1); nOps = numel(ops);
 
@@ -61,7 +62,15 @@ function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops
         k = reluIdx(r);
         a = zeros(size(preL{k}), precision);
         uns = unsM{k} > 0;
-        a(uns) = cast(preU{k}(uns) >= -preL{k}(uns), precision);   % min-area binary {0,1}
+        if ~isempty(alphaInit) && numel(alphaInit) >= k && ~isempty(alphaInit{k})
+            % WARM START: seed unstable slopes from the supplied (e.g. amortized root) alpha. keep-best
+            % then floors the bound at THIS init, so few PGA iters refine it instead of climbing from
+            % min-area. Sound for any alpha in [0,1] (clamped); a better init only helps convergence.
+            ai = repmat(cast(alphaInit{k}(:), precision), 1, size(preL{k}, 2));   % dim_k x B
+            a(uns) = min(max(ai(uns), 0), 1);
+        else
+            a(uns) = cast(preU{k}(uns) >= -preL{k}(uns), precision);   % min-area binary {0,1}
+        end
         a0(offsets(r)+1 : offsets(r+1)) = a(:);
         % BETA: per-node split-constraint sign (s_i = +1 active fix / -1 inactive fix / 0 free).
         % beta is a free dual ONLY on fixed neurons -> at the root (no fixings) fixedMask=0 ->

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
@@ -1,0 +1,379 @@
+function [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings, reluIdx, precision, nIter, lr, rootBounds)
+% GPU_BAB_CROWN_ALPHA_DAG  alpha-CROWN lower bound on a linear spec C*f(x) for CONV/DAG nets.
+%   The fusion of gpu_bab_crown_alpha_fix (the FC alpha-CROWN harness) onto the full DAG
+%   backward of gpu_bab_crown_spec_dag (affine/conv/normaffine/avgpool/relu/add). It optimizes
+%   the unstable-ReLU LOWER slopes (alpha in [0,1]) to MAXIMIZE the certified margin, exactly
+%   like the FC version, but the backward routes through conv/pool/normaffine/add adjoints so it
+%   works for cifar-style conv resnets (where the FC-only i_aback mis-bounds any non-affine op).
+%
+%   [margins, unstable, preL, preU] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, fixings,
+%                                       reluIdx, precision, nIter, lr, rootBounds)
+%     ops/x_lb/x_ub/C/fixings/rootBounds : as gpu_bab_crown_spec_dag (rootBounds STRONGLY
+%         preferred -- tight intermediate bounds; the loose DAG IBP forward is the fallback).
+%     reluIdx  : indices of the relu ops (the alpha-carrying ops).
+%     nIter    : alpha-CROWN projected-gradient-ascent iterations. nIter<=0 -> FIXED min-area
+%                slope == gpu_bab_crown_spec_dag bound-for-bound (the soundness/parity gate).
+%     margins  : nSpec-by-B optimized lower bound on C*f over each node's clamped box.
+%
+%   SOUNDNESS (sound-or-unknown; NEVER a false robust):
+%     * alpha enters ONLY the lower slope al = actM + unsM.*alpha, projected to [0,1] every step.
+%       Any al in [0,1] is a valid lower ReLU relaxation (ReLU(z) >= al*z on [l,u]); the upper
+%       line (au,bu) and the active/stable units are FIXED constants -> any in-range alpha gives
+%       a sound lower bound. The optimizer only SEARCHES alpha; it never weakens the bound.
+%     * au/bu/actM/unsM and the intermediate bounds preL/preU are PRECOMPUTED constants (detached
+%       from the alpha tape) -- alpha can never leak back into the bounds (no joint-alpha).
+%     * keep-best + a final re-evaluation at bestVec means the returned margin is >= the min-area
+%       (spec_dag) margin: alpha-CROWN is sound-AND-no-worse, can only help or no-op.
+%     * the conv/normaffine/avgpool/add adjoints are EXACT (linear, no relaxation), so alpha is
+%       the only free variable. maxpool is unsupported and ERRORS (caller falls back, sound).
+%
+%   PARITY GATE: at nIter<=0 (alpha == min-area), the backward is OP-FOR-OP identical to
+%   gpu_bab_crown_spec_dag -- gpu_bab_alpha_dag_parity_test asserts bound-for-bound equality
+%   before this is ever trusted for a 'robust' emit.
+%
+%   NOTE (Phase 2 / autodiff): for nIter>0 the PGA loop needs the backward to be dlarray-
+%   traceable so dlgradient reaches alpha. i_conv_backward/i_avgpool_backward currently extract
+%   to numeric (tape-break) -> gradients vanish through conv and the optimizer no-ops (SOUND, no
+%   improvement). Making those adjoints traceable is the Phase-2 work; until then nIter>0 returns
+%   the min-area bound (keep-best), which is still sound.
+
+    if nargin < 7 || isempty(precision), precision = 'single'; end
+    if nargin < 8 || isempty(nIter), nIter = 20; end
+    if nargin < 9 || isempty(lr), lr = 0.2; end
+    if nargin < 10, rootBounds = []; end
+
+    B = size(x_lb, 2); nSpec = size(C, 1); nOps = numel(ops);
+
+    % ---- per-relu pre-activation bounds (clamped) + the FIXED upper-line relaxation (au,bu) and
+    % active/unstable masks. rootBounds reuse (tight) preferred; else full DAG IBP forward. ----
+    [preL, preU, actM, unsM, auC, buC, unstable] = i_dag_relu_bounds(ops, x_lb, x_ub, precision, fixings, rootBounds);
+
+    % ---- flat alpha vector (min-area init) ----
+    rdims = arrayfun(@(k) size(preL{k},1), reluIdx);
+    offsets = [0; cumsum(rdims(:) * B)];
+    nP = offsets(end);
+    a0 = zeros(nP, 1, precision);
+    fixSign = cell(nOps, 1); fixedMask = zeros(nP, 1, precision);
+    for r = 1:numel(reluIdx)
+        k = reluIdx(r);
+        a = zeros(size(preL{k}), precision);
+        uns = unsM{k} > 0;
+        a(uns) = cast(preU{k}(uns) >= -preL{k}(uns), precision);   % min-area binary {0,1}
+        a0(offsets(r)+1 : offsets(r+1)) = a(:);
+        % BETA: per-node split-constraint sign (s_i = +1 active fix / -1 inactive fix / 0 free).
+        % beta is a free dual ONLY on fixed neurons -> at the root (no fixings) fixedMask=0 ->
+        % beta stays 0 -> this reduces EXACTLY to pure alpha (parity gate preserved).
+        if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
+            fs = cast(fixings{k}, precision);
+        else
+            fs = zeros(size(preL{k}), precision);
+        end
+        fixSign{k} = fs;
+        fixedMask(offsets(r)+1 : offsets(r+1)) = cast(fs(:) ~= 0, precision);
+    end
+    pVec = dlarray([a0; zeros(nP, 1, precision)]);   % [alpha; beta], alpha=min-area, beta=0
+
+    if nIter <= 0
+        margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                             pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+        margins = i_g(margins);
+        return;
+    end
+
+    % ---- projected gradient ascent over [alpha; beta] (Adam, keep-best) ----
+    % SOUNDNESS: the bound is max_{alpha in[0,1], beta>=0} min_x [C*f(x) - sum beta_i s_i z_i] over
+    % the clamped box -- a valid lower bound for ANY alpha in [0,1], beta>=0 (sound ReLU relaxation
+    % + weak Lagrangian duality on the split constraints). keep-best + the final re-eval at bestVec
+    % mean the returned bound is >= the min-area/beta=0 bound regardless of the optimizer; a severed
+    % autodiff tape is CAUGHT -> min-area fallback (sound, no improvement), never error/unsound.
+    m0 = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                    pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+    bestObj = i_g(sum(min(m0,[],1), 'all')); bestVec = pVec;
+    mt = zeros(2*nP, 1, precision); vt = zeros(2*nP, 1, precision);
+    b1 = 0.9; b2 = 0.999; epsA = cast(1e-8, precision);
+    try
+        for it = 1:nIter
+            [~, grad] = dlfeval(@(p) i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, ...
+                                x_lb, x_ub, C, precision, p, reluIdx, rdims, offsets, nP, B, nSpec), pVec);
+            g = extractdata(grad);
+            if ~any(g(:)), break; end                  % zero gradient (tape didn't reach params) -> stop
+            mt = b1*mt + (1-b1)*g;
+            vt = b2*vt + (1-b2)*g.^2;
+            mhat = mt / (1 - b1^it); vhat = vt / (1 - b2^it);
+            v = extractdata(pVec) - lr * mhat ./ (sqrt(vhat) + epsA);
+            v(1:nP)      = max(min(v(1:nP), 1), 0);            % alpha in [0,1]
+            v(nP+1:end)  = max(v(nP+1:end), 0) .* fixedMask;   % beta >= 0, only on fixed neurons
+            pVec = dlarray(v);
+            m = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                           pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+            obj = i_g(sum(min(m,[],1), 'all'));
+            if obj > bestObj, bestObj = obj; bestVec = pVec; end
+        end
+    catch ME
+        if ~any(strcmp(ME.identifier, {'MATLAB:dlarray:GradientNotTraced', ...
+                'deep:dlarray:ValueToDiffNotDlarray', 'MATLAB:dlarray:NotDifferentiable'}))
+            % a real error (not the known tape-break) -> keep-best already holds the min-area
+            % bound; swallow to stay sound-or-unknown rather than throw out of the precheck.
+        end
+    end
+    margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                         bestVec, reluIdx, rdims, offsets, nP, B, nSpec);
+    margins = i_g(margins);
+end
+
+% =====================================================================================
+function [loss, grad] = i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec)
+    margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+    loss = -sum(min(margins, [], 1), 'all');
+    grad = dlgradient(loss, pVec);
+end
+
+% =====================================================================================
+function margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, pVec, reluIdx, rdims, offsets, nP, B, nSpec)
+% Backward CROWN over the FULL DAG (spec_dag's backward), with the unstable ReLU LOWER slope
+% supplied by alpha (al = actM + unsM.*alpha) AND the beta split-dual subtracted at each ReLU
+% (-beta_k*s_k on z_k). au/bu are precomputed constants. With alpha=min-area and beta=0 this is
+% op-for-op identical to gpu_bab_crown_spec_dag.
+    nOps = numel(ops); n = size(x_lb, 1);
+    skipA = cell(nOps, 1);
+    skipA{nOps} = repmat(cast(C, precision), 1, 1, B);
+    d = zeros(nSpec, B, precision);
+    inputSkipA = [];
+    for k = nOps:-1:1
+        A = skipA{k};
+        if isempty(A), continue; end
+        skipA{k} = [];
+        op = ops{k};
+        if strcmp(op.type, 'add')
+            for ii = 1:numel(op.inputs)
+                s = op.inputs(ii);
+                if s == 0
+                    if isempty(inputSkipA), inputSkipA = A; else, inputSkipA = inputSkipA + A; end
+                elseif isempty(skipA{s}), skipA{s} = A;
+                else, skipA{s} = skipA{s} + A;
+                end
+            end
+            continue;
+        end
+        switch op.type
+            case 'affine'
+                W = cast(op.W, precision); bb = cast(op.b(:), precision);
+                d = d + reshape(pagemtimes(A, bb), nSpec, B);
+                A = pagemtimes(A, W);
+            case 'conv'
+                [A, d] = i_conv_backward(A, d, op, precision);
+            case 'normaffine'
+                sf = i_bcast_flat(op.scale, op.shape, precision);
+                tf = i_bcast_flat(op.shift, op.shape, precision);
+                d = d + reshape(pagemtimes(A, tf), nSpec, B);
+                A = A .* reshape(sf, 1, [], 1);
+            case 'avgpool'
+                [A, d] = i_avgpool_backward(A, d, op, precision);
+            case 'relu'
+                r = find(reluIdx == k, 1);
+                dim = rdims(r);
+                alpha_k = reshape(pVec(offsets(r)+1 : offsets(r+1)), dim, B);
+                beta_k  = reshape(pVec(nP + offsets(r)+1 : nP + offsets(r+1)), dim, B);
+                au = auC{k}; bu = buC{k};
+                al = actM{k} + unsM{k} .* alpha_k;
+                Apos = max(A, 0); Aneg = min(A, 0);
+                d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);
+                A = Apos .* reshape(al, 1, dim, B) + Aneg .* reshape(au, 1, dim, B);
+                % BETA split-dual: subtract beta_k*s_k from the coefficient on z_k (all spec rows).
+                % Zero at the root / unfixed neurons (beta=0 there) -> reduces to pure alpha.
+                A = A - reshape(beta_k .* fixSign{k}, 1, dim, B);
+            otherwise
+                error('gpu_bab_crown_alpha_dag:op', ...
+                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add only).', op.type);
+        end
+        s = op.src;
+        if s == 0
+            if isempty(inputSkipA), inputSkipA = A; else, inputSkipA = inputSkipA + A; end
+        elseif isempty(skipA{s}), skipA{s} = A;
+        else, skipA{s} = skipA{s} + A;
+        end
+    end
+    if isempty(inputSkipA)
+        margins = d; return;
+    end
+    A = inputSkipA;
+    Apos = max(A, 0); Aneg = min(A, 0);
+    lbcol = reshape(cast(x_lb, precision), n, 1, B);
+    ubcol = reshape(cast(x_ub, precision), n, 1, B);
+    margins = reshape(pagemtimes(Apos, lbcol), nSpec, B) ...
+            + reshape(pagemtimes(Aneg, ubcol), nSpec, B) + d;
+end
+
+% =====================================================================================
+function [preL, preU, actM, unsM, auC, buC, unstable] = i_dag_relu_bounds(ops, x_lb, x_ub, precision, fixings, rootBounds)
+% Per-relu (clamped) pre-activation bounds + the fixed upper-line relaxation (au,bu) and the
+% active/unstable masks. rootBounds-reuse (tight) preferred; else the full DAG IBP forward.
+    nOps = numel(ops); B = size(x_lb, 2);
+    preL = cell(nOps,1); preU = cell(nOps,1);
+    actM = cell(nOps,1); unsM = cell(nOps,1);
+    auC = cell(nOps,1);  buC = cell(nOps,1); unstable = cell(nOps,1);
+
+    if isempty(rootBounds)
+        % full DAG IBP forward (spec_dag's forward), clamped per node, caching every op's bounds
+        cl = cell(nOps+1,1); cu = cell(nOps+1,1);
+        cl{1} = cast(x_lb, precision); cu{1} = cast(x_ub, precision);
+        for k = 1:nOps
+            op = ops{k};
+            if strcmp(op.type, 'add')
+                a = op.inputs(1)+1; b = op.inputs(2)+1;
+                cl{k+1} = cl{a} + cl{b}; cu{k+1} = cu{a} + cu{b}; continue;
+            end
+            s = op.src + 1; lb = cl{s}; ub = cu{s};
+            switch op.type
+                case 'affine'
+                    W = cast(op.W, precision); bb = cast(op.b(:), precision);
+                    Wp = max(W,0); Wn = min(W,0);
+                    cl{k+1} = Wp*lb + Wn*ub + bb; cu{k+1} = Wp*ub + Wn*lb + bb;
+                case 'conv'
+                    [cl{k+1}, cu{k+1}] = i_conv_ibp(op, lb, ub, precision);
+                case 'normaffine'
+                    sf = i_bcast_flat(op.scale, op.shape, precision);
+                    tf = i_bcast_flat(op.shift, op.shape, precision);
+                    pos = sf >= 0;
+                    cl{k+1} = (sf.*lb).*pos + (sf.*ub).*(~pos) + tf;
+                    cu{k+1} = (sf.*ub).*pos + (sf.*lb).*(~pos) + tf;
+                case 'avgpool'
+                    [cl{k+1}, cu{k+1}] = i_avgpool_ibp(op, lb, ub, precision);
+                case 'relu'
+                    if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
+                        fx = fixings{k};
+                        lb(fx == 1)  = max(lb(fx == 1),  0);
+                        ub(fx == -1) = min(ub(fx == -1), 0);
+                    end
+                    [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(lb, ub, precision);
+                    cl{k+1} = max(lb,0); cu{k+1} = max(ub,0);
+                otherwise
+                    error('gpu_bab_crown_alpha_dag:op', 'Unsupported op "%s".', op.type);
+            end
+        end
+    else
+        if ~isstruct(rootBounds) || ~all(isfield(rootBounds, {'preL','preU'}))
+            error('gpu_bab_crown_alpha_dag:rootBounds', 'rootBounds must have fields preL,preU.');
+        end
+        tmpl = cast(x_lb(1), precision);
+        for k = 1:nOps
+            tk = ops{k}.type;
+            if strcmp(tk, 'relu')
+                l = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
+                u = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
+                if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
+                    fx = fixings{k};
+                    l(fx == 1)  = max(l(fx == 1),  0);
+                    u(fx == -1) = min(u(fx == -1), 0);
+                end
+                [preL{k}, preU{k}, actM{k}, unsM{k}, auC{k}, buC{k}, unstable{k}] = i_relu_pre(l, u, precision);
+            elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add'}))
+                error('gpu_bab_crown_alpha_dag:op', 'Unsupported op "%s".', tk);
+            end
+        end
+    end
+end
+
+function [pl, pu, actM, unsM, au, bu, uns] = i_relu_pre(l, u, precision)
+% Clamped pre-activation bounds + the FIXED upper-line au*z+bu and active/unstable masks. The
+% lower slope is left to alpha (al = act + uns*alpha). Matches spec_dag's i_relu_relax au/bu and
+% alpha_fix's min-area init, so alpha=min-area reproduces spec_dag exactly.
+    pl = l; pu = u;
+    act = (l >= 0); uns = (l < 0) & (u > 0);
+    au = zeros(size(l), precision); bu = zeros(size(l), precision);
+    au(act) = 1;
+    dn = u(uns) - l(uns);
+    au(uns) = u(uns) ./ dn; bu(uns) = -au(uns) .* l(uns);
+    actM = cast(act, precision); unsM = cast(uns, precision);
+end
+
+% ---- exact linear adjoints + interval forwards (duplicated from gpu_bab_crown_spec_dag; kept
+% local so the alpha-dag is self-contained and spec_dag stays untouched) -------------------
+function [olb, oub] = i_conv_ibp(op, lb, ub, precision)
+    ish = op.inShape; osh = op.outShape; B = size(lb,2);
+    W = cast(op.W, precision); Wp = max(W,0); Wn = min(W,0);
+    bb = reshape(cast(op.b(:), precision), [1 1 osh(3)]);
+    L4 = dlarray(reshape(lb, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    U4 = dlarray(reshape(ub, [ish(1) ish(2) ish(3) B]), 'SSCB');
+    pad2 = [op.pad(1) op.pad(3); op.pad(2) op.pad(4)];
+    args = {'Stride', op.stride, 'Padding', pad2, 'DilationFactor', op.dil};
+    Lo = dlconv(L4, Wp, bb, args{:}) + dlconv(U4, Wn, 0, args{:});
+    Hi = dlconv(U4, Wp, bb, args{:}) + dlconv(L4, Wn, 0, args{:});
+    olb = reshape(extractdata(Lo), [prod(osh) B]);
+    oub = reshape(extractdata(Hi), [prod(osh) B]);
+end
+
+function [A2, d2] = i_conv_backward(A, d, op, precision)
+% Exact CROWN backward through a conv (linear), batched over B. TRACEABLE for dlgradient:
+% A4 stays an (unformatted) dlarray, dltranspconv uses DataFormat, and the crop/pad/bias are
+% slice+cat+sum (no extractdata, no indexed-assignment-into-zeros) so alpha's gradient flows.
+    nSpec = size(A,1); B = size(A,3);
+    osh = op.outShape; ish = op.inShape; W = cast(op.W, precision);
+    Aperm = permute(A, [2 1 3]);
+    A4 = reshape(Aperm, [osh(1) osh(2) osh(3) nSpec*B]);
+    if ~isa(A4, 'dlarray'), A4 = dlarray(A4); end                 % unformatted dlarray (trace preserved)
+    Afull = dltranspconv(A4, W, 0, 'Stride', op.stride, 'Cropping', 0, ...
+                         'DilationFactor', op.dil, 'DataFormat', 'SSCB');
+    pt = op.pad(1); pl = op.pad(3);
+    hi = min(ish(1), size(Afull,1)-pt); wi = min(ish(2), size(Afull,2)-pl);
+    Ain = Afull(pt+(1:hi), pl+(1:wi), :, :);                       % traceable slice
+    if hi < ish(1) || wi < ish(2), Ain = i_zeropad_hw(Ain, ish(1), ish(2)); end
+    A2 = permute(reshape(Ain, [prod(ish) nSpec B]), [2 1 3]);
+    bc = reshape(cast(op.b(:), precision), [1 1 osh(3)]);
+    A4u = reshape(A4, [osh(1) osh(2) osh(3) nSpec B]);
+    dinc = reshape(sum(A4u .* bc, [1 2 3]), [nSpec B]);
+    d2 = d + dinc;
+end
+
+function [olb, oub] = i_avgpool_ibp(op, lb, ub, precision)
+    ish = op.inShape; osh = op.outShape; B = size(lb,2);
+    L4 = reshape(cast(lb,precision), [ish(1) ish(2) ish(3) B]);
+    U4 = reshape(cast(ub,precision), [ish(1) ish(2) ish(3) B]);
+    olb = reshape(i_pool_mean(L4, op), [prod(osh) B]);
+    oub = reshape(i_pool_mean(U4, op), [prod(osh) B]);
+end
+
+function Y = i_pool_mean(X, op)
+    osh = op.outShape; kh = op.pool(1); kw = op.pool(2); B = size(X,4);
+    Y = zeros([osh(1) osh(2) osh(3) B], 'like', X);
+    for oh = 1:osh(1)
+        for ow = 1:osh(2)
+            rh = (oh-1)*op.stride(1) + (1:kh); rw = (ow-1)*op.stride(2) + (1:kw);
+            Y(oh,ow,:,:) = mean(mean(X(rh,rw,:,:),1),2);
+        end
+    end
+end
+
+function [A2, d2] = i_avgpool_backward(A, d, op, precision)
+% Exact CROWN backward through non-overlapping avgpool (distribute A_out/(kh*kw) uniformly).
+% TRACEABLE: repelem + slice/cat (no indexed-assignment-into-zeros) so alpha's gradient flows.
+    nSpec = size(A,1); B = size(A,3); osh = op.outShape; ish = op.inShape;
+    kh = op.pool(1); kw = op.pool(2);
+    Aperm = permute(A, [2 1 3]);
+    A4 = reshape(Aperm, [osh(1) osh(2) osh(3) nSpec*B]);
+    Aup = repelem(A4, kh, kw, 1, 1) / (kh*kw);
+    hi = min(ish(1), size(Aup,1)); wi = min(ish(2), size(Aup,2));
+    Ain = Aup(1:hi, 1:wi, :, :);                                   % traceable slice
+    if hi < ish(1) || wi < ish(2), Ain = i_zeropad_hw(Ain, ish(1), ish(2)); end
+    A2 = permute(reshape(Ain, [prod(ish) nSpec B]), [2 1 3]);
+    d2 = d;
+end
+
+function Y = i_zeropad_hw(X, H, W)
+% Traceable zero-pad of an [h w c n] array up to [H W c n] (cat with 'like' zeros keeps the tape).
+    h = size(X,1); w = size(X,2);
+    if h < H, X = cat(1, X, zeros([H-h, size(X,2), size(X,3), size(X,4)], 'like', X)); end
+    w = size(X,2);
+    if w < W, X = cat(2, X, zeros([size(X,1), W-w, size(X,3), size(X,4)], 'like', X)); end
+    Y = X;
+end
+
+function v = i_bcast_flat(x, sh, precision)
+    v = reshape(zeros([sh(1) sh(2) sh(3)], precision) + cast(x, precision), [], 1);
+end
+
+function y = i_g(x)
+    if isa(x, 'dlarray'), x = extractdata(x); end
+    if isa(x, 'gpuArray'), x = gather(x); end
+    y = x;
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_alpha_dag.m
@@ -100,13 +100,13 @@ function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops
     % ONE spec row per node (1 x featureMap x B) instead of all nSpec -> ~nSpec x less memory ->
     % large frontier with full alpha+beta. For small nSpec (cheap) keep the exact full gradient.
     useWorst = (nSpec > 16);
+    if useWorst
+        [~, wIdx] = min(i_g(m0), [], 1);              % worst spec per node, found ONCE (the stable bottleneck)
+        Cw = i_worst_C(C, wIdx, precision);          % 1 x nOut x B -> the optimization + keep-best use only this
+    end
     try
         for it = 1:nIter
             if useWorst
-                mF = i_g(i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
-                                    pVec, reluIdx, rdims, offsets, nP, B, nSpec));   % all specs, NO tape
-                [~, wIdx] = min(mF, [], 1);                       % worst spec per node (1 x B)
-                Cw = i_worst_C(C, wIdx, precision);              % 1 x nOut x B (per-node worst row)
                 [~, grad] = dlfeval(@(p) i_aloss(ops, preL, actM, unsM, auC, buC, fixSign, ...
                                     x_lb, x_ub, Cw, precision, p, reluIdx, rdims, offsets, nP, B, 1), pVec);
             else
@@ -122,9 +122,17 @@ function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops
             v(1:nP)      = max(min(v(1:nP), 1), 0);            % alpha in [0,1]
             v(nP+1:end)  = max(v(nP+1:end), 0) .* fixedMask;   % beta >= 0, only on fixed neurons
             pVec = dlarray(v);
-            m = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
-                           pVec, reluIdx, rdims, offsets, nP, B, nSpec);
-            obj = i_g(sum(min(m,[],1), 'all'));
+            if useWorst
+                % cheap keep-best: score only the worst spec (1 row), not all nSpec. At init the
+                % worst spec IS the per-node argmin, so sum(worst) == sum(min) -> bestObj stays comparable.
+                mw = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, Cw, precision, ...
+                                pVec, reluIdx, rdims, offsets, nP, B, 1);
+                obj = i_g(sum(mw, 'all'));
+            else
+                m = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
+                               pVec, reluIdx, rdims, offsets, nP, B, nSpec);
+                obj = i_g(sum(min(m,[],1), 'all'));
+            end
             if obj > bestObj, bestObj = obj; bestVec = pVec; end
         end
     catch ME
@@ -137,6 +145,14 @@ function [margins, unstable, preL, preU, alphaOut] = gpu_bab_crown_alpha_dag(ops
     margins = i_dag_back(ops, preL, actM, unsM, auC, buC, fixSign, x_lb, x_ub, C, precision, ...
                          bestVec, reluIdx, rdims, offsets, nP, B, nSpec);
     margins = i_g(margins);
+    % NO-WORSE-THAN-MIN-AREA guarantee. The worst-spec keep-best optimizes a FIXED-worst-spec proxy;
+    % as (alpha,beta) move, a node's true argmin spec can shift, so the proxy can diverge and bestVec's
+    % true worst-margin can dip below min-area (still SOUND -- a valid lower bound at feasible
+    % (alpha,beta) -- just looser). Per node, fall back to the min-area bound m0 wherever it is tighter,
+    % so the returned bound is never below min-area. (No-op for the exact full-gradient path.)
+    m0g = i_g(m0);
+    fb = min(m0g, [], 1) > min(margins, [], 1);          % 1 x B: min-area beats optimized for this node
+    if any(fb), margins(:, fb) = m0g(:, fb); end
     alphaOut = i_alpha_cell(bestVec, nP, nOps, reluIdx, rdims, offsets);
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -1,4 +1,8 @@
-function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, precision, fixings, rootBounds)
+function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, precision, fixings, rootBounds, alphaCell)
+% AMORTIZED alpha-CROWN: optional alphaCell (cell(nOps,1) of per-relu lower-slope vectors,
+% dim_k x 1, in [0,1]) lets the caller bound a whole BaB frontier with FIXED root-optimized
+% slopes -- no autodiff, no per-node gradient tape -> large frontier. Unset -> min-area (default,
+% bound-for-bound unchanged). Any alpha in [0,1] is a sound lower ReLU slope, so this is sound.
 % GPU_BAB_CROWN_SPEC_DAG  Sound CROWN lower bound on a linear output spec C*f(x), batched
 %   over B node columns, for feedforward conv nets INCLUDING residual DAGs
 %   (affine/conv/normaffine/avgpool/relu/add). The generalisation of gpu_bab_crown_spec from
@@ -42,6 +46,7 @@ function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, prec
     if nargin < 5 || isempty(precision), precision = 'single'; end
     if nargin < 6, fixings = {}; end
     if nargin < 7, rootBounds = []; end
+    if nargin < 8, alphaCell = {}; end
     B = size(x_lb, 2); nSpec = size(C, 1); nOps = numel(ops); n = size(x_lb, 1);
     preL = cell(nOps,1); preU = cell(nOps,1);
 
@@ -162,7 +167,8 @@ function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, prec
                 [A, d] = i_avgpool_backward(A, d, op, precision);
             case 'relu'
                 l = preL{k}; u = preU{k};                  % dim x B
-                [au, bu, al] = i_relu_relax(l, u, precision);
+                ak = []; if ~isempty(alphaCell) && numel(alphaCell) >= k, ak = alphaCell{k}; end
+                [au, bu, al] = i_relu_relax(l, u, precision, ak);
                 dim = size(l, 1);
                 Apos = max(A, 0); Aneg = min(A, 0);
                 d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);
@@ -270,12 +276,20 @@ function v = i_bcast_flat(x, sh, precision)
     v = reshape(zeros([sh(1) sh(2) sh(3)], precision) + cast(x, precision), [], 1);
 end
 
-function [au, bu, al] = i_relu_relax(l, u, precision)
+function [au, bu, al] = i_relu_relax(l, u, precision, alpha)
 % Per-neuron ReLU relaxation over [l,u] (elementwise, dim x B): stable-on (l>=0) identity,
-% stable-off (u<=0) zero, unstable upper line au*z+bu / lower line al*z (al in {0,1}).
+% stable-off (u<=0) zero, unstable upper line au*z+bu / lower line al*z. al = min-area {0,1}
+% by default; if alpha (dim x 1, the AMORTIZED root slopes) is given, al(unstable) = alpha
+% (clamped [0,1] -> sound), broadcast over the B node columns.
+    if nargin < 4, alpha = []; end
     au = zeros(size(l), precision); bu = zeros(size(l), precision); al = zeros(size(l), precision);
     act = (l >= 0); au(act) = 1; al(act) = 1;
     unst = (l < 0) & (u > 0); dn = u(unst) - l(unst);
     au(unst) = u(unst) ./ dn; bu(unst) = -au(unst) .* l(unst);
-    al(unst) = cast(u(unst) >= -l(unst), precision);
+    if isempty(alpha)
+        al(unst) = cast(u(unst) >= -l(unst), precision);     % min-area binary {0,1}
+    else
+        ab = repmat(cast(alpha(:), precision), 1, size(l,2));  % dim x 1 -> dim x B (root slopes)
+        al(unst) = min(max(ab(unst), 0), 1);                   % clamp [0,1] (sound)
+    end
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -1,4 +1,4 @@
-function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, precision, fixings, rootBounds, alphaCell)
+function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, precision, fixings, rootBounds, alphaCell)
 % AMORTIZED alpha-CROWN: optional alphaCell (cell(nOps,1) of per-relu lower-slope vectors,
 % dim_k x 1, in [0,1]) lets the caller bound a whole BaB frontier with FIXED root-optimized
 % slopes -- no autodiff, no per-node gradient tape -> large frontier. Unset -> min-area (default,
@@ -135,6 +135,12 @@ function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, prec
     skipA{nOps} = repmat(cast(C, precision), 1, 1, B);   % spec sits on the network output (op nOps)
     d = zeros(nSpec, B, precision);
     inputSkipA = [];
+    % BaBSR sensitivity score (computed only if the caller asks for the 4th output). At each ReLU,
+    % neuron i's relaxation LOWERS the bound by exactly Aneg(s,i,b)*bu(i,b) for spec s; the total
+    % slack a split there can recover is sum_s |Aneg(s,i,b)|*bu(i,b). Branching on the largest such
+    % score (output-sensitivity x gap) closes the bound in far fewer nodes than largest-gap alone.
+    wantScore = nargout >= 4;
+    scoreCell = cell(nOps, 1);
     for k = nOps:-1:1
         A = skipA{k};
         if isempty(A), continue; end
@@ -172,6 +178,10 @@ function [margins, preL, preU] = gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, prec
                 dim = size(l, 1);
                 Apos = max(A, 0); Aneg = min(A, 0);
                 d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);
+                if wantScore
+                    % sum_s |Aneg(s,i,b)| * bu(i,b) -> dim x B (the BaBSR split score for this layer)
+                    scoreCell{k} = reshape(sum(abs(Aneg), 1), dim, B) .* bu;
+                end
                 A = Apos .* reshape(al, 1, dim, B) + Aneg .* reshape(au, 1, dim, B);
             otherwise
                 error('gpu_bab_crown_spec_dag:op', ...

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -85,7 +85,11 @@ function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
     spec = struct();
     spec.C = C; spec.g = gAll(:); spec.rowGroups = rows;
     bopts = struct('precision', precision, 'spec', spec, 'margin', guardTol, 'rootTight', true, ...
-                   'maxNodes', i_optget(opts, 'maxNodes', 5000), 'maxFrontier', i_optget(opts, 'maxFrontier', 256));
+                   'maxNodes', i_optget(opts, 'maxNodes', 5000), 'maxFrontier', i_optget(opts, 'maxFrontier', 256), ...
+                   'alphaIter', i_optget(opts, 'alphaIter', 20), 'betaIter', i_optget(opts, 'betaIter', 20));
+    ev = getenv('NNV_HS_ALPHA'); if ~isempty(ev), bopts.alphaIter = str2double(ev); end
+    ev = getenv('NNV_HS_BETA');  if ~isempty(ev), bopts.betaIter  = str2double(ev); end
+    ev = getenv('NNV_HS_MAXNODES'); if ~isempty(ev), bopts.maxNodes = str2double(ev); end
     try
         [st, binfo] = gpu_bab_relu_split_batched(ops, lb, ub, 1, nOut, bopts);
     catch ME

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -1,0 +1,129 @@
+function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
+% GPU_BAB_HALFSPACE_VERIFY  Sound, ADDITIVE GPU-BaB pre-check for GENERAL-halfspace safety
+%   specs (the control-style benchmarks: cersyve, lsnc_relu, linearizenn). Generalises the
+%   argmax pre-check (gpu_bab_try_verify) to an arbitrary vnnlib unsafe region.
+%
+%   prop.Hg is an array of HalfSpace objects; each HalfSpace {y : G*y <= g} is ONE unsafe
+%   DISJUNCT (polytope). The vnnlib unsafe region is their UNION. The property HOLDS (unsat /
+%   safe) iff the reachable output avoids EVERY disjunct. A disjunct {G*y <= g} is AVOIDED iff
+%   SOME row i has G_i*y - g_i > 0 for the WHOLE reachable set (R lies entirely outside row i's
+%   halfspace -> outside the polytope). So:
+%       'robust' (safe)  <=>  for every disjunct d,  max_i ( lb(G_d,i * y) - g_d,i ) > guardTol
+%   where lb(.) is a sound CROWN lower bound over the input box. (argmax is the special case:
+%   each disjunct is a single row e_target - e_j, and "all disjuncts avoided" == "all margins>0".)
+%
+%   verdict : 'robust'  -- PROVEN safe (every disjunct provably avoided)  -> caller emits unsat
+%             'unknown' -- root CROWN did not avoid some disjunct          -> caller runs Star
+%             'skip'    -- unsupported net / orientation guard failed       -> caller runs Star
+%
+%   SOUNDNESS (never a wrong unsat / -150):
+%     (1) nn_to_ops REFUSES any layer it cannot bound -> 'skip'.
+%     (2) ORIENTATION GUARD: the op-list must reproduce net.evaluate at several non-uniform
+%         probe points (the bounds describe the SAME function the spec is about) -> else 'skip'.
+%     (3) gpu_bab_crown_tight is a sound CROWN LOWER bound on C*y; G_d,i*y >= margins -> the
+%         avoidance test margins-g > tol is a sufficient (sound) condition. DOUBLE precision
+%         (FP64 ~1e-15) so rounding cannot make an avoidance spuriously hold.
+%     (4) This pre-check only ever returns 'robust' on the PROVEN side; anything it cannot prove
+%         is 'unknown'/'skip' -> Star. It can only ADD sound unsats, never a wrong verdict.
+%
+%   This first cut uses the ROOT tight CROWN bound (no BaB yet); benchmarks it cannot decide at
+%   the root fall through to Star. ReLU-split BaB over the disjunctive predicate is the follow-on.
+
+    info = struct('reason', '', 'nDisjuncts', 0, 'guardErr', NaN);
+    if nargin < 5, opts = struct(); end
+    guardTol = i_optget(opts, 'guardTol', 1e-4);
+    precision = 'double';                              % certified path: FP64 (sound)
+
+    lb = double(lb(:)); ub = double(ub(:));
+    inShape = [numel(lb) 1];                           % control nets are flat FC feature inputs
+
+    % (1+2) extract ops + orientation guard (multi-probe, non-uniform; deterministic, no rng).
+    c = (lb + ub) / 2;
+    n = numel(lb); idx = (1:n)';
+    f1 = mod(idx * 0.6180339887498949, 1);
+    f2 = mod(idx * 1.3247179572447460 + 0.37, 1);
+    f3 = mod(idx * 0.7548776662466927 + 0.11, 1);
+    probes = [c, lb + f1.*(ub-lb), lb + f2.*(ub-lb), lb + f3.*(ub-lb)];
+    orders = {'colmajor', 'chw_rowmajor', 'hwc_rowmajor'};
+    ops = []; nOut = NaN;
+    for oi = 1:numel(orders)
+        try
+            cand = nn_to_ops(net, orders{oi});
+        catch ME0
+            if oi == 1, info.reason = ['nn_to_ops refused: ' ME0.message]; end
+            continue;
+        end
+        ok = true; maxe = 0;
+        for pp = 1:size(probes, 2)
+            cp = probes(:, pp);
+            yo = gpu_bab_ibp(cand, cp, cp, 'double'); yo = yo(:);
+            yn = net.evaluate(reshape(cp, inShape)); yn = yn(:);
+            if numel(yo) ~= numel(yn), ok = false; break; end
+            e = max(abs(yo - yn)); maxe = max(maxe, e);
+            if e > guardTol * max(1, max(abs(yn))), ok = false; break; end
+        end
+        if ok, ops = cand; nOut = numel(yn); info.guardErr = maxe; info.reason = sprintf('flatten=%s', orders{oi}); break; end
+    end
+    if isempty(ops)
+        if isempty(info.reason), info.reason = 'no flatten order matched net.evaluate (guard)'; end
+        verdict = 'skip'; return;
+    end
+
+    % parse prop.Hg disjuncts -> per-disjunct (G,g); stack rows into one spec C for ONE bound pass
+    [Gd, gd, rows, ok] = i_parse_disjuncts(prop, nOut);
+    if ~ok
+        verdict = 'skip'; info.reason = 'unsupported/empty Hg (could not parse disjuncts)'; return;
+    end
+    info.nDisjuncts = numel(Gd);
+    C = cat(1, Gd{:});                                 % all rows of all disjuncts (nRows x nOut)
+    gAll = cat(1, gd{:});                              % matching offsets
+
+    % (3) sound CROWN lower bound on C*y over the box (FP64). margins_i = lb(G_i*y).
+    try
+        margins = gpu_bab_crown_tight(ops, lb, ub, C, precision, cell(numel(ops),1));
+        margins = double(margins(:));
+    catch ME
+        verdict = 'skip'; info.reason = ['crown_tight errored: ' ME.message]; return;
+    end
+    avoidMargin = margins - gAll(:);                   % G_i*y - g_i >= avoidMargin (sound lower bound)
+
+    % per-disjunct OR (some row avoided), all-disjunct AND (every disjunct avoided)
+    allAvoided = true; worst = inf;
+    for d = 1:numel(rows)
+        best_d = max(avoidMargin(rows{d}));            % the most-separated row of disjunct d
+        worst = min(worst, best_d);
+        if ~(best_d > guardTol), allAvoided = false; end
+    end
+    info.worstDisjunctMargin = worst;
+    if allAvoided
+        verdict = 'robust';                            % every unsafe disjunct provably avoided
+    else
+        verdict = 'unknown'; info.reason = sprintf('root crown did not avoid all disjuncts (worst=%.4g)', worst);
+    end
+end
+
+% ---------------------------------------------------------------------------------------------
+function [Gd, gd, rows, ok] = i_parse_disjuncts(prop, nOut)
+% prop.Hg: array of HalfSpace objects, each one unsafe disjunct {y : G*y <= g}. Return per-disjunct
+% G (k_d x nOut) and g (k_d x 1), plus rows{d} = the indices of disjunct d in the stacked spec.
+    Gd = {}; gd = {}; rows = {}; ok = false;
+    if ~isfield(prop, 'Hg') && ~isprop(prop, 'Hg'), return; end
+    Hg = prop.Hg;
+    if isempty(Hg), return; end
+    if ~iscell(Hg), Hg = num2cell(Hg); end             % HalfSpace array -> cell of disjuncts
+    r0 = 0;
+    for d = 1:numel(Hg)
+        hd = Hg{d};
+        if ~(isprop(hd,'G') && isprop(hd,'g')), return; end
+        G = double(hd.G); g = double(hd.g(:));
+        if isempty(G) || size(G,2) ~= nOut || size(G,1) ~= numel(g), return; end
+        Gd{end+1} = G; gd{end+1} = g; %#ok<AGROW>
+        rows{end+1} = (r0 + 1) : (r0 + size(G,1)); %#ok<AGROW>
+        r0 = r0 + size(G,1);
+    end
+    ok = ~isempty(Gd);
+end
+
+function v = i_optget(s, f, d)
+    if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -78,27 +78,24 @@ function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
     C = cat(1, Gd{:});                                 % all rows of all disjuncts (nRows x nOut)
     gAll = cat(1, gd{:});                              % matching offsets
 
-    % (3) sound CROWN lower bound on C*y over the box (FP64). margins_i = lb(G_i*y).
+    % (3) sound disjunctive ReLU-split BaB (FP64). opts.spec routes the disjunct structure into the
+    % batched BaB, which certifies SAFE iff EVERY disjunct is avoided (some row separated) -- and
+    % SPLITS unstable ReLUs to tighten beyond the (typically too-loose) root CROWN. margin=guardTol
+    % is the FP64 soundness slack. 'robust' is a sound UNSAT proof; anything else -> Star.
+    spec = struct();
+    spec.C = C; spec.g = gAll(:); spec.rowGroups = rows;
+    bopts = struct('precision', precision, 'spec', spec, 'margin', guardTol, 'rootTight', true, ...
+                   'maxNodes', i_optget(opts, 'maxNodes', 5000), 'maxFrontier', i_optget(opts, 'maxFrontier', 256));
     try
-        margins = gpu_bab_crown_tight(ops, lb, ub, C, precision, cell(numel(ops),1));
-        margins = double(margins(:));
+        [st, binfo] = gpu_bab_relu_split_batched(ops, lb, ub, 1, nOut, bopts);
     catch ME
-        verdict = 'skip'; info.reason = ['crown_tight errored: ' ME.message]; return;
+        verdict = 'skip'; info.reason = ['halfspace BaB errored: ' ME.message]; return;
     end
-    avoidMargin = margins - gAll(:);                   % G_i*y - g_i >= avoidMargin (sound lower bound)
-
-    % per-disjunct OR (some row avoided), all-disjunct AND (every disjunct avoided)
-    allAvoided = true; worst = inf;
-    for d = 1:numel(rows)
-        best_d = max(avoidMargin(rows{d}));            % the most-separated row of disjunct d
-        worst = min(worst, best_d);
-        if ~(best_d > guardTol), allAvoided = false; end
-    end
-    info.worstDisjunctMargin = worst;
-    if allAvoided
-        verdict = 'robust';                            % every unsafe disjunct provably avoided
+    info.nodes = binfo.nodes;
+    if strcmp(st, 'robust')
+        verdict = 'robust';                            % every unsafe disjunct provably avoided over the box
     else
-        verdict = 'unknown'; info.reason = sprintf('root crown did not avoid all disjuncts (worst=%.4g)', worst);
+        verdict = 'unknown'; info.reason = sprintf('BaB %s (nodes=%d, rounds=%d)', st, binfo.nodes, binfo.rounds);
     end
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -66,7 +66,10 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % alpha/beta-CROWN node bounding (gpu_bab_crown_alpha_fix / _alpha_beta) is FC-only
     % (affine/relu); for conv/normaffine/avgpool nets fall back to the (root-tight) CROWN bound
     % so we never mis-bound.
-    if (alphaIter > 0 || betaIter > 0) && ~all(cellfun(@(o) any(strcmp(o.type, {'affine','relu'})), ops))
+    % alpha/beta route: FC (affine/relu) -> alpha_fix/alpha_beta; DAG (conv/normaffine/avgpool/add)
+    % -> gpu_bab_crown_alpha_dag (alpha+beta over the full DAG). Only maxpool has no batched alpha
+    % backward -> disable alpha/beta there (sound: falls back to fixed-slope spec_dag / tight path).
+    if (alphaIter > 0 || betaIter > 0) && any(cellfun(@(o) strcmp(o.type, 'maxpool'), ops))
         alphaIter = 0; betaIter = 0;
     end
     % SPEC: argmax-robustness (default) builds C internally; a general-halfspace caller passes
@@ -219,7 +222,17 @@ function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x
     if nargin < 11 || isempty(alphaLr), alphaLr = 0.2; end
     if nargin < 12 || isempty(betaIter), betaIter = 0; end
     LB = repmat(x_lb, 1, B); UB = repmat(x_ub, 1, B);
-    if betaIter > 0
+    % DAG nets (conv/normaffine/avgpool/add) route to gpu_bab_crown_alpha_dag (alpha+beta over the
+    % full DAG); the FC-only alpha_fix/alpha_beta mis-bound a conv/add op (fail-open) so are used
+    % ONLY for pure affine/relu. alphaIter==betaIter==0 -> fixed-slope spec_dag (the cheap bound).
+    isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add'})), ops));
+    if isDAG
+        if alphaIter > 0 || betaIter > 0
+            [m, ~, pL, pU] = gpu_bab_crown_alpha_dag(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
+        else
+            [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
+        end
+    elseif betaIter > 0
         [m, ~, pL, pU] = gpu_bab_crown_alpha_beta(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
     elseif alphaIter > 0
         [m, ~, pL, pU] = gpu_bab_crown_alpha_fix(ops, LB, UB, C, fixc, reluIdx, precision, alphaIter, alphaLr, rootBounds);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -69,15 +69,30 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     if (alphaIter > 0 || betaIter > 0) && ~all(cellfun(@(o) any(strcmp(o.type, {'affine','relu'})), ops))
         alphaIter = 0; betaIter = 0;
     end
-    C = -eye(nClasses, precision);
-    C(:, trueLabel) = C(:, trueLabel) + 1;
-    C(trueLabel, :) = [];
+    % SPEC: argmax-robustness (default) builds C internally; a general-halfspace caller passes
+    % opts.spec = struct('C',C,'g',g,'rowGroups',{rows-per-disjunct}). The node certification then
+    % generalises "all margins > 0" to "every unsafe DISJUNCT has SOME row G_i*y-g_i > 0" (the
+    % output avoids every unsafe polytope). argmax is the special case: each margin is its own
+    % single-row disjunct, so the disjunctive test reduces EXACTLY to all-margins>0.
+    spec = i_get(opts, 'spec', []);
+    if isempty(spec)
+        C = -eye(nClasses, precision);
+        C(:, trueLabel) = C(:, trueLabel) + 1;
+        C(trueLabel, :) = [];
+        gOff = zeros(size(C,1), 1, precision);
+        rowGroups = num2cell(1:size(C,1));
+    else
+        C = cast(spec.C, precision); gOff = cast(spec.g(:), precision); rowGroups = spec.rowGroups;
+    end
+    doCex = isempty(spec);             % i_find_cex is argmax (misclassification) only; skip for halfspace
     info = struct('nodes', 0, 'rounds', 0, 'maxStack', 1, 'cex', [], 'cexLabel', []);
 
-    % concrete counterexample on the whole box first (cheap falsification)
-    [cex, lab] = i_find_cex(ops, x_lb, x_ub, trueLabel, nSample, precision);
-    if ~isempty(cex)
-        status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
+    % concrete counterexample on the whole box first (cheap falsification; argmax only)
+    if doCex
+        [cex, lab] = i_find_cex(ops, x_lb, x_ub, trueLabel, nSample, precision);
+        if ~isempty(cex)
+            status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
+        end
     end
 
     % --- root: bound the un-split network once; certify, or seed the stack from its split.
@@ -97,7 +112,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         [mRoot, preL, preU] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, cell(nOps,1), 1);
     end
     info.nodes = 1;
-    if all(mRoot > margin, 1)
+    if i_certify_dis(mRoot, gOff, rowGroups, margin)
         status = 'robust'; return;
     end
     reluDim = zeros(1, nOps);
@@ -137,15 +152,17 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
         % so the BaB splits it forever and degrades a robust query to a false 'unknown'.
-        undec = find(~(all(margins > margin, 1) | infeas));
+        undec = find(~(i_certify_dis(margins, gOff, rowGroups, margin) | infeas));
         if isempty(undec)
             continue;                               % whole batch certified; pop the next
         end
 
-        % periodic concrete counterexample search (cheap; once per round on the original box)
-        [cex, lab] = i_find_cex(ops, x_lb, x_ub, trueLabel, nSample, precision);
-        if ~isempty(cex)
-            status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
+        % periodic concrete counterexample search (cheap; argmax only -- halfspace sat is the dispatcher's job)
+        if doCex
+            [cex, lab] = i_find_cex(ops, x_lb, x_ub, trueLabel, nSample, precision);
+            if ~isempty(cex)
+                status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
+            end
         end
 
         % split each undecided node on its largest-gap unstable unfixed neuron
@@ -169,6 +186,20 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         M = M + 2 * nu;
     end
     status = 'robust';
+end
+
+% ------------------------------------------------------------------------------------
+function ok = i_certify_dis(margins, gOff, rowGroups, marginSlack)
+% Disjunctive certification: a node is certified SAFE iff EVERY unsafe disjunct is avoided, and a
+% disjunct {G*y<=g} is avoided iff SOME of its rows has a lower bound G_i*y-g_i > slack (the
+% reachable set lies entirely outside that halfspace -> outside the polytope). margins: nRows x B
+% (sound lower bound of G*y). Returns 1 x B. For argmax (each row its own disjunct, g=0) this is
+% exactly all(margins>slack) -- the original argmax certification, bound-for-bound.
+    av = (margins - gOff) > marginSlack;          % nRows x B : row i provably avoided
+    ok = true(1, size(margins, 2));
+    for d = 1:numel(rowGroups)
+        ok = ok & any(av(rowGroups{d}, :), 1);    % disjunct d avoided iff some of its rows avoided
+    end
 end
 
 % ------------------------------------------------------------------------------------

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -169,7 +169,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         end
 
         % bound the popped batch (reusing the tight root bounds, clamped per node, if rootTight)
-        [margins, preL, preU, infeas] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot);
+        [margins, preL, preU, infeas, scoreC] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot);
         % An INFEASIBLE node (a fixing combination that made the clamped IBP box empty,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
@@ -187,8 +187,9 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
             end
         end
 
-        % split each undecided node on its largest-gap unstable unfixed neuron
-        [sK, sJ, hasS] = i_pick_splits(reluIdx, preL, preU, fixc, undec);
+        % split each undecided node on its highest BaBSR-score unstable unfixed neuron
+        % (output-sensitivity x gap; falls back to largest-gap when no score is available)
+        [sK, sJ, hasS] = i_pick_splits(reluIdx, preL, preU, fixc, undec, scoreC);
         if ~all(hasS)
             status = 'unknown'; return;             % an undecided node cannot be split
         end
@@ -225,7 +226,7 @@ function ok = i_certify_dis(margins, gOff, rowGroups, marginSlack)
 end
 
 % ------------------------------------------------------------------------------------
-function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot)
+function [margins, preL, preU, infeasible, scoreCell] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot)
 % Bound B frontier nodes (B <= maxFrontier) in one batched CROWN call. The backward CROWN
 % (pagemtimes) runs on-device; margins and the per-relu pre-activation bounds are gathered to
 % host (small) for the verdict + split-neuron selection. infeasible(j) is true when node j's
@@ -248,40 +249,46 @@ function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x
     % else min-area spec_dag. FC-only alpha_fix/alpha_beta mis-bound conv/add (fail-open) -> never
     % used for DAG. All sound (alpha in [0,1], beta>=0).
     isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add'})), ops));
+    sc = {};                                          % per-relu BaBSR score (dim_k x B); {} -> gap fallback
     if isDAG
         if ~isempty(alphaRoot)
-            [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds, alphaRoot);
+            [m, pL, pU, sc] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds, alphaRoot);
         elseif alphaIter > 0 || betaIter > 0
             [m, ~, pL, pU] = gpu_bab_crown_alpha_dag(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
         else
-            [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
+            [m, pL, pU, sc] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
         end
     elseif betaIter > 0
         [m, ~, pL, pU] = gpu_bab_crown_alpha_beta(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
     elseif alphaIter > 0
         [m, ~, pL, pU] = gpu_bab_crown_alpha_fix(ops, LB, UB, C, fixc, reluIdx, precision, alphaIter, alphaLr, rootBounds);
     else
-        [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
+        [m, pL, pU, sc] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);
     end
     margins = gather(m);
     preL = cell(numel(ops), 1); preU = cell(numel(ops), 1);
+    scoreCell = cell(numel(ops), 1);
     infeasible = false(1, B);
     for r = 1:numel(reluIdx)
         k = reluIdx(r);
         preL{k} = gather(pL{k});
         preU{k} = gather(pU{k});
+        if ~isempty(sc) && numel(sc) >= k && ~isempty(sc{k}), scoreCell{k} = gather(sc{k}); end
         infeasible = infeasible | any(preL{k} > preU{k} + 1e-6, 1);   % clamp made box empty
     end
 end
 
 % ------------------------------------------------------------------------------------
-function [splitK, splitJ, hasSplit] = i_pick_splits(reluIdx, preL, preU, fixc, undec)
-% For each undecided node, pick the unstable, unfixed neuron with the largest ReLU
-% relaxation gap bu = u*(-l)/(u-l) (the upper-line slack a split removes) -- a BaBSR-lite
-% heuristic that closes the bound far faster than first-unstable. Returns the chosen relu
-% op index + neuron index per node, and a flag (false => no splittable neuron left).
+function [splitK, splitJ, hasSplit] = i_pick_splits(reluIdx, preL, preU, fixc, undec, scoreCell)
+% For each undecided node, pick the unstable, unfixed neuron with the highest split score among
+% all relu layers. When a per-relu BaBSR score is supplied (scoreCell{k} = sum_s |Aneg|*bu, the
+% output-sensitivity-weighted intercept slack a split recovers), branch on the largest score --
+% proper BaBSR, which closes the bound in far fewer nodes. Without a score (alpha_dag/FC paths),
+% fall back to the largest ReLU relaxation gap bu = u*(-l)/(u-l) (BaBSR-lite). Returns the chosen
+% relu op index + neuron index per node, and a flag (false => no splittable neuron left).
+    if nargin < 6, scoreCell = {}; end
     nu = numel(undec);
-    bestGap = -inf(1, nu);
+    bestVal = -inf(1, nu);
     splitK  = zeros(1, nu);
     splitJ  = zeros(1, nu);
     for r = 1:numel(reluIdx)
@@ -289,15 +296,20 @@ function [splitK, splitJ, hasSplit] = i_pick_splits(reluIdx, preL, preU, fixc, u
         l = preL{k}(:, undec); u = preU{k}(:, undec);     % dim_k x nu
         uns = (l < 0) & (u > 0);
         if isempty(fixc{k}), free = true(size(l)); else, free = (fixc{k}(:, undec) == 0); end
-        gap = u .* (-l) ./ (u - l);
-        gap(~(uns & free)) = -inf;
-        [g, j] = max(gap, [], 1);                          % 1 x nu
-        better = g > bestGap;
-        bestGap(better) = g(better);
+        haveScore = ~isempty(scoreCell) && numel(scoreCell) >= k && ~isempty(scoreCell{k});
+        if haveScore
+            val = scoreCell{k}(:, undec);                  % BaBSR score (sensitivity x gap)
+        else
+            val = u .* (-l) ./ (u - l);                    % gap fallback
+        end
+        val(~(uns & free)) = -inf;
+        [g, j] = max(val, [], 1);                          % 1 x nu
+        better = g > bestVal;
+        bestVal(better) = g(better);
         splitK(better)  = k;
         splitJ(better)  = j(better);
     end
-    hasSplit = isfinite(bestGap);
+    hasSplit = isfinite(bestVal);
 end
 
 % ------------------------------------------------------------------------------------

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -151,6 +151,8 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     M = 2;
 
     % --- batched DFS over the node stack ---
+    dbgBab = ~isempty(getenv('NNV_DEBUG_BAB')); dbgEvery = 100;   % progress telemetry cadence (rounds)
+    bestWorst = -inf;                                            % best (largest) worst-margin seen so far
     while M > 0
         info.rounds = info.rounds + 1;
         info.maxStack = max(info.maxStack, M);
@@ -175,6 +177,16 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
         % so the BaB splits it forever and degrades a robust query to a false 'unknown'.
         undec = find(~(i_certify_dis(margins, gOff, rowGroups, margin) | infeas));
+        % progress telemetry: stack-size trajectory is the convergence signal (shrinking => the
+        % BaB is certifying faster than it splits; growing => bounds too loose, more nodes won't help)
+        if dbgBab
+            bw = min(min(margins, [], 1));           % worst (most-negative) margin in this batch
+            if isfinite(bw), bestWorst = max(bestWorst, bw); end
+            if mod(info.rounds, dbgEvery) == 0
+                fprintf('[bab] round=%d nodes=%d stack=%d batch=%d certified=%d/%d worstMargin=%.4g bestWorst=%.4g\n', ...
+                    info.rounds, info.nodes, M, B, B - numel(undec), B, bw, bestWorst);
+            end
+        end
         if isempty(undec)
             continue;                               % whole batch certified; pop the next
         end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -137,6 +137,41 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     if i_certify_dis(mRoot, gOff, rowGroups, margin)
         status = 'robust'; return;
     end
+    % ---- SPEC REDUCTION (monotone-margin pruning) -------------------------------------------
+    % Each spec's CROWN margin is MONOTONE non-decreasing down the BaB tree: a split only fixes a
+    % ReLU / shrinks the box, which tightens (never loosens) the fixed-slope bound. So any unsafe
+    % DISJUNCT already avoided at the root (some row margin > slack) is avoided at EVERY descendant
+    % -- drop it and keep only the unproven rows. The per-node bound then costs O(#unproven specs)
+    % not O(all specs); for cifar100 (99 argmax rows, root median margin ~6.5) that is a ~10-99x
+    % cheaper bound. SOUND: the reference is the SAME fixed-slope no-fixings root bound the children
+    % use (a guaranteed lower bound every descendant meets), so monotonicity holds exactly; a small
+    % eps keeps borderline disjuncts in the BaB.
+    if numel(rowGroups) > 1
+        if ~isempty(rootBounds)
+            mRef = gather(reshape(gpu_bab_crown_spec_dag(ops, x_lb, x_ub, C, precision, {}, rootBounds, alphaRoot), [], 1));
+        else
+            mRef = mRoot(:);                            % rootTight off: children use this same min-area bound
+        end
+        provenEps = cast(1e-3, precision);
+        keepDisj = true(1, numel(rowGroups));
+        for d = 1:numel(rowGroups)
+            if any(mRef(rowGroups{d}) > margin + provenEps), keepDisj(d) = false; end  % avoided everywhere
+        end
+        if ~any(keepDisj)
+            status = 'robust'; return;                  % every disjunct proven at the root
+        end
+        if ~all(keepDisj)
+            keepRows = unique([rowGroups{keepDisj}], 'stable');
+            remap = zeros(1, size(C,1)); remap(keepRows) = 1:numel(keepRows);
+            C = C(keepRows, :); gOff = gOff(keepRows); mRoot = mRoot(keepRows);
+            rowGroups = rowGroups(keepDisj);
+            for d = 1:numel(rowGroups), rowGroups{d} = remap(rowGroups{d}); end
+            if ~isempty(getenv('NNV_DEBUG_BAB'))
+                fprintf('[spec-reduce] kept %d/%d rows, %d/%d disjuncts unproven at root\n', ...
+                    numel(keepRows), numel(remap), numel(rowGroups), numel(keepDisj));
+            end
+        end
+    end
     reluDim = zeros(1, nOps);
     for r = 1:numel(reluIdx), reluDim(reluIdx(r)) = size(preL{reluIdx(r)}, 1); end
     [sK, sJ, hasS] = i_pick_splits(reluIdx, preL, preU, cell(nOps,1), 1);
@@ -151,8 +186,10 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     M = 2;
 
     % --- batched DFS over the node stack ---
-    dbgBab = ~isempty(getenv('NNV_DEBUG_BAB')); dbgEvery = 100;   % progress telemetry cadence (rounds)
+    dbgBab = ~isempty(getenv('NNV_DEBUG_BAB'));
+    dbgEvery = str2double(getenv('NNV_BAB_DBG_EVERY')); if isnan(dbgEvery) || dbgEvery < 1, dbgEvery = 100; end
     bestWorst = -inf;                                            % best (largest) worst-margin seen so far
+    tBab = tic; tPrev = 0;                                       % wall clock for node-throughput telemetry
     while M > 0
         info.rounds = info.rounds + 1;
         info.maxStack = max(info.maxStack, M);
@@ -183,8 +220,11 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
             bw = min(min(margins, [], 1));           % worst (most-negative) margin in this batch
             if isfinite(bw), bestWorst = max(bestWorst, bw); end
             if mod(info.rounds, dbgEvery) == 0
-                fprintf('[bab] round=%d nodes=%d stack=%d batch=%d certified=%d/%d worstMargin=%.4g bestWorst=%.4g\n', ...
-                    info.rounds, info.nodes, M, B, B - numel(undec), B, bw, bestWorst);
+                tNow = toc(tBab); dt = max(tNow - tPrev, 1e-6);
+                fprintf('[bab] round=%d nodes=%d stack=%d certified=%d/%d worstMargin=%.4g bestWorst=%.4g | %.0f nodes/s (%.1fs elapsed)\n', ...
+                    info.rounds, info.nodes, M, B - numel(undec), B, bw, bestWorst, ...
+                    dbgEvery * B / dt, tNow);
+                tPrev = tNow;
             end
         end
         if isempty(undec)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -178,11 +178,15 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     if ~hasS
         status = 'unknown'; return;                 % root undecided, nothing to split
     end
-    % stack as per-relu fixing matrices fixStack{k} = [dim_k x M]; seed with root's 2 children.
+    % Stack as per-relu fixing matrices fixStack{k} = int8(dim_k x cap), with a SHARED column
+    % pointer M and amortized-doubling capacity. Pop/push then move only the pointer (no per-round
+    % concat/delete), so each is O(B) not O(stack) -- the cell-array realloc made rounds slow to a
+    % crawl (>17s) as the stack grew. int8 (fixings are -1/0/+1) keeps the live set ~8x smaller.
+    cap = max(1024, 4 * maxFrontier);
     fixStack = cell(nOps, 1);
-    for r = 1:numel(reluIdx), k = reluIdx(r); fixStack{k} = zeros(reluDim(k), 2); end
-    fixStack{sK}(sJ, 1) =  1;                        % active child
-    fixStack{sK}(sJ, 2) = -1;                        % inactive child
+    for r = 1:numel(reluIdx), k = reluIdx(r); fixStack{k} = zeros(reluDim(k), cap, 'int8'); end
+    fixStack{sK}(sJ, 1) =  int8(1);                 % active child
+    fixStack{sK}(sJ, 2) = -int8(1);                 % inactive child
     M = 2;
 
     % --- batched DFS over the node stack ---
@@ -190,7 +194,9 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     dbgEvery = str2double(getenv('NNV_BAB_DBG_EVERY')); if isnan(dbgEvery) || dbgEvery < 1, dbgEvery = 100; end
     bestWorst = -inf;                                            % best (largest) worst-margin seen so far
     tBab = tic; tPrev = 0;                                       % wall clock for node-throughput telemetry
+    tProf = zeros(1,5);                                          % [pop bound pick cex push] cumulative seconds
     while M > 0
+        tS = tic;
         info.rounds = info.rounds + 1;
         info.maxStack = max(info.maxStack, M);
         if M > maxStack
@@ -199,16 +205,19 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         B = min(maxFrontier, M);
         cols = (M - B + 1):M;                       % pop the top B nodes (LIFO -> DFS)
         fixc = cell(nOps, 1);
-        for r = 1:numel(reluIdx), k = reluIdx(r); fixc{k} = fixStack{k}(:, cols); end
-        for r = 1:numel(reluIdx), k = reluIdx(r); fixStack{k}(:, cols) = []; end
-        M = M - B;
+        % cast the popped batch to double (the type the bounding functions expect); only the big
+        % fixStack stays int8 for memory -- fixc is just B columns, so the cast is cheap.
+        for r = 1:numel(reluIdx), k = reluIdx(r); fixc{k} = double(fixStack{k}(:, cols)); end
+        M = M - B;                                  % move pointer only; popped cols become free space
         info.nodes = info.nodes + B;
         if info.nodes > maxNodes
             status = 'unknown'; return;
         end
+        tProf(1) = tProf(1) + toc(tS); tS = tic;
 
         % bound the popped batch (reusing the tight root bounds, clamped per node, if rootTight)
         [margins, preL, preU, infeas, scoreC] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot);
+        tProf(2) = tProf(2) + toc(tS); tS = tic;
         % An INFEASIBLE node (a fixing combination that made the clamped IBP box empty,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
@@ -220,45 +229,67 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
             bw = min(min(margins, [], 1));           % worst (most-negative) margin in this batch
             if isfinite(bw), bestWorst = max(bestWorst, bw); end
             if mod(info.rounds, dbgEvery) == 0
-                tNow = toc(tBab); dt = max(tNow - tPrev, 1e-6);
-                fprintf('[bab] round=%d nodes=%d stack=%d certified=%d/%d worstMargin=%.4g bestWorst=%.4g | %.0f nodes/s (%.1fs elapsed)\n', ...
+                tNow = toc(tBab); dt = max(tNow - tPrev, 1e-6); tp = tProf / max(tNow,1e-6) * 100;
+                fprintf('[bab] round=%d nodes=%d stack=%d certified=%d/%d worstMargin=%.4g bestWorst=%.4g | %.0f nodes/s (%.1fs) | pop%.0f bound%.0f pick%.0f cex%.0f push%.0f %%\n', ...
                     info.rounds, info.nodes, M, B - numel(undec), B, bw, bestWorst, ...
-                    dbgEvery * B / dt, tNow);
+                    dbgEvery * B / dt, tNow, tp(1), tp(2), tp(3), tp(4), tp(5));
                 tPrev = tNow;
             end
         end
         if isempty(undec)
             continue;                               % whole batch certified; pop the next
         end
+        tS = tic;
 
-        % periodic concrete counterexample search (cheap; argmax only -- halfspace sat is the dispatcher's job)
-        if doCex
+        % periodic concrete counterexample search (cheap; argmax only -- halfspace sat is the dispatcher's job).
+        % The box is fixed, so this only needs to run occasionally (the pre-loop check already covered it).
+        if doCex && mod(info.rounds, 25) == 0
             [cex, lab] = i_find_cex(ops, x_lb, x_ub, trueLabel, nSample, precision);
             if ~isempty(cex)
                 status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
             end
         end
+        tProf(4) = tProf(4) + toc(tS); tS = tic;
 
         % split each undecided node on its highest BaBSR-score unstable unfixed neuron
         % (output-sensitivity x gap; falls back to largest-gap when no score is available)
         [sK, sJ, hasS] = i_pick_splits(reluIdx, preL, preU, fixc, undec, scoreC);
+        tProf(3) = tProf(3) + toc(tS); tS = tic;
         if ~all(hasS)
             status = 'unknown'; return;             % an undecided node cannot be split
         end
 
-        % push the two children of every undecided node onto the stack
+        % push the two children of every undecided node onto the stack (write into free columns
+        % above the pointer; grow capacity by doubling only when needed -> amortized O(B) per push)
         nu = numel(undec);
+        need = M + 2 * nu;
+        if need > maxStack
+            status = 'unknown'; return;             % live set would exceed the memory guard
+        end
+        if need > cap
+            newCap = cap; while newCap < need, newCap = 2 * newCap; end
+            newCap = min(newCap, maxStack);
+            for r = 1:numel(reluIdx)
+                k = reluIdx(r);
+                grown = zeros(reluDim(k), newCap, 'int8');
+                grown(:, 1:M) = fixStack{k}(:, 1:M);
+                fixStack{k} = grown;
+            end
+            cap = newCap;
+        end
         for r = 1:numel(reluIdx)
             k = reluIdx(r);
-            parent = fixc{k}(:, undec);             % dim_k x nu
-            fixStack{k} = [fixStack{k}, parent, parent];   % [active block | inactive block]
+            parent = fixc{k}(:, undec);             % dim_k x nu (int8)
+            fixStack{k}(:, M+1     : M+nu)   = parent;     % active block
+            fixStack{k}(:, M+nu+1  : M+2*nu) = parent;     % inactive block
         end
         for i = 1:nu
             k = sK(i); j = sJ(i);
-            fixStack{k}(j, M + i)      =  1;        % active child  (column M+i)
-            fixStack{k}(j, M + nu + i) = -1;        % inactive child (column M+nu+i)
+            fixStack{k}(j, M + i)      =  int8(1);  % active child  (column M+i)
+            fixStack{k}(j, M + nu + i) = -int8(1);  % inactive child (column M+nu+i)
         end
         M = M + 2 * nu;
+        tProf(5) = tProf(5) + toc(tS);
     end
     status = 'robust';
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -104,15 +104,34 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % for every batched bound below. This gives tight bounds (vs the loose per-node IBP) at
     % batched speed (vs recomputing the tight pass per node). Falls back to the IBP forward
     % when rootTight is off. ---
-    rootBounds = [];
+    rootBounds = []; alphaRoot = {};
     if rootTight
         [mRoot, rtL, rtU] = gpu_bab_crown_tight(ops, x_lb, x_ub, C, precision, cell(nOps,1));
         mRoot = gather(mRoot(:));
         rootBounds = struct('preL', {rtL}, 'preU', {rtU});
         preL = cell(nOps,1); preU = cell(nOps,1);
         for r = 1:numel(reluIdx), k = reluIdx(r); preL{k} = gather(rtL{k}); preU{k} = gather(rtU{k}); end
+        % AMORTIZED alpha-CROWN: optimize alpha ONCE at the root (B=1, no per-node gradient memory)
+        % and reuse the FIXED slopes for every BaB node via spec_dag -> LARGE frontier (the per-node
+        % alpha autodiff OOMs past frontier ~8 on cifar). env NNV_AMORT_ALPHA = #root iters.
+        ev = getenv('NNV_AMORT_ALPHA');
+        if ~isempty(ev) && (alphaIter > 0 || betaIter > 0 || true)
+            nitR = str2double(ev); if isnan(nitR), nitR = 50; end
+            try
+                tRoot = tic;
+                [mR2, ~, ~, ~, alphaRoot] = gpu_bab_crown_alpha_dag(ops, x_lb, x_ub, C, cell(nOps,1), reluIdx, precision, nitR, alphaLr, rootBounds);
+                mRoot = gather(mR2(:));   % the root-alpha margin (tighter than min-area crown_tight)
+                if ~isempty(getenv('NNV_DEBUG_BAB'))
+                    fprintf('[amort] root-alpha (%d it, %.1fs): margin min=%.6g median=%.6g (n=%d, frontier=%d)\n', ...
+                        nitR, toc(tRoot), min(mRoot), median(mRoot), numel(mRoot), maxFrontier);
+                end
+            catch ME
+                alphaRoot = {};
+                if ~isempty(getenv('NNV_DEBUG_BAB')), fprintf('[amort] root-alpha errored: %s\n', ME.message); end
+            end
+        end
     else
-        [mRoot, preL, preU] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, cell(nOps,1), 1);
+        [mRoot, preL, preU] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, cell(nOps,1), 1, [], 0, 0.2, 0, {});
     end
     info.nodes = 1;
     if i_certify_dis(mRoot, gOff, rowGroups, margin)
@@ -150,7 +169,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         end
 
         % bound the popped batch (reusing the tight root bounds, clamped per node, if rootTight)
-        [margins, preL, preU, infeas] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter);
+        [margins, preL, preU, infeas] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot);
         % An INFEASIBLE node (a fixing combination that made the clamped IBP box empty,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
         % vacuously, so it is certified. Without this, IBP+CROWN cannot bound such a node,
@@ -206,7 +225,7 @@ function ok = i_certify_dis(margins, gOff, rowGroups, marginSlack)
 end
 
 % ------------------------------------------------------------------------------------
-function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter)
+function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot)
 % Bound B frontier nodes (B <= maxFrontier) in one batched CROWN call. The backward CROWN
 % (pagemtimes) runs on-device; margins and the per-relu pre-activation bounds are gathered to
 % host (small) for the verdict + split-neuron selection. infeasible(j) is true when node j's
@@ -221,13 +240,18 @@ function [margins, preL, preU, infeasible] = i_bound_batch(ops, reluIdx, x_lb, x
     if nargin < 10 || isempty(alphaIter), alphaIter = 0; end
     if nargin < 11 || isempty(alphaLr), alphaLr = 0.2; end
     if nargin < 12 || isempty(betaIter), betaIter = 0; end
+    if nargin < 13, alphaRoot = {}; end
     LB = repmat(x_lb, 1, B); UB = repmat(x_ub, 1, B);
-    % DAG nets (conv/normaffine/avgpool/add) route to gpu_bab_crown_alpha_dag (alpha+beta over the
-    % full DAG); the FC-only alpha_fix/alpha_beta mis-bound a conv/add op (fail-open) so are used
-    % ONLY for pure affine/relu. alphaIter==betaIter==0 -> fixed-slope spec_dag (the cheap bound).
+    % DAG nets (conv/normaffine/avgpool/add): with AMORTIZED root slopes (alphaRoot) bound the whole
+    % frontier via spec_dag (fixed slopes, NO autodiff -> large frontier, the cifar memory fix);
+    % else per-node alpha_dag (alpha+beta, autodiff -> small frontier) when alphaIter/betaIter>0;
+    % else min-area spec_dag. FC-only alpha_fix/alpha_beta mis-bound conv/add (fail-open) -> never
+    % used for DAG. All sound (alpha in [0,1], beta>=0).
     isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add'})), ops));
     if isDAG
-        if alphaIter > 0 || betaIter > 0
+        if ~isempty(alphaRoot)
+            [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds, alphaRoot);
+        elseif alphaIter > 0 || betaIter > 0
             [m, ~, pL, pU] = gpu_bab_crown_alpha_dag(ops, LB, UB, C, fixc, reluIdx, precision, max(alphaIter,betaIter), alphaLr, rootBounds);
         else
             [m, pL, pU] = gpu_bab_crown_spec_dag(ops, LB, UB, C, precision, fixc, rootBounds);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -135,6 +135,12 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     % (false robust); clamp to >= 0 (sound-or-unknown).
     if isfield(bopts, 'margin') && bopts.margin < 0, bopts.margin = 0; end
     if ~isfield(bopts, 'maxNodes'),  bopts.maxNodes  = 300;      end
+    % per-node alpha+beta CROWN tightening (env override for dev/tuning; sound for any value --
+    % alpha in [0,1], beta>=0 are valid relaxations). Lets the BaB cross the convex barrier the
+    % fixed-slope bound can't, on the hardest deep nodes.
+    if ~isfield(bopts, 'alphaIter'), ev = getenv('NNV_BAB_ALPHA_ITERS'); if ~isempty(ev), bopts.alphaIter = str2double(ev); end; end
+    if ~isfield(bopts, 'betaIter'),  ev = getenv('NNV_BAB_BETA_ITERS');  if ~isempty(ev), bopts.betaIter  = str2double(ev); end; end
+    if ~isfield(bopts, 'alphaLr'),   ev = getenv('NNV_BAB_ALPHA_LR');    if ~isempty(ev), bopts.alphaLr   = str2double(ev); end; end
     % DEVICE (opts.device 'cpu' default | 'gpu'): run the whole BaB on the GPU by moving the ops'
     % weight tensors + the input box to gpuArray ONCE here. The IBP/CROWN passes are gpuArray-
     % overloaded pure linear algebra, so all heavy compute + the per-node intermediate bounds stay

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -746,8 +746,39 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     if nargin < 9, inputSize = []; end
     isFC   = contains(category,"safenlp") || contains(category,"sat_relu") || contains(category,"relusplitter");
     isConv = contains(category,"cifar100") || contains(category,"tinyimagenet");
-    if ~(isFC || isConv), return; end                    % only the gated timeout categories
+    % General-halfspace control benchmarks (NOT argmax): prove the output avoids every unsafe
+    % disjunct in prop.Hg. gpu_bab_halfspace_verify is sound-or-skip (FP64 CROWN + orientation
+    % guard), so it can only ADD a sound unsat. Routed separately below (own predicate).
+    isHalfspace = contains(category,"cersyve") || contains(category,"lsnc_relu") || contains(category,"linearizenn");
+    if ~(isFC || isConv || isHalfspace), return; end     % only the gated timeout categories
     if ~is_nnvnet_valid(nnvnet), return; end             % need a valid NNV net for nn_to_ops + evaluate
+    if isHalfspace
+        try
+            if iscell(lb)                                % multiple input sets -> every set must be safe
+                allRobust = ~isempty(lb);
+                for s = 1:numel(lb)
+                    pv = prop{min(s, numel(prop))};
+                    hv = gpu_bab_halfspace_verify(nnvnet, lb{s}, ub{s}, pv);
+                    if ~strcmp(hv, 'robust'), allRobust = false; break; end
+                end
+                if allRobust
+                    status = 1; reachOptionsList = {};
+                    fprintf('halfspace pre-check: robust/unsat (all %d input sets) -> skip Star\n', numel(lb));
+                end
+            else
+                [hv, hinfo] = gpu_bab_halfspace_verify(nnvnet, lb, ub, prop{1});
+                if strcmp(hv, 'robust')
+                    status = 1; reachOptionsList = {};
+                    fprintf('halfspace pre-check: robust/unsat (%d disjuncts) -> skip Star\n', hinfo.nDisjuncts);
+                else
+                    fprintf('halfspace pre-check: %s (%s) -> Star reach\n', hv, hinfo.reason);
+                end
+            end
+        catch ME
+            fprintf('halfspace pre-check errored (%s) -> Star reach\n', ME.message);
+        end
+        return;                                          % halfspace path is terminal (no argmax fall-through)
+    end
     if isConv && needReshape ~= 0 && ~isempty(inputSize) && ~isscalar(inputSize)
         try
             lb = i_remap_box_to_net(lb, inputSize, needReshape);

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -798,18 +798,30 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     ev = getenv('NNV_CONV_FRONTIER'); if ~isempty(ev), cFrontier = str2double(ev); end
     try
         if isConv && gpuDeviceCount >= 1
-            [gv, ginfo] = gpu_bab_try_verify(nnvnet, lb, ub, prop, ...
-                struct('engine','batched','maxNodes',cMaxNodes,'maxFrontier',cFrontier,'device','gpu','allowUnsoundSingle',true));
-            if strcmp(gv, 'robust')
+            % CONV: an optional fast GPU-single SCREEN, then the sound CPU-DOUBLE pass that decides
+            % the emit (single is never trusted). The screen filters cheaply, but DOUBLE bounds are
+            % tighter (no FP32 rounding loosening) so the double pass crosses the convex barrier in
+            % far fewer nodes -- on robust conv the screen grinds the launch-bound tail much longer
+            % than the double pass takes. NNV_CONV_GPU_SCREEN=0 skips the screen -> straight to double.
+            useScreen = ~isequal(getenv('NNV_CONV_GPU_SCREEN'), '0');
+            screenPass = true;
+            if useScreen
+                [gv, ginfo] = gpu_bab_try_verify(nnvnet, lb, ub, prop, ...
+                    struct('engine','batched','maxNodes',cMaxNodes,'maxFrontier',cFrontier,'device','gpu','allowUnsoundSingle',true));
+                screenPass = strcmp(gv, 'robust');
+                if ~screenPass
+                    fprintf('GPU-BaB pre-check: %s (gpu-screen, %s) -> Star reach\n', gv, ginfo.reason);
+                end
+            end
+            if screenPass
                 [gv2, gi2] = gpu_bab_try_verify(nnvnet, lb, ub, prop, struct('engine','batched','maxNodes',cMaxNodes,'maxFrontier',cFrontier));  % CPU double = sound emit
                 if strcmp(gv2, 'robust')
                     status = 1; reachOptionsList = {};
-                    fprintf('GPU-BaB pre-check: robust/unsat (gpu-screen + %d-node double-confirm) -> skip Star\n', gi2.nodes);
+                    if useScreen, src = 'gpu-screen + '; else, src = ''; end
+                    fprintf('GPU-BaB pre-check: robust/unsat (%s%d-node double) -> skip Star\n', src, gi2.nodes);
                 else
-                    fprintf('GPU-BaB pre-check: gpu-screen robust but double-confirm=%s -> Star reach\n', gv2);
+                    fprintf('GPU-BaB pre-check: double=%s -> Star reach\n', gv2);
                 end
-            else
-                fprintf('GPU-BaB pre-check: %s (gpu-screen, %s) -> Star reach\n', gv, ginfo.reason);
             end
         else
             mn = 5000; if isConv, mn = 64; end                 % conv-without-GPU: bounded (slow but sound)

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -793,12 +793,15 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     % DOUBLE-precision confirm; GPU-single is just a fast filter that can never emit a verdict.
     % FC nets are cheap in double -> single-stage CPU-double (maxNodes 5000). No GPU -> conv also
     % falls back to CPU-double (slow but sound).
+    cMaxNodes = 64; cFrontier = 32;                          % conv BaB budget (env-tunable for dev)
+    ev = getenv('NNV_CONV_MAXNODES'); if ~isempty(ev), cMaxNodes = str2double(ev); end
+    ev = getenv('NNV_CONV_FRONTIER'); if ~isempty(ev), cFrontier = str2double(ev); end
     try
         if isConv && gpuDeviceCount >= 1
             [gv, ginfo] = gpu_bab_try_verify(nnvnet, lb, ub, prop, ...
-                struct('engine','batched','maxNodes',64,'device','gpu','allowUnsoundSingle',true));
+                struct('engine','batched','maxNodes',cMaxNodes,'maxFrontier',cFrontier,'device','gpu','allowUnsoundSingle',true));
             if strcmp(gv, 'robust')
-                [gv2, gi2] = gpu_bab_try_verify(nnvnet, lb, ub, prop, struct('engine','batched','maxNodes',64));  % CPU double = sound emit
+                [gv2, gi2] = gpu_bab_try_verify(nnvnet, lb, ub, prop, struct('engine','batched','maxNodes',cMaxNodes,'maxFrontier',cFrontier));  % CPU double = sound emit
                 if strcmp(gv2, 'robust')
                     status = 1; reachOptionsList = {};
                     fprintf('GPU-BaB pre-check: robust/unsat (gpu-screen + %d-node double-confirm) -> skip Star\n', gi2.nodes);


### PR DESCRIPTION
## GPU-BaB: cifar conv certification + general-halfspace disjunctive BaB

Lands the GPU-BaB / general-halfspace work that was developed on `vnncomp-general-halfspace` (12 commits, +12/−0 vs master — not stale). All sound (sound-or-unknown; FP64 confirm decides every emit), with the parity + beta-MC soundness gate passing at `0.00e+00`.

### Headline
**cifar100 `resnet_medium` gold-unsat now certifies**: `run_vnncomp_instance` returns `STATUS=1 (unsat = robust)`, correct, soundly via the FP64 confirm, in ~247–259s (verified across two runs). The conv GPU-BaB went from OOMing at frontier 8 to certifying a real cifar ResNet.

### Efficiency work (the cifar levers)
- **Spec reduction (monotone-margin pruning)** — each spec's margin is monotone non-decreasing down the BaB tree, so disjuncts proven at the root are avoided everywhere; bound only the unproven specs. cifar keeps **1/99**. Sound for argmax and general-halfspace disjuncts (reference = the fixed-slope no-fixings root bound children meet/exceed).
- **Amortized alpha-CROWN** (root-optimized slopes reused as a fixed-slope bound, no per-node tape → large frontier) + **worst-spec memory-efficient gradient** (per-node alpha+beta tape = 1 spec, not 99 → frontier 8→256) + **find-worst-once** + **min-area fallback guard** (returned bound never below min-area).
- **Proper BaBSR branching** — split on `sum_s |Aneg|·bu` (output-sensitivity × gap), not just the gap.
- **O(B) preallocated int8 stack** (pointer + amortized doubling; behavior-identical to the old concat stack) and **periodic cex**.
- **alpha_dag `alphaInit` warm-start** param + section profiling + env knobs (`NNV_BAB_ALPHA_ITERS/BETA_ITERS/ALPHA_LR`).
- Dispatcher: optional `NNV_CONV_GPU_SCREEN=0` (skip the FP32 screen). Default path (FP32 GPU screen → FP64 CPU confirm) unchanged.

### General-halfspace foundation
- Generalize the batched BaB certification to the **disjunctive predicate** (prove the output avoids every unsafe disjunct in `prop.Hg`); argmax is the single-row special case.
- Integrate alpha-beta-dag into the disjunctive BaB; root-CROWN general-halfspace pre-check + dispatcher wiring for `cersyve`/`lsnc_relu`/`linearizenn` (sound: skip → Star when it can't decide).

### Soundness
FP32/GPU is a fast screen that never emits; the **FP64 CPU pass decides every verdict**. Spec reduction is sound by the monotonicity argument; the stack rework is behavior-identical; BaBSR only changes *which* neuron splits. Parity test (`gpu_bab_alpha_dag_parity_test`) asserts IBP/rootBounds parity `0.00e+00`, no-worse-than-min-area, and beta Monte-Carlo soundness (bound ≤ MC true-min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
