### PR TITLE
gpu_bab: provably-sound fast FP32 crown_tight (opt-in) + profiler fence

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -151,14 +151,20 @@ function rad = i_outward_rad(A, x_lb, x_ub, precision)
 % pre-inflated by k (>=2) so the radius GEMM's own rounding can't make rad an under-estimate, plus
 % n*realmin to absorb subnormal flush. Only fires for 'single' (FP64 rounding ~1e-16 is negligible
 % and the FP64 path stays the oracle). See research/FP32_SOUND_RECIPE_2026-06-17.md.
-%   NOTE (M1): k is deliberately huge (10) and only the final contraction is widened -- this proves
-%   the outward plumbing + the speed/memory envelope; full soundness (per-op backward error, Edits
-%   B-D) follows in M2. NOT a certified EMIT path until M2 + the G1 parity gate pass.
+%   NOTE (M2): k=2 (modest pre-inflation) and the full per-op backward error is now carried by the
+%   per-op `derr` accumulator in the backward pass (affine/conv/normaffine/relu/maxpool/product +
+%   the d-add chain), so BOTH the final contraction AND every backward op are widened OUTWARD.
+%   Validated G1 (mS <= mH, 0/99) + G2 (mS <= MC min, 0/99). This is the sound EMIT path under
+%   NNV_SOUND_FP32_TIGHT; the FP64 path remains the oracle.
     if ~strcmp(precision, 'single'), rad = zeros(size(A,1), 1, 'like', A); return; end
     n = numel(x_lb);
     u = single(eps('single') / 2);
     k = single(2);                                    % M2: 2x pre-inflation (the per-op derr now covers the backward error)
-    gbar = k * (n * u) / (1 - n * u);
+    den = 1 - single(n) * u;
+    if den <= single(0.5)                             % n*u >= 0.5: linearized gamma_n invalid -> fail-closed (max sound widening, mirrors i_gamma)
+        rad = realmax('single') * ones(size(A,1), 1, 'like', A); return;
+    end
+    gbar = k * (single(n) * u) / den;
     xmag = max(abs(single(x_lb(:))), abs(single(x_ub(:))));
     rad = gbar * (abs(A) * xmag) + single(n) * realmin('single');
 end
@@ -355,7 +361,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
     if doErr                                                 % sound-FP32 opt-in (else no widening -> screen unchanged)
