### PR TITLE
gpu_bab: crown_tight derr tightening + adversarial-review soundness fixes (4x cifar emit, sound, default-OFF)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -302,8 +302,8 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                     mC = size(op.W,1) * size(op.W,2) * size(op.W,4); nO = prod(op.outShape);
                     % Amag/dmc are SINGLE-precision reductions (lengths ~mC / nO), so they can round DOWN
                     % by up to gamma_raw -- the only derr operands NOT computed in double here. The
-                    % (1+2^-10) gamma inflation covers only the final single() cast, NOT this operand
-                    % shortfall, which exceeds 2^-10 once nO > ~16380 (early CIFAR convs hit 32x32x64).
+                    % the (1+2^-7) gamma inflation covers the cast + accumulation, NOT this operand
+                    % shortfall (a single reduction can round down by gamma_nO), so inflate it explicitly.
                     % Inflate each by (1+2*gamma_raw) >= 1/(1-gamma_raw) -> a sound over-estimate of the
                     % true magnitude (adversarial-review finding 2026-06-18; ~0.8% for nO=65536, so the
                     % derr stays ~halved while remaining a rigorous bound).
@@ -342,7 +342,7 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 if doErr   % slope mult (|A_in|<=|A|, no cancel) + the bu intercept (PER-NODE dim x B, R1a)
                            % |A| covers the d-pass; +4u for the au=u/(u-l)/bu=-au*l derivation rounding
                     Abu  = i_dterm_raw_sd(A, reshape(double(abs(bu)), dim, 1, B), nSpec, B);   % |A|*|bu| (nSpec x B)
-                    derr = derr + i_dterm_sd(A, reshape(double(vin), dim, 1, 1), 2, nSpec, B) ...
+                    derr = derr + i_dterm_sd(A, reshape(double(vin), dim, 1, 1), 8, nSpec, B) ...    % m=8: slope multiply (~u) + the relu RELAXATION-DERIVATION rounding (~3u*vin at z=u; scales with vin, NOT bu) -- review 2026-06-18
                                 + single(i_gamma_sd(dim,'double') + double(4)*double(us)) * Abu;
                     dmag = dmag + Abu; derr = derr + us * dmag;        % d=d+Aneg*bu add-chain
                 end
@@ -377,12 +377,13 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
     Apos = max(A, 0); Aneg = min(A, 0);
     lbcol = reshape(cast(x_lb, precision), n, 1, B);
     ubcol = reshape(cast(x_ub, precision), n, 1, B);
-    margins = reshape(pagemtimes(Apos, lbcol), nSpec, B) ...
-            + reshape(pagemtimes(Aneg, ubcol), nSpec, B) + d;
+    aposx = reshape(pagemtimes(Apos, lbcol), nSpec, B);
+    anegx = reshape(pagemtimes(Aneg, ubcol), nSpec, B);
+    margins = aposx + anegx + d;
     if doErr   % widen the LOWER bound OUTWARD (down) by the final-contraction rad + the accumulated
                % per-op derr, so margins_single <= margins_double <= true (monotone-sound, can EMIT)
         rad  = i_outward_rad_sd(A, x_lb, x_ub, precision);
-        derr = derr + us * abs(d);                        % the final '+ d' addition roundoff
+        derr = derr + us * abs(d) + cast(3,precision)*us * (abs(aposx) + abs(anegx));  % '+d' u*|d| + the two final adds fl(fl(aposx+anegx)+d) ~2u*P (3*us*P w/ margin; reduced rad k no longer covers them) -- re-review CHECK 3, 2026-06-18
         margins = margins - rad - derr;
         if ~isempty(getenv('NNV_DEBUG_DERR'))             % M3b tightening diagnosis (no behaviour change)
             mraw = margins + rad + derr;                  % the un-widened margin
@@ -513,19 +514,20 @@ end
 function g = i_gamma_sd(m, precision)
 % Deterministic Higham factor gamma_m = m*u/(1-m*u) for a length-m FP32 contraction; fail-closed to
 % realmax when m*u>=0.5. INFLATION (M3b-T): spec_dag computes each derr term in DOUBLE
