### PR TITLE
GPU-BaB: control-benchmark op support (Concat + bilinear McCormick) + flat-op width soundness fix + Clip-and-Verify

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_clip.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_clip.m
@@ -1,0 +1,58 @@
+function [lb2, ub2, empty] = gpu_bab_clip(lb, ub, A, c)
+% GPU_BAB_CLIP  Clip-and-Verify Relaxed Clipping (Zhou et al., NeurIPS 2025, Thm 3.2).
+%   [lb2, ub2, empty] = GPU_BAB_CLIP(lb, ub, A, c) tightens the axis-aligned box [lb,ub] against
+%   the linear constraint system A*x + c <= 0 (A is m-by-n, c is m-by-1). It returns the tightest
+%   box that still contains the feasible set F = { x in [lb,ub] : A*x + c <= 0 }, and a flag
+%   `empty` that is true when F is provably EMPTY (the constraint system is infeasible over the
+%   box). One O(n) closed-form pass per constraint (parallel version: every constraint clips from
+%   the ORIGINAL box center, then the elementwise-tightest bound is kept -- order-independent and
+%   a sound over-approximation).
+%
+%   USE FOR JOINT POLYTOPE AVOIDANCE (the gap single-halfspace separation misses): to prove the
+%   network output avoids an unsafe disjunct {G*y <= g}, take the CROWN input-space LOWER plane of
+%   each row, G_i*y >= Ain_i*x + din_i (from gpu_bab_crown_tight), so the unsafe set
+%   {x : G_i*y(x) <= g_i for ALL i} is a SUBSET of {x : Ain_i*x + (din_i - g_i) <= 0 for all i}.
+%   Call gpu_bab_clip(lb, ub, Ain, din - g); if `empty`, NO input reaches the unsafe polytope ->
+%   the disjunct is avoided JOINTLY -> sound UNSAT. (Each row alone need not separate.)
+%
+%   SOUNDNESS (Thm 3.2 + its proof B.4): for a single constraint a'x + c <= 0, the per-coordinate
+%   clip x_i^clip = ( -sum_{j!=i}[a_j*xhat_j - |a_j|*eps_j] - c ) / a_i (xhat = box center, eps =
+%   half-width) is the exact max/min of x_i over F, so F subset [lb2,ub2] subset [lb,ub]. The
+%   infeasibility test min_{box}(a'x + c) = a'xhat - sum|a|eps + c > 0 means the constraint cannot
+%   hold anywhere in the box. For multiple constraints, F subset (intersection of per-constraint
+%   over-approx boxes) subset [lb2,ub2]; empty => F empty. No false "empty" -> no wrong UNSAT.
+
+    lb = double(lb(:)); ub = double(ub(:)); n = numel(lb);
+    A = double(A); c = double(c(:)); m = size(A, 1);
+    lb2 = lb; ub2 = ub; empty = false;
+    if m == 0, return; end
+    if size(A, 2) ~= n
+        error('gpu_bab_clip:dim', 'A has %d cols but the box is %d-dim.', size(A,2), n);
+    end
+    xhat = (lb + ub) / 2;
+    eps  = (ub - lb) / 2;                          % >= 0
+    tol  = 1e-12;
+    for k = 1:m
+        a = A(k, :).';                             % n x 1
+        ck = c(k);
+        boxMin = a.' * xhat - sum(abs(a) .* eps);  % min over the box of a'x
+        if boxMin + ck > tol                       % constraint a'x + c <= 0 infeasible over the box
+            empty = true; return;
+        end
+        nz = find(a ~= 0);
+        for q = 1:numel(nz)
+            i = nz(q); ai = a(i);
+            % worst (most-negative) value of sum_{j != i} a_j x_j over the box:
+            crossMin = boxMin - (ai * xhat(i) - abs(ai) * eps(i));
+            xclip = (-crossMin - ck) / ai;
+            if ai > 0
+                ub2(i) = min(ub2(i), xclip);
+            else
+                lb2(i) = max(lb2(i), xclip);
+            end
+        end
+    end
+    if any(lb2 > ub2 + tol)                        % some coordinate clipped to empty
+        empty = true;
+    end
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -70,6 +70,14 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                 cl{k+1} = vertcat(cl{ic}); cu{k+1} = vertcat(cu{ic});
                 continue;
             end
+            if strcmp(op.type, 'product')                 % bilinear: store stacked input bounds + corner interval
+                ia = op.inputs(1)+1; ib = op.inputs(2)+1;
+                la = cl{ia}; ua = cu{ia}; lyy = cl{ib}; uyy = cu{ib};
+                preL{k} = [la; lyy]; preU{k} = [ua; uyy];  % feed the McCormick backward
+                c1=la.*lyy; c2=la.*uyy; c3=ua.*lyy; c4=ua.*uyy;
+                cl{k+1} = min(min(c1,c2),min(c3,c4)); cu{k+1} = max(max(c1,c2),max(c3,c4));
+                continue;
+            end
             s = op.src + 1; lb = cl{s}; ub = cu{s};
             switch op.type
                 case 'affine'
@@ -122,9 +130,15 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                     u(fx == -1) = min(u(fx == -1), 0);
                 end
                 preL{k} = l; preU{k} = u;
+            elseif strcmp(tk, 'product')
+                % bilinear: reuse the root stacked input bounds (broadcast). No per-node clamp --
+                % products carry no ReLU fixings; root bounds hold over the full box >= node region
+                % (sound, possibly looser than re-concretizing). Backward reads preL{k}=[xb;yb].
+                preL{k} = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
+                preU{k} = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
             elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add','concat'}))
                 error('gpu_bab_crown_spec_dag:op', ...
-                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add/concat only).', tk);
+                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add/concat/product only).', tk);
             end
         end
     end
@@ -174,6 +188,36 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                 elseif isempty(skipA{s}), skipA{s} = Ablk;
                 else, skipA{s} = skipA{s} + Ablk;
                 end
+            end
+            continue;
+        end
+        if strcmp(op.type, 'product')
+            % out = in[a].*in[b], bilinear: McCormick (gpu_bab_mul_relax), sign-aware, route a
+            % DISTINCT coefficient to each input (like 'add' but Ax/Ay differ). A is nSpec x wa x B;
+            % preL{k}=[xb;yb] is 2*wa x B (stacked input bounds). Sound: +coeff uses the LOWER
+            % plane for a spec lower bound; -coeff the UPPER plane (the al/au rule).
+            wa = op.sizes(1); lz = preL{k}; uz = preU{k};
+            la = lz(1:wa,:); ua = uz(1:wa,:); lyy = lz(wa+1:end,:); uyy = uz(wa+1:end,:);
+            [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(la, ua, lyy, uyy, [], [], precision);  % each wa x B
+            % spec_dag computes a LOWER bound on C*f (like its ReLU relax): +coeff -> LOWER plane,
+            % -coeff -> UPPER plane.
+            Apos = max(A,0); Aneg = min(A,0);
+            aLr = reshape(aL,1,wa,B); aUr = reshape(aU,1,wa,B);
+            bLr = reshape(bL,1,wa,B); bUr = reshape(bU,1,wa,B);
+            Ax = Apos.*aLr + Aneg.*aUr; Ay = Apos.*bLr + Aneg.*bUr;
+            d = d + reshape(pagemtimes(Apos, reshape(cL,wa,1,B)), nSpec, B) ...
+                  + reshape(pagemtimes(Aneg, reshape(cU,wa,1,B)), nSpec, B);
+            sa = op.inputs(1);
+            if sa == 0
+                if isempty(inputSkipA), inputSkipA = Ax; else, inputSkipA = inputSkipA + Ax; end
+            elseif isempty(skipA{sa}), skipA{sa} = Ax;
+            else, skipA{sa} = skipA{sa} + Ax;
+            end
+            sb = op.inputs(2);
+            if sb == 0
+                if isempty(inputSkipA), inputSkipA = Ay; else, inputSkipA = inputSkipA + Ay; end
+            elseif isempty(skipA{sb}), skipA{sb} = Ay;
+            else, skipA{sb} = skipA{sb} + Ay;
             end
             continue;
         end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -65,6 +65,11 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                 cl{k+1} = cl{a} + cl{b}; cu{k+1} = cu{a} + cu{b};
                 continue;
             end
+            if strcmp(op.type, 'concat')
+                ic = op.inputs + 1;                       % stack input bounds (LINEAR -> exact)
+                cl{k+1} = vertcat(cl{ic}); cu{k+1} = vertcat(cu{ic});
+                continue;
+            end
             s = op.src + 1; lb = cl{s}; ub = cu{s};
             switch op.type
                 case 'affine'
@@ -117,9 +122,9 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                     u(fx == -1) = min(u(fx == -1), 0);
                 end
                 preL{k} = l; preU{k} = u;
-            elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add'}))
+            elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add','concat'}))
                 error('gpu_bab_crown_spec_dag:op', ...
-                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add only).', tk);
+                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add/concat only).', tk);
             end
         end
     end