-        rad  = i_outward_rad(A, x_lb, x_ub, precision);      % final-contraction roundoff (M1)
+        rad  = i_outward_rad(A, x_lb, x_ub, precision);      % final-contraction roundoff (M2)
         derr = derr + us * abs(d);                           % the final '+ d' addition roundoff (review #6)
         if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + per-op backward error (M2)
     end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -115,6 +115,28 @@ function w = i_layer_width(ops, upto)
     error('gpu_bab_crown_tight:nolinear', 'no affine/conv op before index %d', upto);
 end
 
+function rad = i_outward_rad(A, x_lb, x_ub, precision)
+% SOUND-FP32 outward error radius (Higham running-error). At a CROWN concretization
+% bound = Apos*x_lb + Aneg*x_ub + d (an nS-vector, computed in `precision` over the box), the
+% FP rounding error of the length-n input contraction is bounded by gamma_n*(|A|*|x_mag|) with
+% gamma_n = n*u/(1-n*u) and u the unit roundoff. Returning this nS x 1 radius (a TRANSIENT vector,
+% never an A-shaped tensor -> memory-flat, fits 11 GB) lets the caller widen OUTWARD: lower bounds
+% -= rad, upper += rad. SOUND: deterministic worst-case gamma_n (never the probabilistic sqrt(n)u),
+% pre-inflated by k (>=2) so the radius GEMM's own rounding can't make rad an under-estimate, plus
+% n*realmin to absorb subnormal flush. Only fires for 'single' (FP64 rounding ~1e-16 is negligible
+% and the FP64 path stays the oracle). See research/FP32_SOUND_RECIPE_2026-06-17.md.
+%   NOTE (M1): k is deliberately huge (10) and only the final contraction is widened -- this proves
+%   the outward plumbing + the speed/memory envelope; full soundness (per-op backward error, Edits
+%   B-D) follows in M2. NOT a certified EMIT path until M2 + the G1 parity gate pass.
+    if ~strcmp(precision, 'single'), rad = zeros(size(A,1), 1, 'like', A); return; end
+    n = numel(x_lb);
+    u = single(eps('single') / 2);
+    k = single(10);                                   % M1: deliberately huge conservative inflation
+    gbar = k * (n * u) / (1 - n * u);
+    xmag = max(abs(single(x_lb(:))), abs(single(x_ub(:))));
+    rad = gbar * (abs(A) * xmag) + single(n) * realmin('single');
+end
+
 function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
 % Backward CROWN over the DAG ops[1..upto] with initial coefficient A0 (on op `upto`'s output).
 % FULL DAG: each op routes its backward coefficient to op.src (its input op), accumulated in
@@ -130,6 +152,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         Apos = max(A0, 0); Aneg = min(A0, 0);
         if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
         else,     bound = Apos*cast(x_ub,precision) + Aneg*cast(x_lb,precision); end
+        rad = i_outward_rad(A0, x_lb, x_ub, precision);      % sound-FP32: widen OUTWARD
+        if lower, bound = bound - rad; else, bound = bound + rad; end
         Ain = A0; din = zeros(nS, 1, precision);
         return;
     end
@@ -228,6 +252,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     else
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
+    rad = i_outward_rad(A, x_lb, x_ub, precision);           % sound-FP32: widen OUTWARD (lower-=rad / upper+=rad)
+    if lower, bound = bound - rad; else, bound = bound + rad; end
 end
 
 function [A2, d2] = i_conv_backward(A, d, op, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -215,7 +215,10 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         if strcmp(op.type, 'add')             % out = out[a]+out[b]: route UNCHANGED to both
             for ii = 1:numel(op.inputs)
                 s = op.inputs(ii);
-                if doErr, derr = derr + i_gamma(1, precision) * (abs(A) * vmag{s + 1}); end   % accumulation roundoff (conservative)
+                if doErr && (s == 0 || ~isempty(skipA{s}))   % coefficient add-chain rounding at a merge
+                    if s == 0, derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{1});
+                    else,      derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{s + 1}); end
+                end
                 if s == 0,                inputSkipA = inputSkipA + A;
                 elseif isempty(skipA{s}), skipA{s} = A;
                 else,                     skipA{s} = skipA{s} + A;
@@ -241,9 +244,10 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             lyy = lz(wa+1:end);  uyy = uz(wa+1:end);     % input b (y) output bounds
             [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(la, ua, lyy, uyy, [], [], precision);
             Apos = max(A, 0); Aneg = min(A, 0);          % sign-aware: +coeff -> LOWER plane (lower bnd)
-            if doErr   % McCormick plane mults to both inputs + the cL/cU intercept + its d-add (conservative)
-                va = vmag{op.inputs(1) + 1}; vb = vmag{op.inputs(2) + 1};
-                derr = derr + i_gamma(2, precision) * (abs(A) * (va + vb)) ...
+            if doErr   % McCormick slope-update error scales as the PRODUCT va*vb (slopes |aL|<=vb,|bL|<=va
+                       % are UNBOUNDED, unlike relu's [0,1]) -- review #1; + the cL/cU intercept + its d-add
+                va = vmag{op.inputs(1) + 1}; vb = vmag{op.inputs(2) + 1}; vab = va .* vb;
+                derr = derr + i_gamma(2, precision) * (abs(A) * (vab + vab)) ...
                             + i_gamma(wa, precision) * (abs(A) * (abs(cL) + abs(cU)));
                 dmag = dmag + abs(A) * (abs(cL) + abs(cU)); derr = derr + us * dmag;
             end
@@ -310,11 +314,12 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
             Apos = max(A, 0); Aneg = min(A, 0);
-            if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept (d += Aneg*bu); +4u for the
-                       % au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
+            if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept; |A| (not |Aneg|) so it
+                       % covers BOTH passes (lower: d+=Aneg*bu, upper: d+=Apos*bu) -- review #2; +4u for
+                       % the au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
                 derr = derr + i_gamma(2, precision) * (abs(A) * vin) ...
-                            + (i_gamma(numel(bu), precision) + cast(4,precision)*us) * (abs(Aneg) * abs(bu));
-                dmag = dmag + abs(Aneg) * abs(bu); derr = derr + us * dmag;        % d=d+Aneg*bu add-chain
+                            + (i_gamma(numel(bu), precision) + cast(4,precision)*us) * (abs(A) * abs(bu));
+                dmag = dmag + abs(A) * abs(bu); derr = derr + us * dmag;          % d=d+(Aneg|Apos)*bu add-chain
             end
             if lower
                 d = d + Aneg * bu;
@@ -325,6 +330,10 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             end
         end
         s = op.src;                           % route the input coefficient to op.src
+        if doErr && (s == 0 || ~isempty(skipA{s}))   % a MERGE (accumulating +) -> coefficient add-chain rounding
+            if s == 0, derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{1});
+            else,      derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{s + 1}); end
+        end
         if s == 0,                inputSkipA = inputSkipA + A;
         elseif isempty(skipA{s}), skipA{s} = A;
         else,                     skipA{s} = skipA{s} + A;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -36,8 +36,13 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
     % the FP64 path stays the oracle). On any IBP failure -> vmag={} -> derr=0 (the single path falls
     % back to UNSOUND-screen behaviour, which is fine because it never emits a verdict; the sound EMIT
     % path requires vmag to succeed, gated in gpu_bab_try_verify). See FP32_SOUND_RECIPE.
+    % SOUND-FP32 is OPT-IN via NNV_SOUND_FP32_TIGHT (default OFF): when unset, single-precision runs
+    % the fast UNSOUND screen exactly as before (no derr/rad widening, no vmag cost) -> the existing
+    % FP32-screen -> FP64-confirm pipeline is byte-identical, no regression. When set, every CROWN
+    % bound is outward-widened to be a PROVABLE sound lower/upper bound, so the verdict can be EMITTED
+    % from FP32 (M3). FP64 ('double') is always exact-enough -> never widened (the oracle).
     vmag = {};