-% (i_dterm_sd: single(gamma * pagemtimes(double|A|, double vmag))), so the ONLY single-precision
-% rounding in the derr value is the final single() cast (rel. error <= u ~= 6e-8). A (1 + 2^-10)
-% inflation covers that cast ~16000x over -> still a sound over-estimate of the Higham bound on the
-% actual single CROWN rounding. (crown_tight.m's i_gamma keeps the 2x because ITS derr is accumulated
-% in single; this divergence is intentional + each is sound. Diagnosed 2026-06-18: the old 2x made
-% derr ~2x larger than necessary, blocking cifar emit; this halves it.)
+% (i_dterm_sd: single(gamma * pagemtimes(double|A|, double vmag))), so the only single-precision
+% rounding in the derr value is the final single() cast (<= u) PLUS the single derr-accumulator sum
+% (round-down ~ gamma_N for N derr-adds). A (1 + 2^-7) inflation covers BOTH the cast AND the
+% accumulation for N <= 2^17 derr-adds (any net), provably -> a sound over-estimate of the Higham
+% bound. (crown_tight.m's i_gamma now matches at (1+2^-7) -- same double-GEMM derr. The old 2x made
+% derr ~2x larger than necessary, blocking cifar emit; adversarial review 2026-06-18 confirmed the
+% relu-slope (m=8), final-add (3*us*|a|), and accumulator coverages this 2^-7 + the conv inflation.)
     u = single(eps('single') / 2);
     m = single(m);
     den = 1 - m * u;
     if den <= single(0.5)
         g = cast(realmax('single'), precision); return;
     end
-    g = cast(1 + 2^-10, precision) * (m * u) / den;
+    g = cast(1 + 2^-7, precision) * (m * u) / den;   % (1+2^-7): covers the final cast AND the single derr-accumulator sum for N<=2^17 derr-adds (any net). Was (1+2^-10) which covered only N<=16384 -- adversarial review 2026-06-18.
 end
 
 function g = i_gamma_raw_sd(m, precision)
@@ -551,7 +553,7 @@ function rad = i_outward_rad_sd(A, x_lb, x_ub, precision)
 % DOUBLE). A: nSpec x n x B (input-space coeff), x_lb/x_ub: n x B -> rad: nSpec x B (single).
     nSpec = size(A,1); B = size(A,3); n = size(x_lb,1);
     if ~strcmp(precision, 'single'), rad = zeros(nSpec, B, 'like', A); return; end
-    u = single(eps('single') / 2); k = single(1 + 2^-10);   % M3b-T: double-computed + single-cast -> (1+2^-10) covers the cast (was 2x, over-inflated)
+    u = single(eps('single') / 2); k = single(1 + 2^-7);    % M3b-T: double GEMM -> covers cast + accumulation (was 2x); final-add u*|a| covered at the margin block -- review 2026-06-18
     den = 1 - single(n) * u;
     if den <= single(0.5)
         rad = realmax('single') * ones(nSpec, B, 'like', A); return;

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -165,7 +165,7 @@ function rad = i_outward_rad(A, x_lb, x_ub, precision)
     if ~strcmp(precision, 'single'), rad = zeros(size(A,1), 1, 'like', A); return; end
     n = numel(x_lb);
     u = single(eps('single') / 2);
-    k = single(1 + 2^-10);                            % M2b: the GEMM below is DOUBLE -> only the final single() cast needs covering (was 2x)
+    k = single(1 + 2^-7);                             % M2b: DOUBLE GEMM -> covers the rad cast + accumulation (was 2x); the final-add u*|a| is covered separately at line ~411
     den = 1 - single(n) * u;
     if den <= single(0.5)                             % n*u >= 0.5: linearized gamma_n invalid -> fail-closed (max sound widening, mirrors i_gamma)
         rad = realmax('single') * ones(size(A,1), 1, 'like', A); return;
@@ -180,18 +180,21 @@ function g = i_gamma(m, precision)
 % over-estimated where cheap. SOUND only with the DETERMINISTIC m (never probabilistic sqrt(m) -- a
 % single tail = a -150). INFLATION (M2b): the derr terms now compute each magnitude product in DOUBLE
 % (single(i_gamma(m,'double') * (double(abs(A)) * double(OP)))), so the only single-precision rounding