@@ -153,6 +158,21 @@ function [margins, preL, preU, scoreCell] = gpu_bab_crown_spec_dag(ops, x_lb, x_
                     if isempty(inputSkipA), inputSkipA = A; else, inputSkipA = inputSkipA + A; end
                 elseif isempty(skipA{s}), skipA{s} = A;
                 else, skipA{s} = skipA{s} + A;
+                end
+            end
+            continue;
+        end
+        if strcmp(op.type, 'concat')
+            % out = [in_1; in_2; ...] -> SLICE the coefficient's dim axis (axis 2) back to each
+            % input's block (transpose of stacking, LINEAR -> exact). A is nSpec x outDim x B.
+            off = 0;
+            for ii = 1:numel(op.inputs)
+                sz = op.sizes(ii); s = op.inputs(ii);
+                Ablk = A(:, off+(1:sz), :); off = off + sz;
+                if s == 0
+                    if isempty(inputSkipA), inputSkipA = Ablk; else, inputSkipA = inputSkipA + Ablk; end
+                elseif isempty(skipA{s}), skipA{s} = Ablk;
+                else, skipA{s} = skipA{s} + Ablk;
                 end
             end
             continue;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -1,5 +1,9 @@
-function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, C, precision, fixings)
+function [margins, preL, preU, unstable, Ain, din] = gpu_bab_crown_tight(ops, x_lb, x_ub, C, precision, fixings)
 % GPU_BAB_CROWN_TIGHT  CROWN with TIGHT (backward) intermediate-layer bounds.
+%   Optional 5th/6th outputs Ain (nSpec x nIn), din (nSpec x 1) are the CROWN input-space LOWER
+%   plane for the spec: C*f(x) >= Ain*x + din for every x in [x_lb,x_ub] (margins = min over the
+%   box of that plane). Used by Clip-and-Verify domain clipping (gpu_bab_clip) for the joint
+%   output-polytope avoidance that single-halfspace separation misses.
 %
 %   [margins, preL, preU] = GPU_BAB_CROWN_TIGHT(ops, x_lb, x_ub, C, precision)
 %   computes a sound lower bound on C*f(x) over [x_lb,x_ub] using CROWN-tight
@@ -67,8 +71,8 @@ function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, 
         end
     end
 
-    % ---- final spec margin (lower bound on C*output) ----
-    margins = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true);
+    % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
+    [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true);
 end
 
 function w = i_layer_width(ops, upto)
@@ -93,19 +97,22 @@ function w = i_layer_width(ops, upto)
     error('gpu_bab_crown_tight:nolinear', 'no affine/conv op before index %d', upto);
 end
 
-function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
+function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
 % Backward CROWN over the DAG ops[1..upto] with initial coefficient A0 (on op `upto`'s output).
 % FULL DAG: each op routes its backward coefficient to op.src (its input op), accumulated in
 % skipA{src}; an 'add' routes UNCHANGED to BOTH inputs (linear -> exact). skipA{k} = accumulated
 % coefficient on op k's OUTPUT; inputSkipA = coefficient on op 0 (the engine input). Ops are
 % topologically ordered, so k=upto:-1:1 visits every consumer of op k before op k itself, so
 % skipA{k} is complete when op k is processed (sound by induction). lower=true -> lower bound.
+% Optional Ain (nS x nIn), din (nS x 1): the input-space affine form, so for lower=true the
+% bounded quantity >= Ain*x + din for all x in the box (bound = min over the box of that plane).
     nS = size(A0, 1);
     d = zeros(nS, 1, precision);
     if upto == 0                              % A0 is already on the engine input (op 0)
         Apos = max(A0, 0); Aneg = min(A0, 0);
         if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
         else,     bound = Apos*cast(x_ub,precision) + Aneg*cast(x_lb,precision); end
+        Ain = A0; din = zeros(nS, 1, precision);
         return;
     end
     skipA = cell(upto, 1);
@@ -196,6 +203,8 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
         end
     end
     A = inputSkipA;                           % total coefficient on the engine input
+    if isscalar(A), A = zeros(nS, numel(x_lb), precision); end   % input-independent -> zero plane
+    Ain = A; din = d;                         % input-space affine form: bounded >= Ain*x + din (lower)
     Apos = max(A, 0); Aneg = min(A, 0);
     if lower
         bound = Apos * cast(x_lb, precision) + Aneg * cast(x_ub, precision) + d;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -117,7 +117,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     end
     skipA = cell(upto, 1);
     skipA{upto} = A0;                         % seed: A0 is the coefficient on op `upto`'s output
-    inputSkipA = 0;
+    inputSkipA = zeros(nS, numel(x_lb), precision);   % coefficient on the engine input (op 0); always nS x nIn
     for k = upto:-1:1
         A = skipA{k};
         if isempty(A), continue; end          % nothing routed to op k (dead w.r.t. the output)
@@ -202,8 +202,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         else,                     skipA{s} = skipA{s} + A;
         end
     end
-    A = inputSkipA;                           % total coefficient on the engine input
-    if isscalar(A), A = zeros(nS, numel(x_lb), precision); end   % input-independent -> zero plane
+    A = inputSkipA;                           % total coefficient on the engine input (nS x nIn; zero if no input dependence)
     Ain = A; din = d;                         % input-space affine form: bounded >= Ain*x + din (lower)
     Apos = max(A, 0); Aneg = min(A, 0);
     if lower

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -48,6 +48,22 @@ function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, 
             if strcmp(tk, 'relu')
                 unstable{k} = (pl < 0) & (pu > 0);
             end
+        elseif strcmp(tk, 'product')
+            % BILINEAR product feeds the McCormick relaxation from the OUTPUT bounds of BOTH its
+            % input ops. Bound each input op's output (backward CROWN over its prefix, sound by
+            % induction) and store them STACKED [in1; in2] under preL{k}/preU{k} (numeric, so the
+            % BaB infeasible/gather logic stays valid). Width per input = ops{k}.sizes(1)=sizes(2).
+            ins = ops{k}.inputs;
+            plS = []; puS = [];
+            for ii = 1:2
+                si = ins(ii);
+                if si == 0, nki = numel(x_lb); else, nki = i_layer_width(ops, si); end
+                Cki = eye(nki, precision);
+                pui = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, false);
+                pli = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, true);
+                plS = [plS; pli]; puS = [puS; pui]; %#ok<AGROW>
+            end
+            preL{k} = plS; preU{k} = puS;
         end
     end
 
@@ -66,6 +82,7 @@ function w = i_layer_width(ops, upto)
         elseif strcmp(t, 'add'),        w = prod(ops{k}.shape);    return;
         elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
         elseif strcmp(t, 'concat'),     w = sum(ops{k}.sizes);     return;
+        elseif strcmp(t, 'product'),    w = ops{k}.sizes(1);       return;  % elementwise: out width = each input width
         end
     end
     error('gpu_bab_crown_tight:nolinear', 'no affine/conv op before index %d', upto);
@@ -112,6 +129,33 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
                 elseif isempty(skipA{s}), skipA{s} = Ablk;
                 else,                     skipA{s} = skipA{s} + Ablk;
                 end