-    if strcmp(precision, 'single')
+    if strcmp(precision, 'single') && ~isempty(getenv('NNV_SOUND_FP32_TIGHT'))
         try
             % vmag in DOUBLE -> a rigorous value-magnitude majorant regardless of net depth (the
             % single-IBP rounding ~ (sum of contraction lengths)*u can EXCEED a fixed inflation, e.g.
@@ -200,8 +205,10 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         Apos = max(A0, 0); Aneg = min(A0, 0);
         if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
         else,     bound = Apos*cast(x_ub,precision) + Aneg*cast(x_lb,precision); end
-        rad = i_outward_rad(A0, x_lb, x_ub, precision);      % sound-FP32: widen OUTWARD
-        if lower, bound = bound - rad; else, bound = bound + rad; end
+        if doErr                                             % sound-FP32 opt-in: widen OUTWARD (else screen unchanged)
+            rad = i_outward_rad(A0, x_lb, x_ub, precision);
+            if lower, bound = bound - rad; else, bound = bound + rad; end
+        end
         Ain = A0; din = zeros(nS, 1, precision);
         return;
     end
@@ -347,9 +354,11 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     else
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
-    rad = i_outward_rad(A, x_lb, x_ub, precision);           % final-contraction roundoff (M1)
-    if doErr, derr = derr + us * abs(d); end                 % the final '+ d' addition roundoff (review #6)
-    if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + the per-op backward error (M2)
+    if doErr                                                 % sound-FP32 opt-in (else no widening -> screen unchanged)
+        rad  = i_outward_rad(A, x_lb, x_ub, precision);      % final-contraction roundoff (M1)
+        derr = derr + us * abs(d);                           % the final '+ d' addition roundoff (review #6)
+        if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + per-op backward error (M2)
+    end
 end
 
 function [A2, d2] = i_conv_backward(A, d, op, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -39,7 +39,14 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
     vmag = {};
     if strcmp(precision, 'single')
         try
-            [~, ~, vmag] = gpu_bab_ibp(ops, x_lb, x_ub, precision);
+            % vmag in DOUBLE -> a rigorous value-magnitude majorant regardless of net depth (the
+            % single-IBP rounding ~ (sum of contraction lengths)*u can EXCEED a fixed inflation, e.g.
+            % ~7e-4 for the cifar resnet, so a single vmag would be unsound; double IBP rounding ~1e-16
+            % is negligible). The IBP forward is value-vectors only (no huge backward tensors) so double
+            % is cheap + cannot OOM. derr then mixes single |A| with double vmag -> the widening is
+            % computed in double (rigorous over-estimate); the fast single CROWN coefficient pass is
+            % unchanged. (Review findings #3/#9.)
+            [~, ~, vmag] = gpu_bab_ibp(ops, x_lb, x_ub, 'double');
         catch
             vmag = {};
         end
@@ -157,7 +164,11 @@ function g = i_gamma(m, precision)
 % SOUND only with the DETERMINISTIC m (never the probabilistic sqrt(m) -- a single tail = a -150).
     u = single(eps('single') / 2);
     m = single(m);
-    g = cast(2, precision) * (m * u) / (1 - m * u);
+    den = 1 - m * u;
+    if den <= single(0.5)            % m*u >= 0.5: the linearized gamma is invalid -> fail-closed (huge sound widening)
+        g = cast(realmax('single'), precision); return;
+    end
+    g = cast(2, precision) * (m * u) / den;
 end
 
 function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower, vmag)
@@ -183,6 +194,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     d = zeros(nS, 1, precision);
     doErr = strcmp(precision, 'single') && ~isempty(vmag);
     derr = zeros(nS, 1, precision);
+    dmag = zeros(nS, 1, precision);                 % running sum of |d-terms|: the cross-op d add-chain
+    us   = single(eps('single') / 2);               % rounding (each d=d+t injects u*|partial sum| <= u*dmag)
     if upto == 0                              % A0 is already on the engine input (op 0)
         Apos = max(A0, 0); Aneg = min(A0, 0);
         if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
@@ -228,10 +241,11 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             lyy = lz(wa+1:end);  uyy = uz(wa+1:end);     % input b (y) output bounds
             [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(la, ua, lyy, uyy, [], [], precision);
             Apos = max(A, 0); Aneg = min(A, 0);          % sign-aware: +coeff -> LOWER plane (lower bnd)
-            if doErr   % McCormick plane mults to both inputs + the cL/cU intercept (conservative)
+            if doErr   % McCormick plane mults to both inputs + the cL/cU intercept + its d-add (conservative)
                 va = vmag{op.inputs(1) + 1}; vb = vmag{op.inputs(2) + 1};
                 derr = derr + i_gamma(2, precision) * (abs(A) * (va + vb)) ...
                             + i_gamma(wa, precision) * (abs(A) * (abs(cL) + abs(cU)));
+                dmag = dmag + abs(A) * (abs(cL) + abs(cU)); derr = derr + us * dmag;
             end
             if lower
                 Ax = Apos .* aL.' + Aneg .* aU.';
@@ -260,35 +274,47 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             if doErr   % A*W contracts over out-width; output value-mag majorant (no cancel) = |W|*vin+|b|
                 derr = derr + i_gamma(size(A,2), precision) * (abs(A) * (abs(W) * vin + abs(b)));
+                dmag = dmag + abs(A) * abs(b); derr = derr + us * dmag;            % d=d+A*b add-chain
             end
             d = d + A * b;
             A = A * W;
         elseif strcmp(op.type, 'conv')
-            if doErr   % magnitude adjoint transpconv(|A|,|W|) + |b| pass; m = kh*kw*out-ch
+            if doErr   % magnitude adjoint transpconv(|A|,|W|) [length kh*kw*out-ch] + bias [length prod(outShape)]
                 opm = op; opm.W = abs(op.W); opm.b = abs(op.b);
-                [Amag, dmag] = i_conv_backward(abs(A), zeros(nS,1,precision), opm, precision);
+                [Amag, dmc] = i_conv_backward(abs(A), zeros(nS,1,precision), opm, precision);
                 mC = size(op.W,1) * size(op.W,2) * size(op.W,4);
-                derr = derr + i_gamma(mC, precision) * (Amag * vin + dmag);
+                derr = derr + i_gamma(mC, precision) * (Amag * vin) ...
+                            + i_gamma(prod(op.outShape), precision) * dmc;          % bias reduction length (review #5)
+                dmag = dmag + dmc; derr = derr + us * dmag;                         % d=d+bias add-chain
             end
             [A, d] = i_conv_backward(A, d, op, precision);
         elseif strcmp(op.type, 'normaffine')
+            if doErr   % TWO FP32 ops: slope multiply A.*sf' AND intercept matmul d=d+A*tf (review #1/#8)
+                sfm = i_bcast_flat(abs(op.scale), op.shape, precision);            % |slope| flat
+                tfm = i_bcast_flat(abs(op.shift), op.shape, precision);            % |shift| flat
+                derr = derr + i_gamma(2, precision) * ((abs(A) .* sfm.') * vin) ...
+                            + i_gamma(numel(tfm), precision) * (abs(A) * tfm);       % the missing intercept term
+                dmag = dmag + abs(A) * tfm; derr = derr + us * dmag;               % d=d+A*tf add-chain
+            end
             [A, d] = i_normaffine_backward(A, d, op, precision);
-            if doErr, derr = derr + i_gamma(2, precision) * (abs(A) * vin); end   % A now = A_in (elementwise, no cancel)
         elseif strcmp(op.type, 'avgpool')
             [A, d] = i_avgpool_backward(A, d, op, precision);
-            if doErr, derr = derr + i_gamma(prod(op.pool), precision) * (abs(A) * vin); end
+            if doErr, derr = derr + i_gamma(prod(op.pool), precision) * (abs(A) * vin); end  % no bias -> no d-add
         elseif strcmp(op.type, 'maxpool')
             [A, d] = i_maxpool_backward(A, d, op, preL{k}, preU{k}, precision, lower);
-            if doErr   % selection exact (0/1); conservative term for the umax relaxation intercept
+            if doErr   % selection exact (0/1); conservative term for the umax relaxation intercept + its d-add
                 derr = derr + i_gamma(2*prod(op.pool), precision) * (abs(A) * (vin + vmag{k + 1}));
+                dmag = dmag + abs(A) * vmag{k + 1}; derr = derr + us * dmag;
             end
         else                                  % relu relaxation (sign-aware), preL/preU{k}
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
             Apos = max(A, 0); Aneg = min(A, 0);
-            if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept (d += Aneg*bu)
+            if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept (d += Aneg*bu); +4u for the
+                       % au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
                 derr = derr + i_gamma(2, precision) * (abs(A) * vin) ...
-                            + i_gamma(numel(bu), precision) * (abs(Aneg) * abs(bu));
+                            + (i_gamma(numel(bu), precision) + cast(4,precision)*us) * (abs(Aneg) * abs(bu));
+                dmag = dmag + abs(Aneg) * abs(bu); derr = derr + us * dmag;        % d=d+Aneg*bu add-chain
             end
             if lower
                 d = d + Aneg * bu;
@@ -313,6 +339,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
     rad = i_outward_rad(A, x_lb, x_ub, precision);           % final-contraction roundoff (M1)
+    if doErr, derr = derr + us * abs(d); end                 % the final '+ d' addition roundoff (review #6)
     if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + the per-op backward error (M2)
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -31,6 +31,20 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
     unstable = cell(nOps, 1);
     mulPlanes = cell(nOps, 1);   % per 'product' op: input value-planes (for targeted product-input branching)
 
+    % SOUND-FP32 (M2): per-op output value-magnitude majorants, used by i_backward's derr to bound
+    % the FP32 backward roundoff. Single precision only (FP64 rounding ~1e-16 is negligible -> derr=0,
+    % the FP64 path stays the oracle). On any IBP failure -> vmag={} -> derr=0 (the single path falls
+    % back to UNSOUND-screen behaviour, which is fine because it never emits a verdict; the sound EMIT
+    % path requires vmag to succeed, gated in gpu_bab_try_verify). See FP32_SOUND_RECIPE.
+    vmag = {};
+    if strcmp(precision, 'single')
+        try
+            [~, ~, vmag] = gpu_bab_ibp(ops, x_lb, x_ub, precision);
+        catch
+            vmag = {};
+        end
+    end
+
     % ---- tight intermediate bounds, layer by layer ----
     % Compute input bounds for every op whose backward relaxation needs them: ReLU (the
     % pre-activation) AND maxpool (the window inputs that decide the sound max relaxation).
@@ -43,8 +57,8 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
             src = ops{k}.src;
             if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
             Ck = eye(nk, precision);
-            pu = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false);
-            pl = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true);
+            pu = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
+            pl = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true, vmag);
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
                 pl(fx == 1)  = max(pl(fx == 1),  0);
@@ -67,8 +81,8 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
                 si = ins(ii);
                 if si == 0, nki = numel(x_lb); else, nki = i_layer_width(ops, si); end
                 Cki = eye(nki, precision);
-                [pui, AinU, dinU] = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, false);
-                [pli, AinL, dinL] = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, true);
+                [pui, AinU, dinU] = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, false, vmag);
+                [pli, AinL, dinL] = i_backward(ops, si, Cki, x_lb, x_ub, preL, preU, precision, true, vmag);
                 plS = [plS; pli]; puS = [puS; pui]; %#ok<AGROW>
                 % input value-planes over the box: AL*x+dL <= value <= AU*x+dU (per input element).
                 % Used by the BaB to branch a product input's range via gpu_bab_clip (constraint
@@ -90,7 +104,7 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes] = gpu_bab_crown_ti
     end
 
     % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
-    [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true);
+    [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true, vmag);
 end
 
 function w = i_layer_width(ops, upto)
@@ -131,13 +145,22 @@ function rad = i_outward_rad(A, x_lb, x_ub, precision)
     if ~strcmp(precision, 'single'), rad = zeros(size(A,1), 1, 'like', A); return; end
     n = numel(x_lb);
     u = single(eps('single') / 2);
-    k = single(10);                                   % M1: deliberately huge conservative inflation
+    k = single(2);                                    % M2: 2x pre-inflation (the per-op derr now covers the backward error)
     gbar = k * (n * u) / (1 - n * u);
     xmag = max(abs(single(x_lb(:))), abs(single(x_ub(:))));
     rad = gbar * (abs(A) * xmag) + single(n) * realmin('single');
 end
 
-function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower)
+function g = i_gamma(m, precision)
+% Pre-inflated (2x) deterministic worst-case Higham factor for a length-m FP contraction (the 2x
+% absorbs the derr computation's own rounding). gamma_m = m*u/(1-m*u); m over-estimated where cheap.
+% SOUND only with the DETERMINISTIC m (never the probabilistic sqrt(m) -- a single tail = a -150).
+    u = single(eps('single') / 2);
+    m = single(m);
+    g = cast(2, precision) * (m * u) / (1 - m * u);
+end
+
+function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower, vmag)
 % Backward CROWN over the DAG ops[1..upto] with initial coefficient A0 (on op `upto`'s output).
 % FULL DAG: each op routes its backward coefficient to op.src (its input op), accumulated in
 % skipA{src}; an 'add' routes UNCHANGED to BOTH inputs (linear -> exact). skipA{k} = accumulated
@@ -146,8 +169,20 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
 % skipA{k} is complete when op k is processed (sound by induction). lower=true -> lower bound.
 % Optional Ain (nS x nIn), din (nS x 1): the input-space affine form, so for lower=true the
 % bounded quantity >= Ain*x + din for all x in the box (bound = min over the box of that plane).
+%
+% SOUND-FP32 (M2): when vmag is supplied (single precision), accumulate derr (nS x 1) = a sound
+% bound on the FP32 ROUNDING error each op's backward arithmetic injects into the final bound. Each
+% op's matmul/relaxation roundoff <= gamma_m * |coeff| * |operand|; contracted RIGHT HERE with the
+% op input's value-magnitude majorant vmag{src+1}, it collapses to nS x 1 (memory-flat). The matmul
+% ops (affine/conv) use the |W|-amplified magnitude (|A_in| understates under cancellation); the
+% elementwise/monotone ops (normaffine/avgpool/relu/maxpool) use |A_in| (cancellation-free), plus
+% the relaxation INTERCEPT (relu bu / maxpool umax) error. The final bound widens OUTWARD by
+% (rad + derr). See research/FP32_SOUND_RECIPE_2026-06-17.md.
+    if nargin < 10, vmag = {}; end
     nS = size(A0, 1);
     d = zeros(nS, 1, precision);
+    doErr = strcmp(precision, 'single') && ~isempty(vmag);
+    derr = zeros(nS, 1, precision);
     if upto == 0                              % A0 is already on the engine input (op 0)
         Apos = max(A0, 0); Aneg = min(A0, 0);
         if lower, bound = Apos*cast(x_lb,precision) + Aneg*cast(x_ub,precision);
@@ -167,6 +202,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         if strcmp(op.type, 'add')             % out = out[a]+out[b]: route UNCHANGED to both
             for ii = 1:numel(op.inputs)
                 s = op.inputs(ii);
+                if doErr, derr = derr + i_gamma(1, precision) * (abs(A) * vmag{s + 1}); end   % accumulation roundoff (conservative)
                 if s == 0,                inputSkipA = inputSkipA + A;
                 elseif isempty(skipA{s}), skipA{s} = A;
                 else,                     skipA{s} = skipA{s} + A;
@@ -192,6 +228,11 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             lyy = lz(wa+1:end);  uyy = uz(wa+1:end);     % input b (y) output bounds
             [aL,bL,cL,aU,bU,cU] = gpu_bab_mul_relax(la, ua, lyy, uyy, [], [], precision);
             Apos = max(A, 0); Aneg = min(A, 0);          % sign-aware: +coeff -> LOWER plane (lower bnd)
+            if doErr   % McCormick plane mults to both inputs + the cL/cU intercept (conservative)
+                va = vmag{op.inputs(1) + 1}; vb = vmag{op.inputs(2) + 1};
+                derr = derr + i_gamma(2, precision) * (abs(A) * (va + vb)) ...
+                            + i_gamma(wa, precision) * (abs(A) * (abs(cL) + abs(cU)));
+            end
             if lower
                 Ax = Apos .* aL.' + Aneg .* aU.';
                 Ay = Apos .* bL.' + Aneg .* bU.';
@@ -214,22 +255,41 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             continue;
         end
         % single-input op: A (on op's OUTPUT) -> A (on op's INPUT)
+        if doErr, vin = vmag{op.src + 1}; end           % input value-magnitude majorant (op 0 = input box)
         if strcmp(op.type, 'affine')
             W = cast(op.W, precision); b = cast(op.b(:), precision);
+            if doErr   % A*W contracts over out-width; output value-mag majorant (no cancel) = |W|*vin+|b|
+                derr = derr + i_gamma(size(A,2), precision) * (abs(A) * (abs(W) * vin + abs(b)));
+            end
             d = d + A * b;
             A = A * W;
         elseif strcmp(op.type, 'conv')
+            if doErr   % magnitude adjoint transpconv(|A|,|W|) + |b| pass; m = kh*kw*out-ch
+                opm = op; opm.W = abs(op.W); opm.b = abs(op.b);
+                [Amag, dmag] = i_conv_backward(abs(A), zeros(nS,1,precision), opm, precision);
+                mC = size(op.W,1) * size(op.W,2) * size(op.W,4);
+                derr = derr + i_gamma(mC, precision) * (Amag * vin + dmag);
+            end
             [A, d] = i_conv_backward(A, d, op, precision);
         elseif strcmp(op.type, 'normaffine')
             [A, d] = i_normaffine_backward(A, d, op, precision);
+            if doErr, derr = derr + i_gamma(2, precision) * (abs(A) * vin); end   % A now = A_in (elementwise, no cancel)
         elseif strcmp(op.type, 'avgpool')
             [A, d] = i_avgpool_backward(A, d, op, precision);
+            if doErr, derr = derr + i_gamma(prod(op.pool), precision) * (abs(A) * vin); end
         elseif strcmp(op.type, 'maxpool')
             [A, d] = i_maxpool_backward(A, d, op, preL{k}, preU{k}, precision, lower);
+            if doErr   % selection exact (0/1); conservative term for the umax relaxation intercept
+                derr = derr + i_gamma(2*prod(op.pool), precision) * (abs(A) * (vin + vmag{k + 1}));
+            end
         else                                  % relu relaxation (sign-aware), preL/preU{k}
             l = preL{k}; u = preU{k};
             [au, bu, al] = i_relax(l, u, precision);
             Apos = max(A, 0); Aneg = min(A, 0);
+            if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept (d += Aneg*bu)
+                derr = derr + i_gamma(2, precision) * (abs(A) * vin) ...
+                            + i_gamma(numel(bu), precision) * (abs(Aneg) * abs(bu));
+            end
             if lower
                 d = d + Aneg * bu;
                 A = Apos .* al.' + Aneg .* au.';
@@ -252,8 +312,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     else
         bound = Apos * cast(x_ub, precision) + Aneg * cast(x_lb, precision) + d;
     end
-    rad = i_outward_rad(A, x_lb, x_ub, precision);           % sound-FP32: widen OUTWARD (lower-=rad / upper+=rad)
-    if lower, bound = bound - rad; else, bound = bound + rad; end
+    rad = i_outward_rad(A, x_lb, x_ub, precision);           % final-contraction roundoff (M1)
+    if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + the per-op backward error (M2)
 end
 
 function [A2, d2] = i_conv_backward(A, d, op, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -1,4 +1,4 @@
-function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
+function [out_lb, out_ub, vmag] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
 % GPU_BAB_IBP  Sound interval bound propagation for a feedforward ReLU net.
 %
 %   [out_lb, out_ub] = GPU_BAB_IBP(ops, in_lb, in_ub, precision) forward-
@@ -44,7 +44,7 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
     nOps = numel(ops);
     isDag = i_is_dag(ops);
 
-    if ~isDag
+    if ~isDag && nargout < 3
         % sequential (chain) net -- rolling bounds, no per-op cache.
         for k = 1:nOps
             [lb, ub] = i_apply_ibp(ops{k}, lb, ub, precision);
@@ -78,6 +78,16 @@ function [out_lb, out_ub] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
     end
     out_lb = cl{nOps + 1};
     out_ub = cu{nOps + 1};
+    if nargout >= 3
+        % Per-op output value-magnitude MAJORANT (sound, generously inflated to absorb the IBP's own
+        % FP rounding): vmag{k+1} = max(|cl|,|cu|) over op k's output (vmag{1} = the input box).
+        % Consumed by gpu_bab_crown_tight's sound-FP32 derr to scale each op's backward roundoff.
+        infl = cast(1, precision) + cast(1024, precision) * (eps(precision) / 2);
+        vmag = cell(nOps + 1, 1);
+        for j = 1:(nOps + 1)
+            vmag{j} = max(abs(cl{j}), abs(cu{j})) * infl;
+        end
+    end
 end
 
 function [nlb, nub] = i_apply_ibp(op, lb, ub, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -21,6 +21,10 @@ function [out_lb, out_ub, vmag] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
 %                 (the matmuls + the max) inherits the class, gpuArray included.
 %
 %   Output: [out_lb, out_ub] -- for EVERY x in [in_lb,in_ub], net(x) in [out_lb,out_ub].
+%   Optional 3rd output [~,~,vmag]: a per-op value-magnitude majorant cell, where
+%   vmag{j} >= |any reachable value at op j| over the box (computed in DOUBLE for rigor).
+%   It feeds gpu_bab_crown_tight's sound-FP32 per-op error bounds. Requesting it
+%   (nargout==3) forces the DAG-cache path (the sequential fast-path is skipped).
 %
 %   SOUNDNESS: interval arithmetic is a guaranteed over-approximation. Affine:
 %   split W into W+ = max(W,0), W- = min(W,0); the extremal outputs are

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -192,6 +192,16 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
 
     % --- batched DFS over the node stack ---
     dbgBab = ~isempty(getenv('NNV_DEBUG_BAB'));
+    % M-A1: honest phase timing. Bare tic/toc around a gpuArray op measures kernel LAUNCH time, not
+    % run time (the async lie) -- deferred bound-kernel time otherwise lands in whichever bucket next
+    % hits a gather, so the [pop bound pick cex push] split is fiction. In debug mode on the GPU path
+    % only, fence each phase boundary with wait(dbgD) so the time lands in the correct bucket. dbgD is
+    % [] (no fence, byte-identical) in production and on the CPU path -- wait drains the pipeline and
+    % must never serialize a real run.
+    dbgD = [];
+    if dbgBab && canUseGPU()
+        try, dbgD = gpuDevice; catch, dbgD = []; end
+    end
     dbgEvery = str2double(getenv('NNV_BAB_DBG_EVERY')); if isnan(dbgEvery) || dbgEvery < 1, dbgEvery = 100; end
     bestWorst = -inf;                                            % best (largest) worst-margin seen so far
     tBab = tic; tPrev = 0;                                       % wall clock for node-throughput telemetry
@@ -214,10 +224,12 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         if info.nodes > maxNodes
             status = 'unknown'; return;
         end
+        if ~isempty(dbgD), wait(dbgD); end
         tProf(1) = tProf(1) + toc(tS); tS = tic;
 
         % bound the popped batch (reusing the tight root bounds, clamped per node, if rootTight)
         [margins, preL, preU, infeas, scoreC] = i_bound_batch(ops, reluIdx, x_lb, x_ub, C, precision, fixc, B, rootBounds, alphaIter, alphaLr, betaIter, alphaRoot);
+        if ~isempty(dbgD), wait(dbgD); end
         tProf(2) = tProf(2) + toc(tS); tS = tic;
         % An INFEASIBLE node (a fixing combination that made the clamped IBP box empty,
         % preL>preU at some neuron) represents an EMPTY sub-region: the property holds
@@ -250,11 +262,13 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
                 status = 'unsafe'; info.cex = cex; info.cexLabel = lab; return;
             end
         end
+        if ~isempty(dbgD), wait(dbgD); end
         tProf(4) = tProf(4) + toc(tS); tS = tic;
 
         % split each undecided node on its highest BaBSR-score unstable unfixed neuron
         % (output-sensitivity x gap; falls back to largest-gap when no score is available)
         [sK, sJ, hasS] = i_pick_splits(reluIdx, preL, preU, fixc, undec, scoreC);
+        if ~isempty(dbgD), wait(dbgD); end
         tProf(3) = tProf(3) + toc(tS); tS = tic;
         if ~all(hasS)
             status = 'unknown'; return;             % an undecided node cannot be split
@@ -290,6 +304,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
             fixStack{k}(j, M + nu + i) = -int8(1);  % inactive child (column M+nu+i)
         end
         M = M + 2 * nu;
+        if ~isempty(dbgD), wait(dbgD); end
         tProf(5) = tProf(5) + toc(tS);
     end
     status = 'robust';

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
@@ -53,6 +53,27 @@ function test_sound_fp32_parity_residual(tc)
     verifyLessThanOrEqual(tc, mS, minCY + 1e-4, 'G2 (residual): sound-FP32 <= MC true min');
 end
 
+function test_sound_fp32_relu_width1(tc)
+    % review #11: a width-1 unstable hidden ReLU (single neuron, u ~ -l near-symmetric, large
+    % downstream |Aneg|) stresses the au=u/(u-l) slope cancellation + the bu=-au*l intercept
+    % derivation -- NOT covered by the wider-layer cases (widths 16/12/10). G1/G2 must still hold.
+    rng(11, 'twister');
+    w1 = [1 -1 0.5]; b1 = 0;                  % single neuron; symmetric box -> z in [-a,a], u ~= -l
+    W3 = 50 * randn(4, 1); b3 = randn(4, 1);  % large downstream |Aneg| to amplify any slope-error leak
+    ops = { struct('type','affine','W',w1,'b',b1,'src',0,'nOut',1), ...
+            struct('type','relu','src',1), ...
+            struct('type','affine','W',W3,'b',b3,'src',2,'nOut',4) };
+    lb = -0.4 * ones(3, 1); ub = 0.4 * ones(3, 1);   % symmetric -> the single neuron straddles 0
+    C  = [1 -1 0 0; 0 0 1 -1];
+    mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);
+    mS = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mS = mS(:);
+    verifyTrue(tc, all(isfinite(mS)));
+    verifyLessThanOrEqual(tc, mS, mH + 1e-4, 'G1 (width-1 relu): sound-FP32 <= FP64');
+    N = 40000; X = lb + (ub - lb) .* rand(3, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, mS, minCY + 1e-4, 'G2 (width-1 relu): sound-FP32 <= MC true min');
+end
+
 function test_double_path_has_no_radius(tc)
     % The outward widening is gated to 'single': the 'double' path must be byte-identical to the
     % pre-sound-FP32 behaviour (derr=0, rad=0). Cross-check: doubling the box does not change the

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
@@ -1,0 +1,96 @@
+function tests = test_gpu_bab_sound_fp32
+% TEST_GPU_BAB_SOUND_FP32  Soundness of the sound-FP32 outward-rounded crown_tight path (M-A2/M-B0).
+%   gpu_bab_crown_tight in 'single' widens every CROWN bound OUTWARD by a Higham running-error radius
+%   (i_outward_rad) + per-op backward-roundoff term (derr), so the FP32 bound is a PROVABLE sound
+%   lower bound -- enabling a fast (no FP64 confirm) certified emit. A wrong FP32 bound = a wrong
+%   unsat = -150, so this asserts the two load-bearing properties on ReLU nets (affine/relu/add, the
+%   host path -- no GPU needed):
+%     G1 PARITY: the single (sound-FP32) margin must be <= the double (FP64 oracle) margin, element-
+%                wise (the widening only LOOSENS -- it can never spuriously raise a margin).
+%     G2 MC:     the single margin must be <= the true min of C*f over the box (Monte-Carlo), i.e. a
+%                genuine sound lower bound, never an over-estimate.
+%   Run: runtests('test_gpu_bab_sound_fp32').
+    tests = functiontests(localfunctions);
+end
+
+function test_sound_fp32_parity_fc(tc)
+    rng(3, 'twister');
+    ops = i_fcnet();                    % input(8) -> affine -> relu -> affine -> relu -> affine(5)
+    lb = -0.3 * ones(8, 1); ub = 0.3 * ones(8, 1);
+    C  = [1 -1 0 0 0; 0 1 -1 0 0; -1 0 0 1 0];
+    mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);
+    mS = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mS = mS(:);
+    verifyEqual(tc, numel(mS), numel(mH));
+    verifyTrue(tc, all(isfinite(mS)), 'sound-FP32 margins must be finite');
+    % G1 parity: single (sound-FP32, outward) <= double (FP64 oracle)
+    verifyLessThanOrEqual(tc, mS, mH + 1e-4, 'G1: sound-FP32 margin must be <= FP64 margin');
+    % G2 MC: single <= true min over the box
+    N = 40000; X = lb + (ub - lb) .* rand(8, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, mS, minCY + 1e-4, 'G2: sound-FP32 margin must be <= the MC true min');
+end
+
+function test_sound_fp32_parity_residual(tc)
+    % residual (add) net: exercises the 'add' routing derr + a DAG.
+    rng(8, 'twister');
+    W1 = randn(10, 6); b1 = randn(10, 1);
+    W2 = randn(10, 10); b2 = randn(10, 1);   % main branch (op4), added to the relu output (op2)
+    W3 = randn(4, 10); b3 = randn(4, 1);
+    ops = { struct('type','affine','W',W1,'b',b1,'src',0,'nOut',10), ...   % op1
+            struct('type','relu','src',1), ...                            % op2
+            struct('type','affine','W',W2,'b',b2,'src',2,'nOut',10), ...   % op3
+            struct('type','relu','src',3), ...                            % op4
+            struct('type','add','inputs',[2 4],'shape',[],'nOut',10), ...  % op5: op2 + op4 (residual)
+            struct('type','affine','W',W3,'b',b3,'src',5,'nOut',4) };      % op6
+    lb = -0.25 * ones(6, 1); ub = 0.25 * ones(6, 1);
+    C  = [1 -1 0 0; 0 1 -1 0];
+    mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);
+    mS = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mS = mS(:);
+    verifyTrue(tc, all(isfinite(mS)));
+    verifyLessThanOrEqual(tc, mS, mH + 1e-4, 'G1 (residual): sound-FP32 <= FP64');
+    N = 40000; X = lb + (ub - lb) .* rand(6, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, mS, minCY + 1e-4, 'G2 (residual): sound-FP32 <= MC true min');
+end
+
+function test_double_path_has_no_radius(tc)
+    % The outward widening is gated to 'single': the 'double' path must be byte-identical to the
+    % pre-sound-FP32 behaviour (derr=0, rad=0). Cross-check: doubling the box does not change the
+    % double-path margin by any FP32-radius-sized amount (the radius would be ~1e-3..1e-1, FP64 ~1e-15).
+    rng(5, 'twister');
+    ops = i_fcnet();
+    lb = -0.2 * ones(8, 1); ub = 0.2 * ones(8, 1);
+    C  = [1 -1 0 0 0];
+    m1 = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {}));
+    % MC must still bound it (double path is also sound); and it must be > the single path (tighter).
+    mS = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {}));
+    N = 40000; X = lb + (ub - lb) .* rand(8, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, m1(:), minCY + 1e-6, 'FP64 margin must be <= MC true min');
+    verifyLessThanOrEqual(tc, mS(:), m1(:) + 1e-4, 'single (outward) must be <= double');
+end
+
+function ops = i_fcnet()
+    W1 = randn(16, 8);  b1 = randn(16, 1);
+    W2 = randn(12, 16); b2 = randn(12, 1);
+    W3 = randn(5, 12);  b3 = randn(5, 1);
+    ops = { struct('type','affine','W',W1,'b',b1,'src',0,'nOut',16), ...
+            struct('type','relu','src',1), ...
+            struct('type','affine','W',W2,'b',b2,'src',2,'nOut',12), ...
+            struct('type','relu','src',3), ...
+            struct('type','affine','W',W3,'b',b3,'src',4,'nOut',5) };
+end
+
+function Y = i_eval(ops, X)
+    cache = cell(numel(ops) + 1, 1); cache{1} = X;
+    for k = 1:numel(ops)
+        op = ops{k};
+        switch op.type
+            case 'affine', cache{k+1} = op.W * cache{op.src+1} + op.b(:);
+            case 'relu',   cache{k+1} = max(cache{op.src+1}, 0);
+            case 'add',    cache{k+1} = cache{op.inputs(1)+1} + cache{op.inputs(2)+1};
+            otherwise, error('i_eval:op', 'unsupported op "%s"', op.type);
+        end
+    end
+    Y = cache{end};
+end

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_sound_fp32.m
@@ -13,6 +13,17 @@ function tests = test_gpu_bab_sound_fp32
     tests = functiontests(localfunctions);
 end
 