-% in the derr VALUE is the final single() cast (rel. <= u ~= 6e-8). (1 + 2^-10) covers that cast
-% ~16000x over -> still a sound over-estimate of the Higham bound on the actual single CROWN rounding.
-% (Was 2x, which absorbed the OLD single-computed derr; doubling the GEMM lets it halve -> the deep
-% BaB margins are ~2x tighter, so tight-margin certs certify in far fewer nodes. Conv Amag/dmc are
-% the only single-reduced operands -> additionally inflated by (1+2*i_gamma_raw) at the call site.)
+% in the derr VALUE is the final single() cast (rel. <= u ~= 6e-8) PLUS the SINGLE accumulation of the
+% per-op derr terms (derr is a single accumulator; summing N positive terms round-DOWNs by up to
+% gamma_N ~= N*u). (1 + 2^-7) covers BOTH the cast AND the accumulation for N <= 2^-7/u = 2^17 = 131072
+% derr-adds per i_backward call (any realistic net; cifar resnet ~ a few hundred), provably -> a sound
+% over-estimate of the Higham bound on the actual single CROWN rounding. (Was 2x, which absorbed the OLD
+% single-computed derr; doubling the GEMM lets it shrink ~16x while keeping the accumulation guarantee.
+% Conv Amag/dmc -- the only single-REDUCED operands -- get an extra (1+2*i_gamma_raw); the relu slope
+% term carries m=8 to also cover the relaxation-derivation rounding. Adversarial review 2026-06-18.)
     u = single(eps('single') / 2);
     m = single(m);
     den = 1 - m * u;
     if den <= single(0.5)            % m*u >= 0.5: the linearized gamma is invalid -> fail-closed (huge sound widening)
         g = cast(realmax('single'), precision); return;
     end
-    g = cast(1 + 2^-10, precision) * (m * u) / den;
+    g = cast(1 + 2^-7, precision) * (m * u) / den;
 end
 
 function g = i_gamma_raw_ct(m, precision)
@@ -210,7 +213,7 @@ end
 
 function t = i_dt(A, OP, m)
 % M2b: one sound-FP32 derr term = single(gamma_m * (|A| * OP)) with the |A|*OP contraction done in
