### PR TITLE
GPU-BaB: address Copilot review on #380 (env NaN guards + isprop-safe Hg check + halfspace soundness test)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -87,9 +87,11 @@ function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
     bopts = struct('precision', precision, 'spec', spec, 'margin', guardTol, 'rootTight', true, ...
                    'maxNodes', i_optget(opts, 'maxNodes', 5000), 'maxFrontier', i_optget(opts, 'maxFrontier', 256), ...
                    'alphaIter', i_optget(opts, 'alphaIter', 20), 'betaIter', i_optget(opts, 'betaIter', 20));
-    ev = getenv('NNV_HS_ALPHA'); if ~isempty(ev), bopts.alphaIter = str2double(ev); end
-    ev = getenv('NNV_HS_BETA');  if ~isempty(ev), bopts.betaIter  = str2double(ev); end
-    ev = getenv('NNV_HS_MAXNODES'); if ~isempty(ev), bopts.maxNodes = str2double(ev); end
+    % env overrides only when finite + in range (str2double of unset/non-numeric is NaN -> keep the
+    % default; a NaN maxNodes would un-bound the BaB, a NaN iter count would disable the knob)
+    v = str2double(getenv('NNV_HS_ALPHA'));    if isfinite(v) && v >= 0, bopts.alphaIter = v; end
+    v = str2double(getenv('NNV_HS_BETA'));     if isfinite(v) && v >= 0, bopts.betaIter  = v; end
+    v = str2double(getenv('NNV_HS_MAXNODES')); if isfinite(v) && v >= 1, bopts.maxNodes  = v; end
     try
         [st, binfo] = gpu_bab_relu_split_batched(ops, lb, ub, 1, nOut, bopts);
     catch ME
@@ -108,7 +110,7 @@ function [Gd, gd, rows, ok] = i_parse_disjuncts(prop, nOut)
 % prop.Hg: array of HalfSpace objects, each one unsafe disjunct {y : G*y <= g}. Return per-disjunct
 % G (k_d x nOut) and g (k_d x 1), plus rows{d} = the indices of disjunct d in the stacked spec.
     Gd = {}; gd = {}; rows = {}; ok = false;
-    if ~isfield(prop, 'Hg') && ~isprop(prop, 'Hg'), return; end
+    if ~i_has(prop, 'Hg'), return; end                 % struct-safe presence check (skip if no Hg)
     Hg = prop.Hg;
     if isempty(Hg), return; end
     if ~iscell(Hg), Hg = num2cell(Hg); end             % HalfSpace array -> cell of disjuncts
@@ -127,4 +129,10 @@ end
 
 function v = i_optget(s, f, d)
     if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end
+
+function tf = i_has(s, f)
+% struct-safe field/property presence check: isfield for structs (the load_vnnlib* prop case),
+% isprop for objects. Avoids relying on isprop's version-dependent behavior on a struct input.
+    if isstruct(s), tf = isfield(s, f); else, tf = isprop(s, f); end
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_try_verify.m
@@ -138,9 +138,11 @@ function [verdict, info] = gpu_bab_try_verify(net, lb, ub, target, opts)
     % per-node alpha+beta CROWN tightening (env override for dev/tuning; sound for any value --
     % alpha in [0,1], beta>=0 are valid relaxations). Lets the BaB cross the convex barrier the
     % fixed-slope bound can't, on the hardest deep nodes.
-    if ~isfield(bopts, 'alphaIter'), ev = getenv('NNV_BAB_ALPHA_ITERS'); if ~isempty(ev), bopts.alphaIter = str2double(ev); end; end
-    if ~isfield(bopts, 'betaIter'),  ev = getenv('NNV_BAB_BETA_ITERS');  if ~isempty(ev), bopts.betaIter  = str2double(ev); end; end
-    if ~isfield(bopts, 'alphaLr'),   ev = getenv('NNV_BAB_ALPHA_LR');    if ~isempty(ev), bopts.alphaLr   = str2double(ev); end; end
+    % only override when the parsed env is finite + in range (str2double of unset/non-numeric is NaN;
+    % a NaN alphaIter/betaIter would propagate through max(alphaIter,betaIter) and silently disable the knob)
+    if ~isfield(bopts, 'alphaIter'), v = str2double(getenv('NNV_BAB_ALPHA_ITERS')); if isfinite(v) && v >= 0, bopts.alphaIter = v; end; end
+    if ~isfield(bopts, 'betaIter'),  v = str2double(getenv('NNV_BAB_BETA_ITERS'));  if isfinite(v) && v >= 0, bopts.betaIter  = v; end; end
+    if ~isfield(bopts, 'alphaLr'),   v = str2double(getenv('NNV_BAB_ALPHA_LR'));    if isfinite(v) && v >  0, bopts.alphaLr   = v; end; end
     % DEVICE (opts.device 'cpu' default | 'gpu'): run the whole BaB on the GPU by moving the ops'
     % weight tensors + the input box to gpuArray ONCE here. The IBP/CROWN passes are gpuArray-
     % overloaded pure linear algebra, so all heavy compute + the per-node intermediate bounds stay

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -794,8 +794,10 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     % FC nets are cheap in double -> single-stage CPU-double (maxNodes 5000). No GPU -> conv also
     % falls back to CPU-double (slow but sound).
     cMaxNodes = 64; cFrontier = 32;                          % conv BaB budget (env-tunable for dev)