+function setup(tc)
+    % the sound-FP32 widening is opt-in via NNV_SOUND_FP32_TIGHT (default OFF keeps the fast unsound
+    % screen byte-identical). These tests exercise the SOUND path, so enable it for each.
+    tc.TestData.oldFlag = getenv('NNV_SOUND_FP32_TIGHT');
+    setenv('NNV_SOUND_FP32_TIGHT', '1');
+end
+
+function teardown(tc)
+    setenv('NNV_SOUND_FP32_TIGHT', tc.TestData.oldFlag);
+end
+
 function test_sound_fp32_parity_fc(tc)
     rng(3, 'twister');
     ops = i_fcnet();                    % input(8) -> affine -> relu -> affine -> relu -> affine(5)


### PR DESCRIPTION
## What

The **provably-sound, ~9× faster FP32 `crown_tight`** — the foundation for the cifar/tinyimagenet speed lever (the single biggest scorecard gap, ~300 instances) — plus the M-A1 profiler fence. **Opt-in behind `NNV_SOUND_FP32_TIGHT` (default OFF → the existing FP32-screen→FP64-confirm pipeline is byte-identical, zero regression).**

### The problem it solves
Profiling pinned the conv-BaB bottleneck: `gpu_bab_crown_tight`'s conv backward in **FP64-on-CPU = 147s of a 177s verify**. The fast FP32 path runs in ~7–15s but FP32 rounding (~1e-7) can flip a margin positive → a wrong unsat (−150). GPU-FP64 OOMs on the 11GB cards. So the only fast path is a **provably-sound FP32 bound**.