-% DOUBLE, so the ONLY single rounding is the final single() cast (covered by i_gamma's 1+2^-10). OP
+% DOUBLE, so the ONLY single rounding is the final single() cast (covered by i_gamma's 1+2^-7). OP
 % must be a sound DOUBLE magnitude majorant of the propagated values (vmag/vin, or a double-computed
 % magnitude). Mirrors gpu_bab_crown_spec_dag.i_dterm_sd (2D matmul here vs batched pagemtimes there).
     t = single(i_gamma(m, 'double') * (double(abs(A)) * double(OP)));
@@ -342,7 +345,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 [Amag, dmc] = i_conv_backward(abs(A), zeros(nS,1,precision), opm, precision);
                 mC = size(op.W,1) * size(op.W,2) * size(op.W,4); nO = prod(op.outShape);
                 % Amag/dmc are SINGLE reductions (lengths ~mC / nO) -> can round DOWN by up to gamma_raw;
-                % inflate by (1+2*gamma_raw) >= 1/(1-gamma_raw) so the (1+2^-10) term over-estimates the
+                % inflate by (1+2*gamma_raw) >= 1/(1-gamma_raw) so the (1+2^-7) gamma term over-estimates the
                 % true single rounding even for large outShape (mirrors gpu_bab_crown_spec_dag conv fix).
                 Amag = Amag .* (1 + 2*i_gamma_raw_ct(mC, precision));
                 dmc  = dmc  .* (1 + 2*i_gamma_raw_ct(nO, precision));
@@ -376,7 +379,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept; |A| (not |Aneg|) so it
                        % covers BOTH passes (lower: d+=Aneg*bu, upper: d+=Apos*bu) -- review #2; +4u for
                        % the au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
-                derr = derr + i_dt(A, vin, 2) ...
+                derr = derr + i_dt(A, vin, 8) ...    % m=8: slope multiply (~u) + the relu RELAXATION-DERIVATION rounding (au=u/(u-l),bu=-au*l in single dips the relaxed line below relu by ~3u*vin at z=u; this scales with vin, NOT bu, so the +4u*|bu| term below does NOT cover it when u>>|l| -> bu->0). adversarial review 2026-06-18.
                             + single((i_gamma(numel(bu), 'double') + double(4)*double(us)) * (double(abs(A)) * double(abs(bu))));
                 dmag = dmag + i_draw(A, abs(bu)); derr = derr + us * dmag;        % d=d+(Aneg|Apos)*bu add-chain
             end
@@ -408,8 +411,18 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     end
     if doErr                                                 % sound-FP32 opt-in (else no widening -> screen unchanged)
         rad  = i_outward_rad(A, x_lb, x_ub, precision);      % final-contraction roundoff (M2)
-        derr = derr + us * abs(d);                           % the final '+ d' addition roundoff (review #6)
-        if lower, bound = bound - rad - derr; else, bound = bound + rad + derr; end   % widen OUTWARD by rad + per-op backward error (M2)
+        derr = derr + us * abs(d);                           % the '+ d' add's u*|d| roundoff (review #6)
+        % + the two final non-contraction adds margins=fl(fl(aposx+anegx)+d): each rounds by <= u*P
+        % (P=|aposx|+|anegx|), so ~2u*P total; the reduced (1+2^-7) rad k no longer leaves slack for them
+        % (esp. small input dim n<~1024: MNIST/ACAS/control). 3*us*P covers both adds w/ margin (>= the
+        % true |a| <= P, no cancellation). adversarial review 2026-06-18 (re-review CHECK 3).
+        if lower
+            derr = derr + cast(3,precision)*us * (abs(Apos * cast(x_lb, precision)) + abs(Aneg * cast(x_ub, precision)));
+            bound = bound - rad - derr;
+        else
+            derr = derr + cast(3,precision)*us * (abs(Apos * cast(x_ub, precision)) + abs(Aneg * cast(x_lb, precision)));
+            bound = bound + rad + derr;
+        end
     end
 end
 

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -165,27 +165,60 @@ function rad = i_outward_rad(A, x_lb, x_ub, precision)
     if ~strcmp(precision, 'single'), rad = zeros(size(A,1), 1, 'like', A); return; end
     n = numel(x_lb);
     u = single(eps('single') / 2);
-    k = single(2);                                    % M2: 2x pre-inflation (the per-op derr now covers the backward error)
+    k = single(1 + 2^-10);                            % M2b: the GEMM below is DOUBLE -> only the final single() cast needs covering (was 2x)
     den = 1 - single(n) * u;
     if den <= single(0.5)                             % n*u >= 0.5: linearized gamma_n invalid -> fail-closed (max sound widening, mirrors i_gamma)
         rad = realmax('single') * ones(size(A,1), 1, 'like', A); return;
     end
-    gbar = k * (single(n) * u) / den;
-    xmag = max(abs(single(x_lb(:))), abs(single(x_ub(:))));
-    rad = gbar * (abs(A) * xmag) + single(n) * realmin('single');
+    gbar = double(k) * (double(n) * double(u)) / double(den);
+    xmag = max(abs(double(x_lb(:))), abs(double(x_ub(:))));
+    rad = single(gbar * (double(abs(A)) * xmag)) + single(n) * realmin('single');
 end
 
 function g = i_gamma(m, precision)
-% Pre-inflated (2x) deterministic worst-case Higham factor for a length-m FP contraction (the 2x
-% absorbs the derr computation's own rounding). gamma_m = m*u/(1-m*u); m over-estimated where cheap.
-% SOUND only with the DETERMINISTIC m (never the probabilistic sqrt(m) -- a single tail = a -150).
+% Deterministic worst-case Higham factor gamma_m = m*u/(1-m*u) for a length-m FP contraction; m
+% over-estimated where cheap. SOUND only with the DETERMINISTIC m (never probabilistic sqrt(m) -- a
+% single tail = a -150). INFLATION (M2b): the derr terms now compute each magnitude product in DOUBLE
+% (single(i_gamma(m,'double') * (double(abs(A)) * double(OP)))), so the only single-precision rounding
+% in the derr VALUE is the final single() cast (rel. <= u ~= 6e-8). (1 + 2^-10) covers that cast
+% ~16000x over -> still a sound over-estimate of the Higham bound on the actual single CROWN rounding.
+% (Was 2x, which absorbed the OLD single-computed derr; doubling the GEMM lets it halve -> the deep
+% BaB margins are ~2x tighter, so tight-margin certs certify in far fewer nodes. Conv Amag/dmc are
+% the only single-reduced operands -> additionally inflated by (1+2*i_gamma_raw) at the call site.)
     u = single(eps('single') / 2);
     m = single(m);
     den = 1 - m * u;
     if den <= single(0.5)            % m*u >= 0.5: the linearized gamma is invalid -> fail-closed (huge sound widening)
         g = cast(realmax('single'), precision); return;
     end
-    g = cast(2, precision) * (m * u) / den;
+    g = cast(1 + 2^-10, precision) * (m * u) / den;
+end
+
+function g = i_gamma_raw_ct(m, precision)
+% UN-inflated Higham gamma_m = m*u/(1-m*u): the relative down-rounding bound of a length-m SINGLE
+% reduction. Used to over-estimate the single-computed conv derr operands (Amag/dmc) via (1+2*g),
+% sound (>= 1/(1-g)) for g <= 0.5; fail-close to realmax at den <= 2/3 so the over-estimate is a
+% provable invariant for all reduction lengths (mirrors gpu_bab_crown_spec_dag.i_gamma_raw_sd).
+    u = single(eps('single') / 2);
+    m = single(m);
+    den = 1 - m * u;
+    if den <= single(2/3)
+        g = cast(realmax('single'), precision); return;
+    end
+    g = cast((m * u) / den, precision);
+end
+
+function t = i_dt(A, OP, m)
+% M2b: one sound-FP32 derr term = single(gamma_m * (|A| * OP)) with the |A|*OP contraction done in
+% DOUBLE, so the ONLY single rounding is the final single() cast (covered by i_gamma's 1+2^-10). OP
+% must be a sound DOUBLE magnitude majorant of the propagated values (vmag/vin, or a double-computed
+% magnitude). Mirrors gpu_bab_crown_spec_dag.i_dterm_sd (2D matmul here vs batched pagemtimes there).
+    t = single(i_gamma(m, 'double') * (double(abs(A)) * double(OP)));
+end
+
+function t = i_draw(A, OP)
+% Raw double-computed |A|*OP (no gamma), single-cast -- for the dmag d-add-chain accumulator.
+    t = single(double(abs(A)) * double(OP));
 end
 
 function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, precision, lower, vmag)
@@ -235,8 +268,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             for ii = 1:numel(op.inputs)
                 s = op.inputs(ii);
                 if doErr && (s == 0 || ~isempty(skipA{s}))   % coefficient add-chain rounding at a merge
-                    if s == 0, derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{1});
-                    else,      derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{s + 1}); end
+                    if s == 0, derr = derr + i_dt(A, vmag{1}, upto);
+                    else,      derr = derr + i_dt(A, vmag{s + 1}, upto); end
                 end
                 if s == 0,                inputSkipA = inputSkipA + A;
                 elseif isempty(skipA{s}), skipA{s} = A;
@@ -266,9 +299,10 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % McCormick slope-update error scales as the PRODUCT va*vb (slopes |aL|<=vb,|bL|<=va
                        % are UNBOUNDED, unlike relu's [0,1]) -- review #1; + the cL/cU intercept + its d-add
                 va = vmag{op.inputs(1) + 1}; vb = vmag{op.inputs(2) + 1}; vab = va .* vb;
-                derr = derr + i_gamma(2, precision) * (abs(A) * (vab + vab)) ...
-                            + i_gamma(wa, precision) * (abs(A) * (abs(cL) + abs(cU)));
-                dmag = dmag + abs(A) * (abs(cL) + abs(cU)); derr = derr + us * dmag;
+                ccl = double(abs(cL)) + double(abs(cU));
+                derr = derr + i_dt(A, vab + vab, 2) ...
+                            + i_dt(A, ccl, wa);
+                dmag = dmag + i_draw(A, ccl); derr = derr + us * dmag;
             end
             if lower
                 Ax = Apos .* aL.' + Aneg .* aU.';
@@ -296,8 +330,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         if strcmp(op.type, 'affine')
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             if doErr   % A*W contracts over out-width; output value-mag majorant (no cancel) = |W|*vin+|b|
-                derr = derr + i_gamma(size(A,2), precision) * (abs(A) * (abs(W) * vin + abs(b)));
-                dmag = dmag + abs(A) * abs(b); derr = derr + us * dmag;            % d=d+A*b add-chain
+                omg = double(abs(W)) * double(vin) + double(abs(b));              % DOUBLE-computed magnitude majorant
+                derr = derr + i_dt(A, omg, size(A,2));
+                dmag = dmag + i_draw(A, abs(b)); derr = derr + us * dmag;          % d=d+A*b add-chain
             end
             d = d + A * b;
             A = A * W;
@@ -305,9 +340,14 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % magnitude adjoint transpconv(|A|,|W|) [length kh*kw*out-ch] + bias [length prod(outShape)]
                 opm = op; opm.W = abs(op.W); opm.b = abs(op.b);
                 [Amag, dmc] = i_conv_backward(abs(A), zeros(nS,1,precision), opm, precision);
-                mC = size(op.W,1) * size(op.W,2) * size(op.W,4);
-                derr = derr + i_gamma(mC, precision) * (Amag * vin) ...
-                            + i_gamma(prod(op.outShape), precision) * dmc;          % bias reduction length (review #5)
+                mC = size(op.W,1) * size(op.W,2) * size(op.W,4); nO = prod(op.outShape);
+                % Amag/dmc are SINGLE reductions (lengths ~mC / nO) -> can round DOWN by up to gamma_raw;
+                % inflate by (1+2*gamma_raw) >= 1/(1-gamma_raw) so the (1+2^-10) term over-estimates the
+                % true single rounding even for large outShape (mirrors gpu_bab_crown_spec_dag conv fix).
+                Amag = Amag .* (1 + 2*i_gamma_raw_ct(mC, precision));
+                dmc  = dmc  .* (1 + 2*i_gamma_raw_ct(nO, precision));
+                derr = derr + i_dt(Amag, vin, mC) ...
+                            + single(i_gamma(nO, 'double') * double(dmc));          % bias reduction length (review #5)
                 dmag = dmag + dmc; derr = derr + us * dmag;                         % d=d+bias add-chain
             end
             [A, d] = i_conv_backward(A, d, op, precision);
@@ -315,19 +355,19 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % TWO FP32 ops: slope multiply A.*sf' AND intercept matmul d=d+A*tf (review #1/#8)
                 sfm = i_bcast_flat(abs(op.scale), op.shape, precision);            % |slope| flat
                 tfm = i_bcast_flat(abs(op.shift), op.shape, precision);            % |shift| flat
-                derr = derr + i_gamma(2, precision) * ((abs(A) .* sfm.') * vin) ...
-                            + i_gamma(numel(tfm), precision) * (abs(A) * tfm);       % the missing intercept term
-                dmag = dmag + abs(A) * tfm; derr = derr + us * dmag;               % d=d+A*tf add-chain
+                derr = derr + i_dt(A, double(sfm) .* double(vin), 2) ...           % (|A|.*sf')*vin == |A|*(sf.*vin)
+                            + i_dt(A, tfm, numel(tfm));                            % the missing intercept term
+                dmag = dmag + i_draw(A, tfm); derr = derr + us * dmag;             % d=d+A*tf add-chain
             end
             [A, d] = i_normaffine_backward(A, d, op, precision);
         elseif strcmp(op.type, 'avgpool')
             [A, d] = i_avgpool_backward(A, d, op, precision);
-            if doErr, derr = derr + i_gamma(prod(op.pool), precision) * (abs(A) * vin); end  % no bias -> no d-add
+            if doErr, derr = derr + i_dt(A, vin, prod(op.pool)); end  % no bias -> no d-add
         elseif strcmp(op.type, 'maxpool')
             [A, d] = i_maxpool_backward(A, d, op, preL{k}, preU{k}, precision, lower);
             if doErr   % selection exact (0/1); conservative term for the umax relaxation intercept + its d-add
-                derr = derr + i_gamma(2*prod(op.pool), precision) * (abs(A) * (vin + vmag{k + 1}));
-                dmag = dmag + abs(A) * vmag{k + 1}; derr = derr + us * dmag;
+                derr = derr + i_dt(A, vin + vmag{k + 1}, 2*prod(op.pool));
+                dmag = dmag + i_draw(A, vmag{k + 1}); derr = derr + us * dmag;
             end
         else                                  % relu relaxation (sign-aware), preL/preU{k}
             l = preL{k}; u = preU{k};
@@ -336,9 +376,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept; |A| (not |Aneg|) so it
                        % covers BOTH passes (lower: d+=Aneg*bu, upper: d+=Apos*bu) -- review #2; +4u for
                        % the au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
-                derr = derr + i_gamma(2, precision) * (abs(A) * vin) ...
-                            + (i_gamma(numel(bu), precision) + cast(4,precision)*us) * (abs(A) * abs(bu));
-                dmag = dmag + abs(A) * abs(bu); derr = derr + us * dmag;          % d=d+(Aneg|Apos)*bu add-chain
+                derr = derr + i_dt(A, vin, 2) ...
+                            + single((i_gamma(numel(bu), 'double') + double(4)*double(us)) * (double(abs(A)) * double(abs(bu))));
+                dmag = dmag + i_draw(A, abs(bu)); derr = derr + us * dmag;        % d=d+(Aneg|Apos)*bu add-chain
             end
             if lower
                 d = d + Aneg * bu;
@@ -350,8 +390,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         end
         s = op.src;                           % route the input coefficient to op.src
         if doErr && (s == 0 || ~isempty(skipA{s}))   % a MERGE (accumulating +) -> coefficient add-chain rounding
-            if s == 0, derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{1});
-            else,      derr = derr + i_gamma(upto,precision) * (abs(A) * vmag{s + 1}); end
+            if s == 0, derr = derr + i_dt(A, vmag{1}, upto);
+            else,      derr = derr + i_dt(A, vmag{s + 1}, upto); end
         end
         if s == 0,                inputSkipA = inputSkipA + A;
         elseif isempty(skipA{s}), skipA{s} = A;


### PR DESCRIPTION
## crown_tight derr tightening + adversarial-review soundness fixes (also fixes #388's env-on path)

Extends the M3b-T sound-FP32 EMIT (#388) so MORE cifar certs emit fast, and hardens the soundness of
the gamma reduction in both crown_tight (new) and the merged #388 spec_dag.

### crown_tight tightening (the value)
crown_tight's per-op `derr` (which widens the intermediate `preL/preU` the deep BaB reuses) was
single-computed, so it kept the conservative 2x. Converted every `i_backward` derr term to a DOUBLE
`|A|*OP` contraction + reduced the gamma -> tighter `preL/preU` -> the deep BaB crosses the barrier in
far fewer nodes. **idx_8762: 4423 -> 417 nodes (~11x); broad medium sweep: 1/100 -> 4/100 emits (4x).**
(Deeply-tight certs still fall back to FP64, no regression.)

### Soundness fixes (adversarial review found the gamma reduction `2x -> (1+2^-10)` too aggressive)
The 2x was implicitly covering ~u-scale error beyond the final cast. Three targeted fixes, applied to
BOTH files:
1. **Accumulator**: `(1+2^-10) -> (1+2^-7)` covers the single derr-accumulator sum for N<=2^17 derr-adds
   (was N<=16384). (`i_gamma`/`i_gamma_sd` + `i_outward_rad`/`_sd` k.)
2. **Relu slope**: bumped the slope term to `m=8` -- covers the relu relaxation-derivation rounding
   (`au/bu` in single dip the line below relu by ~3-5u*U; scales with `vin`, not `bu`).
3. **Final-add**: added `3*us*(|aposx|+|anegx|)` -- the two final adds `fl(fl(aposx+anegx)+d)` round by
   ~2u*P, which the reduced rad k no longer covered (esp. small input dim n<1024).

### Soundness validation
- **crown_g1** (crown_tight single vs double oracle): 0/99 margin + 0/10 relu `preL/preU` violations.
- **frontier-G1** (spec_dag): 0/1584 (maxExcess -0.144).
- Two adversarial reviews (the first found the 3 gaps; the second confirmed the fixes are rigorous
  over-estimates + no 4th gap).
- Gated behind `doErr` (`NNV_SOUND_FP32_TIGHT`); **default-OFF -> master's default behavior unchanged.**

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