-    ev = getenv('NNV_CONV_MAXNODES'); if ~isempty(ev), cMaxNodes = str2double(ev); end
-    ev = getenv('NNV_CONV_FRONTIER'); if ~isempty(ev), cFrontier = str2double(ev); end
+    % env overrides only when finite + sane (str2double of unset/non-numeric is NaN -> keep the
+    % default; a NaN budget would make info.nodes>maxNodes false forever and silently un-bound the BaB)
+    ev = str2double(getenv('NNV_CONV_MAXNODES')); if isfinite(ev) && ev >= 1, cMaxNodes = ev; end
+    ev = str2double(getenv('NNV_CONV_FRONTIER')); if isfinite(ev) && ev >= 1, cFrontier = ev; end
     try
         if isConv && gpuDeviceCount >= 1
             % CONV: an optional fast GPU-single SCREEN, then the sound CPU-DOUBLE pass that decides

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_halfspace.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_halfspace.m
@@ -1,0 +1,61 @@
+% test_soundness_gpu_bab_halfspace
+% Soundness tests for gpu_bab_halfspace_verify -- the additive general-halfspace (disjunctive)
+% GPU-BaB pre-check for the control benchmarks (cersyve / lsnc_relu / linearizenn). The cardinal
+% property: it must NEVER return 'robust' when the reachable output ENTERS an unsafe disjunct
+% {y : G*y <= g} (a -150). Malformed / missing / mis-dimensioned Hg must 'skip' GRACEFULLY (no
+% crash -> the dispatcher falls back to Star). Small FC ReLU control-style net + modest budget.
+
+rng(23);
+% control-style net: 4 flat inputs -> 2 outputs (Y_0, Y_1)
+layers = [featureInputLayer(4,'Name','in'); fullyConnectedLayer(6,'Name','f1'); ...
+          reluLayer('Name','r1'); fullyConnectedLayer(2,'Name','out')];
+net = matlab2nnv(dlnetwork(layers));
+lb = -ones(4,1); ub = ones(4,1);
+opts = struct('maxNodes', 300);                        % bound BaB for test speed
+
+% sample the reachable output range to place disjuncts relative to the reachable set
+N = 5000; Y = zeros(2, N);
+for k = 1:N, Y(:,k) = net.evaluate(lb + (ub-lb).*rand(4,1)); end
+y1 = Y(1,:); med1 = median(y1); min1 = min(y1); max1 = max(y1);
+
+%% Test 1: a disjunct the reachable set clearly AVOIDS -> 'robust' (or 'unknown'); if robust, MC-sound
+% unsafe = {y : y_1 <= min1 - 100}: far below every reachable y_1, so provably avoided.
+[v1, i1] = gpu_bab_halfspace_verify(net, lb, ub, struct('Hg', HalfSpace([1 0], min1 - 100)), opts);
+assert(ismember(string(v1), ["robust","unknown"]), 'avoided disjunct must be robust/unknown, got %s', v1);
+assert(i1.guardErr < 1e-4, 'orientation guard must pass on a correctly-extracted FC net');
+if strcmp(v1, 'robust')
+    bad = false;
+    for s = 1:5000, ys = net.evaluate(lb + (ub-lb).*rand(4,1)); if ys(1) <= min1 - 100, bad = true; break; end, end
+    assert(~bad, 'CARDINAL: robust but MC found an output inside the unsafe disjunct (-150)');
+end
+
+%% Test 2: a disjunct the reachable set ENTERS -> must NOT be 'robust' (-150 guard)
+% unsafe = {y : y_1 <= med1}: ~half the reachable outputs are inside, so genuinely unsafe.
+[v2, ~] = gpu_bab_halfspace_verify(net, lb, ub, struct('Hg', HalfSpace([1 0], med1)), opts);
+assert(~strcmp(v2, 'robust'), 'CARDINAL: certified robust on a disjunct the reachable set enters (-150)');
+enters = false;
+for s = 1:5000, ys = net.evaluate(lb + (ub-lb).*rand(4,1)); if ys(1) <= med1, enters = true; break; end, end
+assert(enters, 'test setup: the unsafe disjunct should be reachable');
+
+%% Test 3: malformed / missing / mis-dimensioned Hg must 'skip' gracefully (the isfield/isprop-safe path)
+[va, ~] = gpu_bab_halfspace_verify(net, lb, ub, struct(), opts);                              % no Hg field
+assert(strcmp(va, 'skip'), 'missing Hg must skip, got %s', va);
+[vb, ~] = gpu_bab_halfspace_verify(net, lb, ub, struct('Hg', []), opts);                      % empty Hg
+assert(strcmp(vb, 'skip'), 'empty Hg must skip, got %s', vb);
+[vc, ~] = gpu_bab_halfspace_verify(net, lb, ub, struct('Hg', HalfSpace([1 0 0], 1)), opts);   % wrong dim (3 != nOut 2)
+assert(strcmp(vc, 'skip'), 'dimension-mismatched Hg must skip, got %s', vc);
+
+%% Test 4: unsupported architecture (tanh) -> 'skip'
+ulayers = [featureInputLayer(4,'Name','in'); fullyConnectedLayer(5,'Name','f1'); ...
+           tanhLayer('Name','t'); fullyConnectedLayer(2,'Name','out')];
+unet = matlab2nnv(dlnetwork(ulayers));
+[v4, ~] = gpu_bab_halfspace_verify(unet, lb, ub, struct('Hg', HalfSpace([1 0], 0)), opts);
+assert(strcmp(v4, 'skip'), 'unsupported arch (tanh) must skip, got %s', v4);
+
+%% Test 5: a multi-disjunct UNION the reachable set enters -> must NOT be 'robust'
+% union = {y_1 <= med1} OR {y_1 >= max1 + 100}: the first is entered, so the union is unsafe.
+Hu = [HalfSpace([1 0], med1), HalfSpace([-1 0], -(max1 + 100))];
+[v5, ~] = gpu_bab_halfspace_verify(net, lb, ub, struct('Hg', Hu), opts);
+assert(~strcmp(v5, 'robust'), 'CARDINAL: robust on a union that the reachable set enters (-150)');
+
+disp('test_soundness_gpu_bab_halfspace: all sections passed');