+            end
+            continue;
+        end
+        if strcmp(op.type, 'product')         % out = in[a].*in[b], bilinear: McCormick, route to BOTH inputs
+            wa = op.sizes(1); lz = preL{k}; uz = preU{k};
+            la = lz(1:wa);       ua = uz(1:wa);          % input a (x) output bounds
+            lyy = lz(wa+1:end);  uyy = uz(wa+1:end);     % input b (y) output bounds
+            [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(la, ua, lyy, uyy, [], [], precision);
+            Apos = max(A, 0); Aneg = min(A, 0);          % sign-aware: +coeff -> LOWER plane (lower bnd)
+            if lower
+                Ax = Apos .* aL.' + Aneg .* aU.';
+                Ay = Apos .* bL.' + Aneg .* bU.';
+                d  = d + Apos * cL + Aneg * cU;
+            else
+                Ax = Apos .* aU.' + Aneg .* aL.';
+                Ay = Apos .* bU.' + Aneg .* bL.';
+                d  = d + Apos * cU + Aneg * cL;
+            end
+            sa = op.inputs(1);
+            if sa == 0,                inputSkipA = inputSkipA + Ax;
+            elseif isempty(skipA{sa}), skipA{sa} = Ax;
+            else,                      skipA{sa} = skipA{sa} + Ax;
+            end
+            sb = op.inputs(2);
+            if sb == 0,                inputSkipA = inputSkipA + Ay;
+            elseif isempty(skipA{sb}), skipA{sb} = Ay;
+            else,                      skipA{sb} = skipA{sb} + Ay;
             end
             continue;
         end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -72,7 +72,12 @@ function [margins, preL, preU, unstable] = gpu_bab_crown_tight(ops, x_lb, x_ub, 
 end
 
 function w = i_layer_width(ops, upto)
-% # outputs of ops[1..upto] = rows of the last affine in that prefix.
+% Flat output width of op `upto`. Prefer the recorded nOut (exact for ALL ops incl. flat
+% add/normaffine, where prod(shape)=prod([])=1 was a latent width=1 bug); fall back to the
+% structural walk for ops emitted without it.
+    if isfield(ops{upto}, 'nOut') && ~isempty(ops{upto}.nOut)
+        w = ops{upto}.nOut; return;
+    end
     for k = upto:-1:1
         t = ops{k}.type;
         if strcmp(t, 'affine'),         w = size(ops{k}.W, 1);     return;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -65,6 +65,7 @@ function w = i_layer_width(ops, upto)
         elseif strcmp(t, 'maxpool'),    w = prod(ops{k}.outShape); return;
         elseif strcmp(t, 'add'),        w = prod(ops{k}.shape);    return;
         elseif strcmp(t, 'normaffine'), w = prod(ops{k}.shape);    return;
+        elseif strcmp(t, 'concat'),     w = sum(ops{k}.sizes);     return;
         end
     end
     error('gpu_bab_crown_tight:nolinear', 'no affine/conv op before index %d', upto);
@@ -98,6 +99,18 @@ function bound = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lo
                 if s == 0,                inputSkipA = inputSkipA + A;
                 elseif isempty(skipA{s}), skipA{s} = A;
                 else,                     skipA{s} = skipA{s} + A;
+                end
+            end
+            continue;
+        end
+        if strcmp(op.type, 'concat')          % out = [in_1; in_2; ...]: SLICE columns back to each input
+            off = 0;
+            for ii = 1:numel(op.inputs)
+                sz = op.sizes(ii); s = op.inputs(ii);
+                Ablk = A(:, off+(1:sz)); off = off + sz;
+                if s == 0,                inputSkipA = inputSkipA + Ablk;
+                elseif isempty(skipA{s}), skipA{s} = Ablk;
+                else,                     skipA{s} = skipA{s} + Ablk;
                 end
             end
             continue;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_input_bab.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_input_bab.m
@@ -1,0 +1,84 @@
+function [verdict, info] = gpu_bab_halfspace_input_bab(ops, lb, ub, Gd, gd, opts)
+% GPU_BAB_HALFSPACE_INPUT_BAB  Input-domain bisection branch-and-bound for general-halfspace
+%   specs whose relaxation looseness shrinks with the INPUT box width -- in particular BILINEAR
+%   / product nets (e.g. lsnc Lyapunov), where the McCormick gap is O((box width)^2) so halving
+%   an input dimension quarters the gap. Per sub-box it computes a tight CROWN bound
+%   (gpu_bab_crown_tight, which handles the 'product' McCormick op) and certifies each unsafe
+%   disjunct by EITHER single-row separation (some row's sound lower bound G_i*y - g_i > tol) OR
+%   the Clip-and-Verify joint emptiness test (gpu_bab_clip on the disjunct's conjunction). An
+%   undecided sub-box is split on its widest input dimension.
+%
+%   [verdict, info] = ... ; verdict = 'robust' | 'unknown'.
+%
+%   SOUNDNESS (sound-or-unknown): the two children of a bisection PARTITION the parent box
+%   (closed split [lb,mid] U [mid,ub]); 'robust' is returned ONLY when the stack empties with
+%   EVERY popped sub-box certified avoided, so the whole input box is covered by certified-safe
+%   sub-boxes. Both certification tests are sound (single-row = a sound CROWN lower bound;
+%   gpu_bab_clip never reports a false "empty"). FP64. Never a wrong unsat.
+%
+%   WHEN TO USE: only when the gap shrinks with box width (bilinear/product). For pure-ReLU nets
+%   (e.g. cersyve) the looseness lives in the ReLU relaxation, not the box, and input bisection
+%   does NOT converge -- the caller should gate this on the presence of a 'product' op.
+%
+%   opts (all optional): .maxNodes (2e5) .timeCap (Inf, s) .tol (1e-6) .precision ('double')
+%                        .minWidth (1e-9, barrier guard).
+
+    if nargin < 6, opts = struct(); end
+    maxNodes = i_g(opts, 'maxNodes', 200000);
+    timeCap  = i_g(opts, 'timeCap',  Inf);
+    tol      = i_g(opts, 'tol',      1e-6);
+    prec     = i_g(opts, 'precision','double');
+    minWidth = i_g(opts, 'minWidth', 1e-9);
+
+    nOps = numel(ops);
+    C    = cat(1, Gd{:});
+    gAll = cat(1, gd{:});
+    rows = cell(1, numel(Gd)); r0 = 0;
+    for d = 1:numel(Gd), nr = size(Gd{d}, 1); rows{d} = r0 + (1:nr); r0 = r0 + nr; end
+    lb = double(lb(:)); ub = double(ub(:)); n = numel(lb);
+
+    info = struct('nodes', 0, 'maxStack', 1, 'sep', 0, 'clip', 0, 'reason', '');
+
+    % LIFO stack of sub-boxes as columns of SL/SU (n x cap), amortized-doubling capacity.
+    cap = 1024;
+    SL = zeros(n, cap); SU = zeros(n, cap);
+    SL(:, 1) = lb; SU(:, 1) = ub; top = 1;
+    t0 = tic;
+
+    while top > 0
+        nl = SL(:, top); nu = SU(:, top); top = top - 1;
+        info.nodes = info.nodes + 1;
+        if info.nodes > maxNodes, verdict = 'unknown'; info.reason = 'maxNodes'; return; end
+        if toc(t0) > timeCap,    verdict = 'unknown'; info.reason = 'timeCap'; return; end
+
+        [m, ~, ~, ~, Ain, din] = gpu_bab_crown_tight(ops, nl, nu, C, prec, cell(nOps, 1));
+        m = double(m(:)); Ain = double(Ain); din = double(din(:));
+
+        ok = true;                                   % certify: every disjunct avoided over this sub-box
+        for d = 1:numel(Gd)
+            rr = rows{d};
+            if any(m(rr) - gAll(rr) > tol), info.sep = info.sep + 1; continue; end   % single-row separation
+            [~, ~, isEmpty] = gpu_bab_clip(nl, nu, Ain(rr, :), din(rr) - gAll(rr));   % joint clip emptiness
+            if isEmpty, info.clip = info.clip + 1; else, ok = false; break; end
+        end
+        if ok, continue; end                         % sub-box safe -> discard
+
+        w = nu - nl; [wmax, j] = max(w);
+        if wmax < minWidth
+            verdict = 'unknown'; info.reason = 'barrier (sub-box below minWidth still undecided)'; return;
+        end
+        mid = (nl(j) + nu(j)) / 2;
+        if top + 2 > cap                             % grow (amortized doubling)
+            cap = 2 * cap; SL(:, cap) = 0; SU(:, cap) = 0;
+        end
+        SL(:, top+1) = nl;       SU(:, top+1) = nu;       SU(j, top+1) = mid;   % child 1: [nl, mid]
+        SL(:, top+2) = nl;       SU(:, top+2) = nu;       SL(j, top+2) = mid;   % child 2: [mid, nu]
+        top = top + 2;
+        info.maxStack = max(info.maxStack, top);
+    end
+    verdict = 'robust'; info.reason = 'input-bisection covered (all sub-boxes avoided)';
+end
+
+function v = i_g(s, f, d)
+    if isfield(s, f) && ~isempty(s.(f)), v = s.(f); else, v = d; end
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_input_bab.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_input_bab.m
@@ -14,7 +14,9 @@ function [verdict, info] = gpu_bab_halfspace_input_bab(ops, lb, ub, Gd, gd, opts
 %   (closed split [lb,mid] U [mid,ub]); 'robust' is returned ONLY when the stack empties with
 %   EVERY popped sub-box certified avoided, so the whole input box is covered by certified-safe
 %   sub-boxes. Both certification tests are sound (single-row = a sound CROWN lower bound;
-%   gpu_bab_clip never reports a false "empty"). FP64. Never a wrong unsat.
+%   gpu_bab_clip never reports a false "empty"). The CERTIFIED path is FP64 (`opts.precision`
+%   defaults to 'double'); 'single' is a faster DEV/screen mode only (an emitted 'robust' must come
+%   from an FP64 run). Used soundly, never a wrong unsat.
 %
 %   WHEN TO USE: only when the gap shrinks with box width (bilinear/product). For pure-ReLU nets
 %   (e.g. cersyve) the looseness lives in the ReLU relaxation, not the box, and input bisection

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -78,6 +78,33 @@ function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
     C = cat(1, Gd{:});                                 % all rows of all disjuncts (nRows x nOut)
     gAll = cat(1, gd{:});                              % matching offsets
 
+    % (2.5) CLIP-AND-VERIFY joint pre-check (Zhou et al. NeurIPS 2025). The single-row separation
+    % test below is INCOMPLETE for a disjunct's CONJUNCTION (the reachable set can wrap the unsafe
+    % polytope so no single face separates it, yet every point escapes via SOME face). Here we use
+    % the CROWN input-space LOWER plane of each row (G_i*y >= Ain_i*x + din_i) to clip the input box
+    % against the conjunction {G_i*y <= g_i for all i}; if the clipped box is EMPTY, NO input reaches
+    % the unsafe polytope -> the disjunct is avoided JOINTLY (sound UNSAT). FP64. Cheap (one root
+    % CROWN + an O(n) clip per disjunct), so run before the BaB; disjuncts it cannot close fall
+    % through to the ReLU-split BaB unchanged.
+    try
+        [~, ~, ~, ~, Ain, din] = gpu_bab_crown_tight(ops, lb, ub, C, precision, cell(nOps,1));
+        Ain = gather(double(Ain)); din = gather(double(din(:)));
+        nClipped = 0;
+        for d = 1:numel(Gd)
+            rd = rows{d};                              % stacked-C rows of disjunct d
+            [~, ~, isEmpty] = gpu_bab_clip(lb, ub, Ain(rd, :), din(rd) - gAll(rd));
+            if isEmpty, nClipped = nClipped + 1; end
+        end
+        if nClipped == numel(Gd)
+            verdict = 'robust';                        % every disjunct's conjunction is infeasible -> safe
+            info.reason = sprintf('clip-and-verify (all %d disjuncts jointly avoided)', numel(Gd));
+            info.nodes = 0; return;
+        end
+        info.nClipped = nClipped;                      % partial progress (telemetry); BaB handles the rest
+    catch ME
+        info.clipErr = ME.message;                     % clip is an optional accelerator -> never fatal; fall to BaB
+    end
+
     % (3) sound disjunctive ReLU-split BaB (FP64). opts.spec routes the disjunct structure into the
     % batched BaB, which certifies SAFE iff EVERY disjunct is avoided (some row separated) -- and
     % SPLITS unstable ReLUs to tighten beyond the (typically too-loose) root CROWN. margin=guardTol

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_halfspace_verify.m
@@ -87,7 +87,7 @@ function [verdict, info] = gpu_bab_halfspace_verify(net, lb, ub, prop, opts)
     % CROWN + an O(n) clip per disjunct), so run before the BaB; disjuncts it cannot close fall
     % through to the ReLU-split BaB unchanged.
     try
-        [~, ~, ~, ~, Ain, din] = gpu_bab_crown_tight(ops, lb, ub, C, precision, cell(nOps,1));
+        [~, ~, ~, ~, Ain, din] = gpu_bab_crown_tight(ops, lb, ub, C, precision, cell(numel(ops),1));
         Ain = gather(double(Ain)); din = gather(double(din(:)));
         nClipped = 0;
         for d = 1:numel(Gd)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -64,6 +64,10 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
             a = op.inputs(1) + 1; b = op.inputs(2) + 1;
             cl{k+1} = cl{a} + cl{b};
             cu{k+1} = cu{a} + cu{b};
+        elseif strcmp(op.type, 'concat')
+            ic = op.inputs + 1;                 % stack inputs along the feature dim (LINEAR -> exact)
+            cl{k+1} = vertcat(cl{ic});
+            cu{k+1} = vertcat(cu{ic});
         else
             s = op.src + 1;
             [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{s}, cu{s}, precision);
@@ -103,7 +107,7 @@ function tf = i_is_dag(ops)
     tf = false;
     for k = 1:numel(ops)
         o = ops{k};
-        if strcmp(o.type, 'add'), tf = true; return; end
+        if strcmp(o.type, 'add') || strcmp(o.type, 'concat'), tf = true; return; end
         if isfield(o, 'src') && o.src ~= k-1, tf = true; return; end
     end
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -68,6 +68,9 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
             ic = op.inputs + 1;                 % stack inputs along the feature dim (LINEAR -> exact)
             cl{k+1} = vertcat(cl{ic});
             cu{k+1} = vertcat(cu{ic});
+        elseif strcmp(op.type, 'product')
+            ia = op.inputs(1) + 1; ib = op.inputs(2) + 1;   % elementwise x.*y: exact interval = corner min/max
+            [cl{k+1}, cu{k+1}] = i_mul_interval(cl{ia}, cu{ia}, cl{ib}, cu{ib});
         else
             s = op.src + 1;
             [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{s}, cu{s}, precision);
@@ -107,9 +110,17 @@ function tf = i_is_dag(ops)
     tf = false;
     for k = 1:numel(ops)
         o = ops{k};
-        if strcmp(o.type, 'add') || strcmp(o.type, 'concat'), tf = true; return; end
+        if strcmp(o.type, 'add') || strcmp(o.type, 'concat') || strcmp(o.type, 'product'), tf = true; return; end
         if isfield(o, 'src') && o.src ~= k-1, tf = true; return; end
     end
+end
+
+function [olb, oub] = i_mul_interval(xl, xu, yl, yu)
+% Exact interval for the elementwise product z = x.*y over [xl,xu] x [yl,yu]: the tightest
+% interval is the min/max over the four box-corner products (sound, batched/elementwise).
+    c1 = xl .* yl; c2 = xl .* yu; c3 = xu .* yl; c4 = xu .* yu;
+    olb = min(min(c1, c2), min(c3, c4));
+    oub = max(max(c1, c2), max(c3, c4));
 end
 
 function [olb, oub] = i_conv_ibp(op, lb, ub, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_mul_relax.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_mul_relax.m
@@ -1,0 +1,59 @@
+function [aL, bL, cL, aU, bU, cU] = gpu_bab_mul_relax(xl, xu, yl, yu, alphaL, alphaU, precision)
+% GPU_BAB_MUL_RELAX  McCormick linear relaxation of an elementwise product z = x.*y over the
+%   box [xl,xu] x [yl,yu]. Returns per-element plane coefficients such that, for every x,y in
+%   the box,
+%       aL.*x + bL.*y + cL  <=  x.*y  <=  aU.*x + bU.*y + cU.
+%   (GenBaB / Shi et al. 2019; see research/IMPL_ALGORITHMS_2026-06-17.md s.GenBaB.) The two
+%   LOWER planes pass through corners (xl,yl) and (xu,yu); the two UPPER planes through (xl,yu)
+%   and (xu,yl). CROWN must pick ONE plane per side; GenBaB interpolates the two with an
+%   optimizable alpha in [0,1] (alpha=1 -> corner-solution-1, alpha=0 -> corner-solution-2).
+%
+%   alphaL, alphaU : optional per-element interpolation weights in [0,1] (clipped here for
+%                    soundness). If EMPTY, use the Shi-2019 fixed rule: pick the tighter corner
+%                    per element by comparing the two planes at the box CENTER (the standard
+%                    McCormick choice) -- a sound, division-free default.
+%
+%   Fully ELEMENTWISE: xl/xu/yl/yu may be n-by-1 (single box) or n-by-B (batched subdomains);
+%   the outputs match their shape. No division (unlike ReLU's u/(u-l)) -> no eps guard / NaN
+%   risk; degenerate widths (xl==xu) are valid (the two corner planes coincide).
+%
+%   SOUNDNESS: each corner plane is a supporting under/over-estimator of x*y (Shi-2019 Eq.9/10);
+%   a convex combination (alpha in [0,1]) of two valid under-estimators is a valid under-estimator
+%   (the envelope's feasible set in (a,b,c) is convex), and likewise for over. The CALLER must
+%   apply the plane sign-awarely (positive output-coeff -> LOWER plane for a spec lower bound;
+%   negative -> UPPER plane), exactly like the ReLU al/au rule.
+
+    if nargin < 5, alphaL = []; end
+    if nargin < 6, alphaU = []; end
+    if nargin < 7 || isempty(precision), precision = 'single'; end
+    xl = cast(xl, precision); xu = cast(xu, precision);
+    yl = cast(yl, precision); yu = cast(yu, precision);
+
+    if isempty(alphaL)
+        % Shi-2019 fixed lower corner: compare L1 (corner xl,yl) vs L2 (corner xu,yu) at the
+        % box center; use whichever is the LARGER (tighter) under-estimator. alphaL=1 -> L1.
+        xc = (xl + xu) / 2; yc = (yl + yu) / 2;
+        L1 = yl .* xc + xl .* yc - xl .* yl;
+        L2 = yu .* xc + xu .* yc - xu .* yu;
+        alphaL = cast(L1 >= L2, precision);
+    else
+        alphaL = min(max(cast(alphaL, precision), 0), 1);   % CLIP to [0,1] (soundness)
+    end
+    if isempty(alphaU)
+        xc = (xl + xu) / 2; yc = (yl + yu) / 2;
+        U1 = yu .* xc + xl .* yc - xl .* yu;
+        U2 = yl .* xc + xu .* yc - xu .* yl;
+        alphaU = cast(U1 <= U2, precision);                 % pick the SMALLER (tighter) over-estimator
+    else
+        alphaU = min(max(cast(alphaU, precision), 0), 1);
+    end
+
+    % LOWER plane: convex combo of corner (xl,yl) [alpha=1] and (xu,yu) [alpha=0]
+    aL = alphaL .* yl + (1 - alphaL) .* yu;
+    bL = alphaL .* xl + (1 - alphaL) .* xu;
+    cL = -alphaL .* (xl .* yl) - (1 - alphaL) .* (xu .* yu);
+    % UPPER plane: convex combo of corner (xl,yu) [alpha=1] and (xu,yl) [alpha=0]
+    aU = alphaU .* yu + (1 - alphaU) .* yl;
+    bU = alphaU .* xl + (1 - alphaU) .* xu;
+    cU = -alphaU .* (xl .* yu) - (1 - alphaU) .* (xu .* yl);
+end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -54,7 +54,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % backward coefficient unchanged to both summands, gpu_bab_crown_spec_dag handles the DAG via
     % op.src/op.inputs), only ReLU is relaxed. 'maxpool' needs a per-node window relaxation not
     % yet batched -> refuse (sound-by-refusal -> caller runs the serial tight path / Star).
-    supported = {'affine','relu','conv','normaffine','avgpool','add'};
+    supported = {'affine','relu','conv','normaffine','avgpool','add','concat'};
     badIdx = find(cellfun(@(o) ~any(strcmp(o.type, supported)), ops), 1);
     if ~isempty(badIdx)
         error('gpu_bab_relu_split_batched:unsupportedOp', ...
@@ -331,7 +331,7 @@ function [margins, preL, preU, infeasible, scoreCell] = i_bound_batch(ops, reluI
     % else per-node alpha_dag (alpha+beta, autodiff -> small frontier) when alphaIter/betaIter>0;
     % else min-area spec_dag. FC-only alpha_fix/alpha_beta mis-bound conv/add (fail-open) -> never
     % used for DAG. All sound (alpha in [0,1], beta>=0).
-    isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add'})), ops));
+    isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add','concat'})), ops));
     sc = {};                                          % per-relu BaBSR score (dim_k x B); {} -> gap fallback
     if isDAG
         if ~isempty(alphaRoot)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -67,9 +67,10 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % (affine/relu); for conv/normaffine/avgpool nets fall back to the (root-tight) CROWN bound
     % so we never mis-bound.
     % alpha/beta route: FC (affine/relu) -> alpha_fix/alpha_beta; DAG (conv/normaffine/avgpool/add)
-    % -> gpu_bab_crown_alpha_dag (alpha+beta over the full DAG). Only maxpool has no batched alpha
-    % backward -> disable alpha/beta there (sound: falls back to fixed-slope spec_dag / tight path).
-    if (alphaIter > 0 || betaIter > 0) && any(cellfun(@(o) strcmp(o.type, 'maxpool'), ops))
+    % -> gpu_bab_crown_alpha_dag (alpha+beta over the full DAG). maxpool/concat/product have no
+    % batched alpha backward yet -> disable alpha/beta there (sound: falls back to the fixed-slope
+    % gpu_bab_crown_spec_dag, which DOES handle concat/product; alpha-McCormick is a follow-on).
+    if (alphaIter > 0 || betaIter > 0) && any(cellfun(@(o) any(strcmp(o.type, {'maxpool','concat','product'})), ops))
         alphaIter = 0; betaIter = 0;
     end
     % SPEC: argmax-robustness (default) builds C internally; a general-halfspace caller passes

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -54,7 +54,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % backward coefficient unchanged to both summands, gpu_bab_crown_spec_dag handles the DAG via
     % op.src/op.inputs), only ReLU is relaxed. 'maxpool' needs a per-node window relaxation not
     % yet batched -> refuse (sound-by-refusal -> caller runs the serial tight path / Star).
-    supported = {'affine','relu','conv','normaffine','avgpool','add','concat'};
+    supported = {'affine','relu','conv','normaffine','avgpool','add','concat','product'};
     badIdx = find(cellfun(@(o) ~any(strcmp(o.type, supported)), ops), 1);
     if ~isempty(badIdx)
         error('gpu_bab_relu_split_batched:unsupportedOp', ...
@@ -331,7 +331,7 @@ function [margins, preL, preU, infeasible, scoreCell] = i_bound_batch(ops, reluI
     % else per-node alpha_dag (alpha+beta, autodiff -> small frontier) when alphaIter/betaIter>0;
     % else min-area spec_dag. FC-only alpha_fix/alpha_beta mis-bound conv/add (fail-open) -> never
     % used for DAG. All sound (alpha in [0,1], beta>=0).
-    isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add','concat'})), ops));
+    isDAG = any(cellfun(@(o) any(strcmp(o.type, {'conv','normaffine','avgpool','add','concat','product'})), ops));
     sc = {};                                          % per-relu BaBSR score (dim_k x B); {} -> gap fallback
     if isDAG
         if ~isempty(alphaRoot)

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -282,6 +282,11 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
         if emitted
             shapeOf(numel(ops)) = outShape;
             if isempty(outShape), flatSizeOf(numel(ops)) = outFlat; else, flatSizeOf(numel(ops)) = prod(outShape); end
+            % record the flat OUTPUT width on the op so i_layer_width can read it directly. Needed for
+            % FLAT add/normaffine (shape=[]): prod(shape)=prod([])=1 was a latent width-=-1 bug that
+            % mis-seeded the CROWN intermediate-bound backward (crash at a downstream concat / wrong
+            % bounds elsewhere). The tracked flat size is exact (shape-preserving ops propagate it).
+            ops{numel(ops)}.nOut = i_flat_size(numel(ops), shapeOf, flatSizeOf); %#ok<AGROW>
             if ~isempty(name), layerOp(name) = numel(ops); end
         else
             if ~isempty(name), layerOp(name) = inOp; end

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -70,14 +70,14 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
                 inOps(q) = layerOp(srcs{q});
             end
         end
-        % SOUNDNESS (Copilot #364): AdditionLayer is the ONLY supported multi-input op. Any other
-        % layer that resolves to >1 Connections source would be silently mis-extracted below (only
-        % inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors -> caller runs Star),
-        % never emit a wrong graph. This can only turn a previously-silent mis-extraction into a
-        % sound refusal; supported single-input layers always resolve to exactly one source.
-        if numel(inOps) > 1 && ~contains(cls, 'Addition')
+        % SOUNDNESS (Copilot #364): Addition + Concatenation are the supported multi-input ops. Any
+        % OTHER layer that resolves to >1 Connections source would be silently mis-extracted below
+        % (only inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors -> caller runs
+        % Star), never emit a wrong graph. (Addition is order-insensitive; Concatenation re-resolves
+        % its inputs in PORT order in its own branch below, since concat is order-sensitive.)
+        if numel(inOps) > 1 && ~contains(cls, 'Addition') && ~contains(cls, 'Concatenation')
             error('nn_to_ops:multiInputUnsupported', ...
-                'layer "%s" (%s) has %d inputs but only AdditionLayer is multi-input-supported -- refused for soundness.', ...
+                'layer "%s" (%s) has %d inputs but only Addition/Concatenation are multi-input-supported -- refused for soundness.', ...
                 name, cls, numel(inOps));
         end
         inOp = inOps(1);
@@ -175,6 +175,42 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
                     'Addition with %d inputs not supported (only 2) -- refused for soundness.', numel(inOps));
             end
             ops{end+1} = struct('type','add','inputs',inOps,'shape',inShape,'src',inOps(1)); %#ok<AGROW>
+        elseif contains(cls, 'Concatenation') || contains(cls, 'Concat')
+            % ConcatenationLayer: y = [in_p1; in_p2; ...] STACKED along the feature dim (LINEAR ->
+            % exact). The control-net manifests (e.g. lsnc_relu) concat FLAT feature vectors. Concat
+            % is ORDER-SENSITIVE (unlike add), so resolve the inputs in PORT order (name/in1,in2,...)
+            % -- i_layer_sources strips the port, so use the port-aware resolver. FLAT inputs only;
+            % spatial concat (along H/W/C) is refused (sound-by-refusal). The op records each input's
+            % flat size so the backward pass can slice the coefficient back to the right input. The
+            % mandatory IBP==evaluate orientation guard validates the stacking order.
+            psrcs = i_concat_sources(conns, name);
+            if numel(psrcs) < 2
+                error('nn_to_ops:concatSources', ...
+                    'ConcatenationLayer "%s" did not resolve >=2 port-ordered sources -- refused for soundness.', name);
+            end
+            cinOps = zeros(1, numel(psrcs));
+            for q = 1:numel(psrcs)
+                if ~isKey(layerOp, psrcs{q})
+                    error('nn_to_ops:srcNotEmitted', ...
+                        'concat "%s" input "%s" not yet emitted (non-topological DAG?).', name, psrcs{q});
+                end
+                cinOps(q) = layerOp(psrcs{q});
+            end
+            sizes = zeros(1, numel(cinOps));
+            for q = 1:numel(cinOps)
+                if ~isempty(shapeOf(cinOps(q)))
+                    error('nn_to_ops:concatSpatial', ...
+                        'spatial-input concat (non-flat) not supported -- refused for soundness.');
+                end
+                fq = i_flat_size(cinOps(q), shapeOf, flatSizeOf);
+                if isempty(fq) || fq < 1
+                    error('nn_to_ops:concatFlatSize', ...
+                        'concat input %d has unknown flat size -- refused for soundness.', q);
+                end
+                sizes(q) = fq;
+            end
+            ops{end+1} = struct('type','concat','inputs',cinOps,'sizes',sizes,'src',cinOps(1)); %#ok<AGROW>
+            outShape = []; outFlat = sum(sizes);
         elseif contains(cls, 'FeatureInput') && isempty(ops)
             % LEADING FeatureInputLayer: a flat [n] feature-vector input (e.g. sat_relu /
             % safenlp FC nets imported with InputDataFormats="BC"). It carries no learnable
@@ -405,4 +441,30 @@ function srcs = i_layer_sources(conns, name)
             srcs{end+1} = char(conns.Source(r)); %#ok<AGROW>
         end
     end
+end
+
+% ---- source layer names feeding `name`, ORDERED by input port (name/in1, name/in2, ...) -------
+function srcs = i_concat_sources(conns, name)
+% Concatenation is ORDER-SENSITIVE: the stacking order is the input-PORT order (the "/inK" suffix
+% on the Connections Destination), which i_layer_sources discards. Parse the port index and return
+% the Source layer names sorted by it. Empty if no Connections (a concat needs a DAG anyway).
+    srcs = {};
+    if isempty(conns), return; end
+    cand = {}; ports = [];
+    for r = 1:height(conns)
+        dest = char(conns.Destination(r));
+        base = dest; port = 1;
+        sl = strfind(dest, '/');
+        if ~isempty(sl)
+            base = dest(1:sl(1)-1);
+            d = regexp(dest(sl(1)+1:end), '\d+', 'match', 'once');   % the K in "inK"
+            if ~isempty(d), port = str2double(d); end
+        end
+        if strcmp(base, name)
+            cand{end+1} = char(conns.Source(r)); %#ok<AGROW>
+            ports(end+1) = port; %#ok<AGROW>
+        end
+    end
+    [~, ord] = sort(ports);
+    srcs = cand(ord);
 end

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -75,9 +75,9 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
         % mis-extracted below (only inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors
         % -> caller runs Star), never emit a wrong graph. (Addition + ElementwiseProduct are order-
         % insensitive; Concatenation re-resolves its inputs in PORT order in its own branch below.)
-        if numel(inOps) > 1 && ~contains(cls, 'Addition') && ~contains(cls, 'Concatenation') && ~contains(cls, 'ElementwiseProduct')
+        if numel(inOps) > 1 && ~contains(cls, 'Addition') && ~contains(cls, 'Concatenation') && ~contains(cls, 'ElementwiseProduct') && ~contains(cls, 'Multiplication')
             error('nn_to_ops:multiInputUnsupported', ...
-                'layer "%s" (%s) has %d inputs but only Addition/Concatenation/ElementwiseProduct are multi-input-supported -- refused for soundness.', ...
+                'layer "%s" (%s) has %d inputs but only Addition/Concatenation/ElementwiseProduct/Multiplication are multi-input-supported -- refused for soundness.', ...
                 name, cls, numel(inOps));
         end
         inOp = inOps(1);

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -70,14 +70,14 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
                 inOps(q) = layerOp(srcs{q});
             end
         end
-        % SOUNDNESS (Copilot #364): Addition + Concatenation are the supported multi-input ops. Any
-        % OTHER layer that resolves to >1 Connections source would be silently mis-extracted below
-        % (only inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors -> caller runs
-        % Star), never emit a wrong graph. (Addition is order-insensitive; Concatenation re-resolves
-        % its inputs in PORT order in its own branch below, since concat is order-sensitive.)
-        if numel(inOps) > 1 && ~contains(cls, 'Addition') && ~contains(cls, 'Concatenation')
+        % SOUNDNESS (Copilot #364): Addition + Concatenation + ElementwiseProduct are the supported
+        % multi-input ops. Any OTHER layer that resolves to >1 Connections source would be silently
+        % mis-extracted below (only inOps(1) used) -> a wrong op graph. Refuse it (-> nn_to_ops errors
+        % -> caller runs Star), never emit a wrong graph. (Addition + ElementwiseProduct are order-
+        % insensitive; Concatenation re-resolves its inputs in PORT order in its own branch below.)
+        if numel(inOps) > 1 && ~contains(cls, 'Addition') && ~contains(cls, 'Concatenation') && ~contains(cls, 'ElementwiseProduct')
             error('nn_to_ops:multiInputUnsupported', ...
-                'layer "%s" (%s) has %d inputs but only Addition/Concatenation are multi-input-supported -- refused for soundness.', ...
+                'layer "%s" (%s) has %d inputs but only Addition/Concatenation/ElementwiseProduct are multi-input-supported -- refused for soundness.', ...
                 name, cls, numel(inOps));
         end
         inOp = inOps(1);
@@ -211,6 +211,31 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
             end
             ops{end+1} = struct('type','concat','inputs',cinOps,'sizes',sizes,'src',cinOps(1)); %#ok<AGROW>
             outShape = []; outFlat = sum(sizes);
+        elseif contains(cls, 'ElementwiseProduct') || contains(cls, 'Multiplication')
+            % ElementwiseProductLayer: y = in[a] .* in[b], BOTH operands VARIABLE (bilinear) ->
+            % NONLINEAR. Relaxed by the McCormick envelope (gpu_bab_mul_relax) in the CROWN
+            % backward. 2 FLAT inputs of EQUAL width (elementwise); product is commutative so input
+            % order is irrelevant (the McCormick envelope is symmetric in x,y). This is the genuine
+            % nonlinearity in lsnc Lyapunov nets (e.g. x .* (P*x)). The IBP==evaluate orientation
+            % guard validates the wiring; sound-or-refusal otherwise.
+            if numel(inOps) ~= 2
+                error('nn_to_ops:productNInputs', ...
+                    'ElementwiseProductLayer "%s" has %d inputs (only 2 supported) -- refused for soundness.', name, numel(inOps));
+            end
+            for q = 1:2
+                if ~isempty(shapeOf(inOps(q)))
+                    error('nn_to_ops:productSpatial', ...
+                        'spatial-input elementwise product not supported (flat only) -- refused for soundness.');
+                end
+            end
+            wa = i_flat_size(inOps(1), shapeOf, flatSizeOf);
+            wb = i_flat_size(inOps(2), shapeOf, flatSizeOf);
+            if isempty(wa) || isempty(wb) || wa < 1 || wa ~= wb
+                error('nn_to_ops:productWidth', ...
+                    'elementwise product needs flat equal-width inputs (got %s, %s) -- refused for soundness.', mat2str(wa), mat2str(wb));
+            end
+            ops{end+1} = struct('type','product','inputs',inOps,'sizes',[wa wb],'src',inOps(1)); %#ok<AGROW>
+            outShape = []; outFlat = wa;
         elseif contains(cls, 'FeatureInput') && isempty(ops)
             % LEADING FeatureInputLayer: a flat [n] feature-vector input (e.g. sat_relu /
             % safenlp FC nets imported with InputDataFormats="BC"). It carries no learnable

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_clip.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_clip.m
@@ -1,0 +1,52 @@
+function tests = test_gpu_bab_clip
+% TEST_GPU_BAB_CLIP  Soundness of Clip-and-Verify Relaxed Clipping (gpu_bab_clip):
+%   the clipped box must CONTAIN the constraint-feasible subset of the original box (sound
+%   over-approx), must TIGHTEN when a constraint cuts a coordinate, and must report EMPTY only
+%   when the constraint system is genuinely infeasible over the box (no false "empty" -> no
+%   wrong UNSAT). Run: runtests('test_gpu_bab_clip').
+    tests = functiontests(localfunctions);
+end
+
+function test_clip_tighten_and_contain(tc)
+    rng(3, 'twister');
+    n = 4; lb = -ones(n,1); ub = ones(n,1);
+    a = [1;0;0;0]; c = -0.3;                 % constraint x1 <= 0.3
+    [lb2, ub2, empty] = gpu_bab_clip(lb, ub, a.', c);
+    verifyFalse(tc, empty, 'feasible constraint wrongly reported empty');
+    verifyEqual(tc, ub2(1), 0.3, 'AbsTol', 1e-9);    % coord 1 tightened to 0.3
+    verifyEqual(tc, lb2(1), -1, 'AbsTol', 1e-9);     % lower unchanged
+    % containment: every box point satisfying the constraint lies in [lb2,ub2]
+    N = 30000; X = lb + (ub - lb) .* rand(n, N);
+    Xf = X(:, (a.' * X + c) <= 0);
+    verifyTrue(tc, all(Xf >= lb2 - 1e-9, 'all') && all(Xf <= ub2 + 1e-9, 'all'), ...
+        'clipped box does not contain the feasible set (UNSOUND)');
+end
+
+function test_clip_multi_constraint_contain(tc)
+    rng(4, 'twister');
+    n = 3; lb = [-1;-1;-1]; ub = [1;1;1];
+    A = [1 1 0; 0 1 1]; c = [-0.4; -0.6];    % x1+x2<=0.4 AND x2+x3<=0.6
+    [lb2, ub2, empty] = gpu_bab_clip(lb, ub, A, c);
+    verifyFalse(tc, empty);
+    N = 40000; X = lb + (ub - lb) .* rand(n, N);
+    feas = all(A * X + c <= 0, 1);
+    Xf = X(:, feas);
+    if ~isempty(Xf)
+        verifyTrue(tc, all(Xf >= lb2 - 1e-9, 'all') && all(Xf <= ub2 + 1e-9, 'all'), ...
+            'multi-constraint clipped box does not contain the feasible set (UNSOUND)');
+    end
+end
+
+function test_clip_detects_empty(tc)
+    n = 4; lb = -ones(n,1); ub = ones(n,1);
+    % single infeasible constraint: x1 <= -2 over x1 in [-1,1]
+    [~,~,e1] = gpu_bab_clip(lb, ub, [1 0 0 0], -2);   % x1 + (-2) ... a'x+c = x1-2 <= 0 always true? no
+    % a'x + c <= 0 with a=[1..],c=-2 is x1 <= 2 -> ALWAYS feasible; use c=+2 -> x1 <= -2 infeasible
+    [~,~,e1b] = gpu_bab_clip(lb, ub, [1 0 0 0], 2);
+    verifyTrue(tc, e1b, 'x1<=-2 over [-1,1] should be empty');
+    verifyFalse(tc, e1, 'x1<=2 over [-1,1] should be feasible');
+    % contradictory pair: x1>=0.6 (-x1+0.6<=0) AND x1<=-0.6 (x1+0.6<=0)
+    A = [-1 0 0 0; 1 0 0 0]; c = [0.6; 0.6];
+    [~,~,e2] = gpu_bab_clip(lb, ub, A, c);
+    verifyTrue(tc, e2, 'contradictory constraints should be empty');
+end

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_concat.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_concat.m
@@ -1,0 +1,84 @@
+function tests = test_gpu_bab_concat
+% TEST_GPU_BAB_CONCAT  Soundness of the 'concat' op across the GPU-BaB engines.
+%   Builds a small two-branch DAG (input -> two parallel affines -> concat -> relu -> affine),
+%   then checks that gpu_bab_ibp / gpu_bab_crown_tight / gpu_bab_crown_spec_dag all produce
+%   SOUND bounds (a guaranteed over-approximation) vs a dense Monte-Carlo ground truth, and
+%   that the three engines agree at the root (no fixings). Concat is LINEAR (exact stacking),
+%   so the only requirement is that the backward pass slices the coefficient back to the right
+%   input block -- this test exercises exactly that (the second branch is a skip from the input,
+%   forcing the full DAG path). Run: runtests('test_gpu_bab_concat').
+    tests = functiontests(localfunctions);
+end
+
+function test_concat_sound(tc)
+    rng(0, 'twister');
+    n  = 4;
+    lb = [-1; -0.5;  0; -2];
+    ub = [ 1;  0.5;  1;  0.3];
+
+    % branch 1: affine 3x4 ; branch 2: affine 2x4 (both from the INPUT, op 0) ;
+    % concat -> 5 ; relu ; affine 2x5 -> out (2).
+    A1 = randn(3, n); b1 = randn(3, 1);
+    A2 = randn(2, n); b2 = randn(2, 1);
+    A3 = randn(2, 5); b3 = randn(2, 1);
+    ops = { struct('type','affine','W',A1,'b',b1,'src',0), ...
+            struct('type','affine','W',A2,'b',b2,'src',0), ...
+            struct('type','concat','inputs',[1 2],'sizes',[3 2],'src',1), ...
+            struct('type','relu','src',3), ...
+            struct('type','affine','W',A3,'b',b3,'src',4) };
+
+    % spec: two linear output functionals (margins lower-bound C*out over the box)
+    C = [1 -1; -1 1];
+
+    % --- Monte-Carlo ground truth (exact forward eval) ---
+    N = 40000;
+    X = lb + (ub - lb) .* rand(n, N);
+    Y = i_eval(ops, X);                       % nOut x N
+    yMin = min(Y, [], 2); yMax = max(Y, [], 2);
+    CYmin = min(C * Y, [], 2);
+
+    tol = 1e-9;
+
+    % --- IBP: sound interval over-approx of the output box ---
+    [olb, oub] = gpu_bab_ibp(ops, lb, ub, 'double');
+    verifyEqual(tc, numel(olb), numel(yMin), 'IBP output width mismatch (concat size wrong)');
+    verifyLessThanOrEqual(tc, olb,            yMin + tol);   % lower bound is sound
+    verifyGreaterThanOrEqual(tc, oub,         yMax - tol);   % upper bound is sound
+
+    % --- crown_tight: sound lower bound on C*out ---
+    m = gpu_bab_crown_tight(ops, lb, ub, C, 'double', {});
+    m = m(:);
+    verifyEqual(tc, numel(m), size(C,1), 'crown_tight margin count wrong');
+    verifyTrue(tc, all(isfinite(m)), 'crown_tight produced non-finite margins');
+    verifyLessThanOrEqual(tc, m,  CYmin + tol);              % margin <= true min (sound)
+
+    % --- spec_dag (root, no fixings): sound AND consistent with crown_tight's IBP-forward path ---
+    md = gpu_bab_crown_spec_dag(ops, lb, ub, C, 'double', {});
+    md = md(:);
+    verifyLessThanOrEqual(tc, md, CYmin + tol);              % sound
+
+    % tightness sanity: bounds should not be absurdly loose (within, say, 50 of the MC range)
+    verifyGreaterThan(tc, min(m), min(CYmin) - 50);
+end
+
+function Y = i_eval(ops, X)
+% Exact forward evaluation of the op list (ground truth). Supports affine/relu/concat/add.
+    cache = cell(numel(ops) + 1, 1);
+    cache{1} = X;
+    for k = 1:numel(ops)
+        op = ops{k};
+        switch op.type
+            case 'affine'
+                cache{k+1} = op.W * cache{op.src+1} + op.b(:);
+            case 'relu'
+                cache{k+1} = max(cache{op.src+1}, 0);
+            case 'concat'
+                cache{k+1} = cat(1, cache{op.inputs+1});
+            case 'add'
+                cache{k+1} = cache{op.inputs(1)+1} + cache{op.inputs(2)+1};
+            otherwise
+                error('i_eval:op', 'unsupported op "%s" in test ground-truth eval', op.type);
+        end
+    end
+    Y = cache{end};
+end

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_halfspace_input_bab.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_halfspace_input_bab.m
@@ -1,0 +1,34 @@
+function tests = test_gpu_bab_halfspace_input_bab
+% TEST_GPU_BAB_HALFSPACE_INPUT_BAB  Soundness of the input-bisection halfspace BaB on a tiny
+%   bilinear net (output y = x1*x2 over [-1,1]^2, so y in [-1,1]):
+%     - a genuinely SAFE unsafe-region (y >= 2, empty over the box) must certify -> 'robust';
+%     - a genuinely REACHABLE unsafe-region (y <= 0.5) must NOT be falsely certified -> not 'robust'.
+%   This exercises the product McCormick relaxation + the bisection + the certify path, and guards
+%   the soundness invariant (never a false 'robust'). Run: runtests('test_gpu_bab_halfspace_input_bab').
+    tests = functiontests(localfunctions);
+end
+
+function test_safe_certifies_robust(tc)
+    ops = i_net();
+    lb = [-1; -1]; ub = [1; 1];
+    Gd = {[-1]}; gd = {[-2]};      % unsafe disjunct {-y <= -2} == {y >= 2}: empty over the box -> SAFE
+    [v, info] = gpu_bab_halfspace_input_bab(ops, lb, ub, Gd, gd, ...
+        struct('maxNodes', 20000, 'minWidth', 1e-7, 'timeCap', 60));
+    verifyEqual(tc, v, 'robust', sprintf('safe spec not certified (reason=%s)', info.reason));
+end
+
+function test_unsafe_not_falsely_robust(tc)
+    ops = i_net();
+    lb = [-1; -1]; ub = [1; 1];
+    Gd = {[1]}; gd = {[0.5]};      % unsafe disjunct {y <= 0.5}: reachable (e.g. x=(-1,1)->y=-1) -> NOT safe
+    [v, ~] = gpu_bab_halfspace_input_bab(ops, lb, ub, Gd, gd, ...
+        struct('maxNodes', 20000, 'minWidth', 1e-3, 'timeCap', 60));
+    verifyNotEqual(tc, v, 'robust', 'UNSOUND: falsely certified a reachable unsafe region as robust');
+end
+
+function ops = i_net()
+% y = x1 * x2 : two affine selectors feeding an elementwise product.
+    ops = { struct('type','affine','W',[1 0],'b',0,'src',0), ...   % op1 -> x1
+            struct('type','affine','W',[0 1],'b',0,'src',0), ...   % op2 -> x2
+            struct('type','product','inputs',[1 2],'sizes',[1 1],'src',1) };  % op3 -> x1*x2
+end

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_product.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_product.m
@@ -1,0 +1,81 @@
+function tests = test_gpu_bab_product
+% TEST_GPU_BAB_PRODUCT  Soundness of the bilinear 'product' op (McCormick) across the GPU-BaB
+%   engines. Builds input -> two parallel affines -> elementwise product -> affine, and checks
+%   that gpu_bab_ibp / gpu_bab_crown_tight / gpu_bab_crown_spec_dag produce SOUND bounds vs a
+%   dense Monte-Carlo ground truth of the (nonlinear) network. Also directly verifies that the
+%   gpu_bab_mul_relax planes envelope x.*y over a box. The product is the genuine nonlinearity
+%   in lsnc Lyapunov nets (x .* (P*x)); McCormick has an irreducible gap (closed only by
+%   branching), so this checks SOUNDNESS, not tightness. Run: runtests('test_gpu_bab_product').
+    tests = functiontests(localfunctions);
+end
+
+function test_product_sound(tc)
+    rng(1, 'twister');
+    n  = 4;
+    lb = [-1; -0.5; -0.8; -1.2];
+    ub = [ 1;  0.5;  0.8;  0.7];
+    A1 = randn(3, n); b1 = randn(3, 1);
+    A2 = randn(3, n); b2 = randn(3, 1);
+    A3 = randn(2, 3); b3 = randn(2, 1);
+    ops = { struct('type','affine','W',A1,'b',b1,'src',0), ...
+            struct('type','affine','W',A2,'b',b2,'src',0), ...
+            struct('type','product','inputs',[1 2],'sizes',[3 3],'src',1), ...
+            struct('type','affine','W',A3,'b',b3,'src',3) };
+    C = [1 -1; -1 1];
+    tol = 1e-9;
+
+    % --- Monte-Carlo ground truth (exact nonlinear forward eval) ---
+    N = 60000;
+    X = lb + (ub - lb) .* rand(n, N);
+    Y = i_eval(ops, X);
+    yMin = min(Y, [], 2); yMax = max(Y, [], 2);
+    CYmin = min(C * Y, [], 2);
+
+    % --- IBP: sound interval over the nonlinear output ---
+    [olb, oub] = gpu_bab_ibp(ops, lb, ub, 'double');
+    verifyEqual(tc, numel(olb), numel(yMin), 'IBP output width mismatch');
+    verifyLessThanOrEqual(tc, olb, yMin + tol);
+    verifyGreaterThanOrEqual(tc, oub, yMax - tol);
+
+    % --- crown_tight: sound lower bound on C*out (McCormick relaxed) ---
+    m = gpu_bab_crown_tight(ops, lb, ub, C, 'double', {}); m = m(:);
+    verifyEqual(tc, numel(m), size(C,1), 'crown_tight margin count wrong');
+    verifyTrue(tc, all(isfinite(m)), 'crown_tight produced non-finite margins');
+    verifyLessThanOrEqual(tc, m, CYmin + tol);
+
+    % --- spec_dag (root, no fixings): sound ---
+    md = gpu_bab_crown_spec_dag(ops, lb, ub, C, 'double', {}); md = md(:);
+    verifyLessThanOrEqual(tc, md, CYmin + tol);
+
+    % --- direct McCormick-envelope soundness (planes bracket x.*y over the box) ---
+    xl = [-2; -1; 0.5]; xu = [1; 3; 2];
+    yl = [-1; -2; -0.5]; yu = [2; 1; 1.5];
+    [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(xl, xu, yl, yu, [], [], 'double');
+    M = 8000;
+    for i = 1:numel(xl)
+        xs = xl(i) + (xu(i) - xl(i)) * rand(1, M);
+        ys = yl(i) + (yu(i) - yl(i)) * rand(1, M);
+        z  = xs .* ys;
+        lo = aL(i)*xs + bL(i)*ys + cL(i);
+        hi = aU(i)*xs + bU(i)*ys + cU(i);
+        verifyLessThanOrEqual(tc, lo, z + tol, sprintf('lower plane not an under-estimator (elt %d)', i));
+        verifyGreaterThanOrEqual(tc, hi, z - tol, sprintf('upper plane not an over-estimator (elt %d)', i));
+    end
+end
+
+function Y = i_eval(ops, X)
+% Exact forward evaluation (ground truth). Supports affine/relu/product/concat/add.
+    cache = cell(numel(ops) + 1, 1); cache{1} = X;
+    for k = 1:numel(ops)
+        op = ops{k};
+        switch op.type
+            case 'affine',  cache{k+1} = op.W * cache{op.src+1} + op.b(:);
+            case 'relu',    cache{k+1} = max(cache{op.src+1}, 0);
+            case 'product', cache{k+1} = cache{op.inputs(1)+1} .* cache{op.inputs(2)+1};
+            case 'concat',  cache{k+1} = cat(1, cache{op.inputs+1});
+            case 'add',     cache{k+1} = cache{op.inputs(1)+1} + cache{op.inputs(2)+1};
+            otherwise, error('i_eval:op', 'unsupported op "%s"', op.type);
+        end
+    end
+    Y = cache{end};
+end


### PR DESCRIPTION
## Summary
Extends the GPU-BaB engine to soundly support the **control benchmarks** (lsnc_relu via the python-manifest path) and adds a **general soundness fix** + the **Clip-and-Verify** joint-halfspace pre-check. Sound-or-unknown throughout; **0 wrong verdicts introduced** (7 new unit tests pass).

## Changes
- **Concat op** (`nn_to_ops` + IBP + both CROWN engines + BaB): linear, exact (vertcat fwd, column-slice backward); port-ordered, flat-input.
- **Bilinear `product` op** via GenBaB McCormick envelope (`gpu_bab_mul_relax.m`): 4 sign-aware planes routed to both inputs; corner-product IBP. lsnc now imports fully (orientation guard matches `net.evaluate` to 4.4e-16).
- **Flat-op width SOUNDNESS FIX**: `i_layer_width` returned `prod([])=1` for flat `add`/`normaffine`, mis-seeding the CROWN intermediate-bound backward (latent wrong-bounds path on flat-DAG nets). Fixed via recorded `op.nOut`. **Provably benign for conv** (`nOut == prod(outShape)` == the old walk); only flat add/normaffine behavior changes (wrong → correct).
- **Clip-and-Verify** (`gpu_bab_clip.m` + `gpu_bab_crown_tight` exposes the input-space lower plane): closed-form box clip (Thm 3.2) → joint emptiness certifies the polytope-avoidance that single-row separation misses.
- **Input-bisection halfspace BaB** (`gpu_bab_halfspace_input_bab.m`): sound branch/certify scaffold for bilinear specs.

## Tests
`test_gpu_bab_{concat,product,clip,halfspace_input_bab}.m` — 7 unit tests, all pass on R2026a.

## Soundness
McCormick + clip are valid over/under-approximations; the width fix only corrects under-seeded bounds (cannot introduce a wrong verdict). The control benchmarks currently return sound `unknown` (verdicts need the follow-on GenBaB / multi-neuron work); this PR is the sound foundation + the width soundness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)