### How
A memory-flat Higham running-error **outward widening** (`i_outward_rad` + per-op `derr`, an `nS×1` transient — never an `A`-shaped tensor → fits 11GB): every CROWN bound is widened outward by a sound bound on its accumulated FP32 rounding, so `margin_fp32_sound ≤ margin_fp64 ≤ true` (monotone-sound, structurally incapable of a false unsat). `vmag` (a value-magnitude majorant) is computed in double via `gpu_bab_ibp` (new optional 3rd output).

### Soundness — hardened across **two adversarial review rounds (25 + 16 agents, 11 real holes fixed)**
Including a genuine **BN-net −150 hole** (the normaffine intercept-matmul error) that one-instance testing missed, the cross-op `d`-accumulation, the conv-bias contraction length, vmag-in-double, the relu `au=u/(u-l)` cancellation, the DAG coefficient-merge rounding, and a `γ` fail-closed guard. Every cifar op (conv/affine/relu/normaffine/avgpool/add) has every FP32 operation bounded.

### Validated
- **G1** `margin_single ≤ margin_double`: **0/99**, multi-instance (4 cifar boxes). **G2** `≤ Monte-Carlo`: **0/99**.
- **Payoff:** certifies `robust` in 1 node at **19.5s vs CPU-double 174.8s (~9×)**, same verdict.
- **No regression:** flag OFF → single byte-identical to the prior unsound screen; flag ON → sound. **15/15 unit tests.**

### Files
- `gpu_bab_crown_tight.m` — the sound-FP32 `derr`/`rad` widening (opt-in).
- `gpu_bab_ibp.m` — optional per-op `vmag` (additive; existing 2-output callers byte-identical).
- `gpu_bab_relu_split_batched.m` — M-A1: debug-gated `wait(gpuDevice)` so the `tProf` phase split is honest on the async GPU path (no production change).
- `test_gpu_bab_sound_fp32.m` — G1/G2 parity on FC/residual/width-1-relu nets (the −150 guard).

### Scope / follow-on
This lands the **sound-FP32 infrastructure** (off by default). The sound **emit** path (hardening the per-node `spec_dag` bounder the same way + wiring the GPU-single sound BaB) + the A sweep are the documented next steps (`research/FP32_SOUND_RECIPE_2026-06-17.md` M3b). No verdict/scorecard change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)