### PR DESCRIPTION
Addresses GitHub Copilot's review of #380 (5 comments). Follow-up to the merged GPU-BaB / general-halfspace work.

### Fixes
- **str2double env-var NaN guards** (4 of the 5 comments): `NNV_CONV_MAXNODES/FRONTIER`, `NNV_BAB_ALPHA_ITERS/BETA_ITERS/ALPHA_LR`, and `NNV_HS_ALPHA/BETA/MAXNODES` were applied without validating the parse. A non-numeric (or unset) value yields `NaN`, which would silently un-bound the node budget (`info.nodes > NaN` is always false) or disable an iteration knob (propagates through `max(alphaIter,betaIter)`). Now overridden only when `isfinite` and in range; defaults kept otherwise. (`str2double` of an unset env is already `NaN`, so `isfinite` covers both cases in one check.)
- **`isprop`-on-struct hardening** (comment #3): `gpu_bab_halfspace_verify`'s `Hg`-presence check used `~isfield(prop,'Hg') && ~isprop(prop,'Hg')`. `isprop` on a struct returns `false` in R2026a (verified — no crash) but its struct behavior has varied across MATLAB versions. Replaced with a struct-safe `i_has()` helper (`isfield` for structs, `isprop` for objects). Even the error path was caught by the dispatcher try-catch → Star, so this is hardening, not a −150 fix.
- **New soundness test** (comment #5): `test_soundness_gpu_bab_halfspace.m` — the missing gate for the disjunctive halfspace path. Asserts the cardinal property (never `robust` when the reachable set **enters** an unsafe disjunct — single and multi-disjunct union), MC-confirms any `robust` is sound, and that malformed/missing/mis-dimensioned `Hg` and unsupported architectures `skip` gracefully.

### Verification
On the box (R2026a): `test_soundness_gpu_bab_halfspace` **all sections passed**; existing `test_soundness_gpu_bab_dispatch` still **all sections passed** (try_verify env change is non-breaking).

No behavior change on valid configs; the sound-or-unknown contract is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
