### PR TITLE
VNN-COMP: observable + unit-tested method selection; cp-star quarantine gate (default OFF)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/i_finalize_reach_options.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/i_finalize_reach_options.m
@@ -1,0 +1,55 @@
+function reachOptionsList = i_finalize_reach_options(reachOptionsList, category, nnvnetValid)
+% I_FINALIZE_REACH_OPTIONS  Pure method-selection post-processing for the VNN-COMP harness.
+%   Extracted from load_vnncomp_network (run_vnncomp_instance.m) into its own file so the routing
+%   -- i.e. WHICH reach methods actually run per category, and whether a PROBABILISTIC method can
+%   survive -- is guarded by unit tests instead of being implicit in a ~1500-line function. It is
+%   pure (no MATLAB import, no GPU, no reach), so a test can call it directly with a synthetic
+%   reachOptionsList and assert the resulting method order.
+%
+%   Applies, in order, exactly what the inline code did, plus a new opt-in quarantine:
+%     (1) Phase-1.5 sound prepend -- if the list LEADS with cp-star (probabilistic) AND the net is
+%         valid, prepend {approx-star, relax-star-area 0.5} so the SOUND methods are tried first;
+%         cp-star stays in the list as the last-resort fallback.
+%     (2) slow_cats {cifar100, cora, safenlp, sat_relu, tinyimagenet, vggnet} -- DROP exact-star and
+%         lead with the fast, looser, but STILL-SOUND over-approximations {approx-zono, abs-dom} so
+%         a compute-bound category produces a sound verdict instead of timing out.
+%     (3) cp-star QUARANTINE -- gated by env NNV_QUARANTINE_CPSTAR (DEFAULT OFF). When set, STRIP
+%         cp-star entirely so a probabilistic 'unsat' can never be emitted as a sound verdict in ANY
+%         reach branch (single-spec OR either parfor branch). Strictly sound: removing cp-star can
+%         only turn a would-be unsat into 'unknown', never produce a wrong verdict. DEFAULT OFF =>
+%         the harness behaves exactly as before; set the env to measure / enforce sound-or-unknown.
+%
+%   Inputs:
+%     reachOptionsList : 1xN cell of reachOptions structs (each with a .reachMethod field)
+%     category         : the VNN-COMP category string (substring-matched, e.g. 'cifar100_2024')
+%     nnvnetValid      : logical, is_nnvnet_valid(nnvnet) -- both prepends are gated on it, matching
+%                        the original code (a sentinel net "" disables the prepends).
+%
+%   See also: i_is_probabilistic, is_nnvnet_valid, run_vnncomp_instance,
+%             tests/nn/vnncomp/test_run_vnncomp_routing.m
+    if isempty(reachOptionsList)
+        return;
+    end
+
+    % (1) sound prepend ahead of a cp-star-led list
+    if isfield(reachOptionsList{1}, 'reachMethod') ...
+            && strcmp(reachOptionsList{1}.reachMethod, 'cp-star') && nnvnetValid
+        o1 = struct(); o1.reachMethod = 'approx-star';
+        o2 = struct(); o2.reachMethod = 'relax-star-area'; o2.relaxFactor = 0.5;
+        reachOptionsList = [{o1, o2}, reachOptionsList];
+    end
+
+    % (2) slow_cats: drop exact-star, lead with zonotope + abstract-domain
+    slow_cats = ["cifar100","cora","safenlp","sat_relu","tinyimagenet","vggnet"];
+    if any(contains(category, slow_cats)) && nnvnetValid
+        kept = reachOptionsList(~cellfun(@(o) strcmp(o.reachMethod, 'exact-star'), reachOptionsList));
+        zo = struct(); zo.reachMethod = 'approx-zono';
+        ad = struct(); ad.reachMethod = 'abs-dom';
+        reachOptionsList = [{zo, ad}, kept];
+    end
+
+    % (3) cp-star quarantine (env-gated, DEFAULT OFF -> identity / behavior unchanged)
+    if ~isempty(getenv('NNV_QUARANTINE_CPSTAR'))
+        reachOptionsList = reachOptionsList(~cellfun(@(o) i_is_probabilistic(o.reachMethod), reachOptionsList));
+    end
+end

--- a/code/nnv/examples/Submission/VNN_COMP2026/i_is_probabilistic.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/i_is_probabilistic.m
@@ -1,0 +1,15 @@
+function tf = i_is_probabilistic(reachMethod)
+% I_IS_PROBABILISTIC  TRUE iff a reach method's 'holds'/unsat is NOT a sound proof.
+%   cp-star (Prob_reach, conformal prediction) is the only probabilistic reach method in the
+%   VNN-COMP harness: its verdict is a statistical guarantee, not a sound over-approximation, so a
+%   cp-star 'unsat' can be wrong (-150 in VNN-COMP scoring). Every sound method (approx-star,
+%   relax-star-area, exact-star, approx-zono, abs-dom) returns FALSE.
+%
+%   Centralized in ONE place (its own file, so it is unit-testable) and used by BOTH the cp-star
+%   quarantine (i_finalize_reach_options) and the cp-star verdict log (i_log_cpstar), so the
+%   definition of "probabilistic" can never drift between the gate and the label.
+%
+%   See also: i_finalize_reach_options, run_vnncomp_instance,
+%             tests/nn/vnncomp/test_run_vnncomp_routing.m
+    tf = strcmp(reachMethod, 'cp-star');
+end

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -350,14 +350,11 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                 % Verify property
                 status = verify_specification(ySet, prop);
-                if status == 1 && strcmp(reachOptions.reachMethod, "cp-star")
-                    % cp-star is PROBABILISTIC (conformal prediction): this 'holds'/unsat
-                    % is NOT a sound proof. It is the primary reach method for some
-                    % categories (cifar100, ml4acopf, ...) and a sound-methods-first last
-                    % resort for others (cersyve). Either way, LOG it so the per-benchmark
-                    % -150 exposure from a probabilistic verdict is tracked (see
-                    % PROGRESS_LOG cp-star policy).
-                    fprintf('VERDICT VIA CP-STAR (probabilistic, not a sound proof): %s\n', onnx);
+                if status == 1 && i_is_probabilistic(reachOptions.reachMethod)
+                    % cp-star 'unsat' is PROBABILISTIC (conformal), not a sound proof -> tracked.
+                    % (When NNV_QUARANTINE_CPSTAR is set, cp-star is stripped upstream so this
+                    % branch is never reached; default OFF preserves the original behavior.)
+                    i_log_cpstar(onnx);
                 end
 
                 if status == 1 % verified, then stop
@@ -421,6 +418,9 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                         % Add verification status
                         tempStatus = verify_specification(ySet, prop(spc));
+                        if tempStatus == 1 && i_is_probabilistic(reachOptions.reachMethod)
+                            i_log_cpstar(onnx);   % parity: parfor cp-star verdicts were previously unlogged
+                        end
                     catch
                         tempStatus = 2;   % unknown; try the next reach option
                     end
@@ -488,6 +488,9 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                         % Add verification status
                         tempStatus = verify_specification(ySet, prop(spc));
+                        if tempStatus == 1 && i_is_probabilistic(reachOptions.reachMethod)
+                            i_log_cpstar(onnx);   % parity: parfor cp-star verdicts were previously unlogged
+                        end
                     catch
                         tempStatus = 2;   % unknown; try the next reach option
                     end
@@ -726,6 +729,16 @@ function ok = is_nnvnet_valid(nnvnet)
 % matlab2nnv conversion fails inside a try/catch). We need an NN object,
 % not a string sentinel.
     ok = ~isempty(nnvnet) && ~ischar(nnvnet) && ~isstring(nnvnet);
+end
+
+function i_log_cpstar(onnx)
+% A cp-star (probabilistic, conformal) reach produced the accepted verdict -- NOT a sound proof.
+% Logged in EVERY reach branch (single-spec AND both parfor branches) so the per-benchmark -150
+% exposure from a probabilistic verdict is tracked uniformly (previously only the single-spec
+% branch logged it, hiding parfor cp-star verdicts). i_is_probabilistic + i_finalize_reach_options
+% live in their OWN files (same folder) so the routing logic is unit-testable -- see
+% tests/nn/vnncomp/test_run_vnncomp_routing.m.
+    fprintf('VERDICT VIA CP-STAR (probabilistic, not a sound proof): %s\n', onnx);
 end
 
 function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, ub, prop, status, reachOptionsList, needReshape, inputSize)
@@ -1450,39 +1463,19 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         error("ONNX model not supported")
     end
 
-    % Phase 1.5 (TODO_VNNCOMP25_V01): for any category whose first reach
-    % method is "cp-star" (probabilistic, requires GPU on this machine),
-    % prepend sound CPU-only methods so the dispatcher tries them first.
-    % cp-star remains as fallback when the sound methods can't decide.
-    if ~isempty(reachOptionsList) && isfield(reachOptionsList{1}, 'reachMethod') ...
-            && strcmp(reachOptionsList{1}.reachMethod, 'cp-star') ...
-            && is_nnvnet_valid(nnvnet)
-        sound_opts = cell(1,2);
-        o1 = struct(); o1.reachMethod = 'approx-star';
-        sound_opts{1} = o1;
-        o2 = struct(); o2.reachMethod = 'relax-star-area'; o2.relaxFactor = 0.5;
-        sound_opts{2} = o2;
-        reachOptionsList = [sound_opts, reachOptionsList];
-    end
-
-    % Compute-bound categories (large CNNs / NLP / a SAT-encoding) time out under
-    % exact-star -- and even approx-star -- within a realistic per-instance budget.
-    % Lead with fast, looser, but STILL-SOUND over-approximations (zonotope, then
-    % abstract-domain) and DROP exact-star, so they at least produce a sound verdict
-    % instead of timing out; the tighter per-category methods stay as fallbacks.
-    % (Per the timeout-model guidance: never exact-star for these.)
-    slow_cats = ["cifar100","cora","safenlp","sat_relu","tinyimagenet","vggnet"];
-    if any(contains(category, slow_cats)) && is_nnvnet_valid(nnvnet)
-        kept = {};
-        for k = 1:numel(reachOptionsList)
-            if ~strcmp(reachOptionsList{k}.reachMethod, 'exact-star')
-                kept{end+1} = reachOptionsList{k}; %#ok<AGROW>
-            end
-        end
-        zo = struct(); zo.reachMethod = 'approx-zono';
-        ad = struct(); ad.reachMethod = 'abs-dom';
-        reachOptionsList = [{zo, ad}, kept];
-    end
+    % Method-selection POST-PROCESSING. Extracted to a PURE, unit-testable helper so the routing
+    % (which method actually runs per category, and whether a probabilistic method survives) is
+    % guarded by tests instead of being implicit in a 1500-line function. Does, in order:
+    %   (1) Phase-1.5 sound prepend: for a cp-star-led list, prepend {approx-star, relax-star 0.5}
+    %       so the dispatcher tries the SOUND methods first (cp-star stays as a fallback);
+    %   (2) slow_cats (cifar100/cora/safenlp/sat_relu/tinyimagenet/vggnet): drop exact-star and lead
+    %       with fast still-SOUND over-approximations {approx-zono, abs-dom} to avoid timing out;
+    %   (3) cp-star QUARANTINE: gated by env NNV_QUARANTINE_CPSTAR (default OFF -> behavior UNCHANGED).
+    %       When set, strip cp-star entirely so a probabilistic 'unsat' can never be emitted as a
+    %       sound verdict in ANY reach branch (single-spec OR the two parfor branches). Strictly
+    %       sound: removing cp-star can only turn an unsat/unknown into unknown, never a wrong verdict.
+    % See tests/nn/vnncomp/test_run_vnncomp_routing.m for the per-category routing assertions.
+    reachOptionsList = i_finalize_reach_options(reachOptionsList, category, is_nnvnet_valid(nnvnet));
 
     % ---- Per-category PGD/falsification budget (VNNCOMP2026 tuning) ----------------
     % Applied LAST so it is the single source of truth for falsification effort,

--- a/code/nnv/examples/Submission/VNN_COMP2026/test_run_vnncomp_routing.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/test_run_vnncomp_routing.m
@@ -1,0 +1,107 @@
+%% test_run_vnncomp_routing
+% Routing / method-selection regression tests for the VNN-COMP harness (run_vnncomp_instance).
+%
+% WHY THIS EXISTS: a missing test let a real soundness fragility slip -- the harness can fall
+% through to cp-star (Prob_reach = conformal prediction = PROBABILISTIC) and emit its 'unsat' as
+% if it were a sound proof. These tests pin down WHICH reach methods actually run per category
+% (the thing we could not previously tell from a result) and that the NNV_QUARANTINE_CPSTAR gate
+% removes every probabilistic method. They exercise the PURE, extracted routing helpers
+% (i_is_probabilistic, i_finalize_reach_options) directly -- no ONNX import, no GPU, no reach --
+% so they are fast, deterministic, and run anywhere.
+%
+% Run: runtests('test_run_vnncomp_routing')
+%
+% Each section sets its OWN env + path so the sections are order-independent (the script-test
+% framework runs %% sections with independent workspaces; env + path are process-global, so we
+% set them explicitly per section rather than relying on a prior section).
+
+%% i_is_probabilistic identifies ONLY cp-star
+addpath(fileparts(mfilename('fullpath')));
+assert(i_is_probabilistic('cp-star') == true,  'cp-star must be probabilistic');
+assert(i_is_probabilistic('approx-star') == false);
+assert(i_is_probabilistic('relax-star-area') == false);
+assert(i_is_probabilistic('exact-star') == false);
+assert(i_is_probabilistic('approx-zono') == false);
+assert(i_is_probabilistic('abs-dom') == false);
+
+%% cifar100 effective ladder = 4 SOUND rungs THEN cp-star LAST (default OFF, valid net)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','');                       % default behavior
+L = i_finalize_reach_options(local_mkopts({'cp-star'}), 'cifar100_2024', true);
+names = cellfun(@(o) o.reachMethod, L, 'uni', 0);
+assert(isequal(names, {'approx-zono','abs-dom','approx-star','relax-star-area','cp-star'}), ...
+    ['cifar100 ladder wrong: ' strjoin(names, ',')]);
+assert(i_is_probabilistic(names{end}) == true, 'cp-star must be the LAST (last-resort) rung');
+assert(all(cellfun(@(n) ~i_is_probabilistic(n), names(1:end-1))), 'every leading rung must be SOUND');
+
+%% QUARANTINE strips cp-star -> NO probabilistic method survives for cifar100 (sound rungs kept)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','1');
+L = i_finalize_reach_options(local_mkopts({'cp-star'}), 'cifar100_2024', true);
+names = cellfun(@(o) o.reachMethod, L, 'uni', 0);
+assert(~any(cellfun(@i_is_probabilistic, names)), 'quarantine must remove cp-star');
+assert(isequal(names, {'approx-zono','abs-dom','approx-star','relax-star-area'}), 'sound rungs must remain');
+setenv('NNV_QUARANTINE_CPSTAR','');
+
+%% ml4acopf-style cp-star-ONLY on an INVALID net is the -150 path; quarantine -> empty (sound)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','');
+Lraw = i_finalize_reach_options(local_mkopts({'cp-star'}), 'ml4acopf', false);   % invalid net -> no prepend
+assert(isequal(cellfun(@(o) o.reachMethod, Lraw, 'uni',0), {'cp-star'}), ...
+    'documents the landmine: cp-star ALONE on an invalid net');
+setenv('NNV_QUARANTINE_CPSTAR','1');
+Lq = i_finalize_reach_options(local_mkopts({'cp-star'}), 'ml4acopf', false);
+assert(isempty(Lq), 'quarantine of a cp-star-only list -> empty -> falsify/SAT-or-unknown only (sound)');
+setenv('NNV_QUARANTINE_CPSTAR','');
+
+%% cersyve trailing cp-star: quarantine removes ONLY cp-star, keeps the two sound rungs
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','1');
+L = i_finalize_reach_options(local_mkopts({'approx-star','relax-star-area','cp-star'}), 'cersyve', true);
+names = cellfun(@(o) o.reachMethod, L, 'uni', 0);
+assert(isequal(names, {'approx-star','relax-star-area'}), 'cersyve: cp-star dropped, sound rungs intact');
+assert(~any(cellfun(@i_is_probabilistic, names)));
+setenv('NNV_QUARANTINE_CPSTAR','');
+
+%% a SOUND-only category (acasxu exact-star) is untouched by every step (incl. quarantine)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','1');                      % even with quarantine on, no cp-star to strip
+L = i_finalize_reach_options(local_mkopts({'exact-star'}), 'acasxu', true);
+assert(isequal(cellfun(@(o) o.reachMethod, L, 'uni',0), {'exact-star'}), 'acasxu must be unchanged');
+setenv('NNV_QUARANTINE_CPSTAR','');
+
+%% slow_cats DROP exact-star and LEAD with zono/abs-dom (timeout guidance), valid net
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','');
+L = i_finalize_reach_options(local_mkopts({'approx-star','exact-star'}), 'safenlp', true);
+names = cellfun(@(o) o.reachMethod, L, 'uni', 0);
+assert(~any(strcmp(names,'exact-star')), 'slow_cats must drop exact-star');
+assert(isequal(names(1:2), {'approx-zono','abs-dom'}), 'slow_cats must lead with zono/abs-dom');
+
+%% INVALID net disables BOTH prepends (matches is_nnvnet_valid gating in the original code)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','');
+L = i_finalize_reach_options(local_mkopts({'cp-star'}), 'cifar100_2024', false);
+assert(isequal(cellfun(@(o) o.reachMethod, L, 'uni',0), {'cp-star'}), 'invalid net -> no prepend');
+
+%% empty input list is returned unchanged (cgan/nn4sys-mscn falsify-only categories)
+addpath(fileparts(mfilename('fullpath')));
+setenv('NNV_QUARANTINE_CPSTAR','1');
+L = i_finalize_reach_options({}, 'cgan2026', true);
+assert(isempty(L), 'empty reachOptionsList stays empty (falsify-only is sound)');
+setenv('NNV_QUARANTINE_CPSTAR','');
+
+%% Summary (trailing deterministic section; avoids the script-test line-number quirk)
+disp('test_run_vnncomp_routing: all routing/method-selection assertions passed');
+
+% ---- local helpers (file-scope; available to every section above) ----
+function L = local_mkopts(methods)
+    % Build a reachOptionsList (1xN cell of structs with a .reachMethod field) from a cellstr of
+    % method names -- the loop lives INSIDE this function (not in a %% section) per the script-test
+    % line-number quirk.
+    L = cell(1, numel(methods));
+    for k = 1:numel(methods)
+        o = struct(); o.reachMethod = methods{k};
+        L{k} = o;
+    end
+end


### PR DESCRIPTION
## Make VNN-COMP method selection observable + unit-tested; add cp-star quarantine gate (default OFF)

### Why
A missing test let a real soundness fragility slip. The harness can fall through to **cp-star**
(`Prob_reach` = conformal prediction = **probabilistic**) and emit its `unsat` as if it were a sound
proof — and from a result you couldn't tell *which* method produced the verdict. An exhaustive routing
audit confirmed the exposure is broader than one category:
- **cifar100 / tinyimagenet** lead with 4 sound rungs (`approx-zono, abs-dom, approx-star, relax-star`)
  but cp-star is the trailing **last-resort**, and it *fires* because those rungs return `unknown` on
  hard instances (the GPU-BaB precheck is the real sound guard, single-spec branch only).
- The two **multi-spec parfor branches** call no precheck and logged no cp-star.
- `ml4acopf` + the matlab2nnv-failure paths of `vggnet/yolo/cgan-transformer/nn4sys-pensieve/linearize`
  are genuinely **cp-star-only** (sentinel net gates off the prepends).

(`verify_specification` only returns 1/2, so there is **no cp-star SAT** — SAT is a separate falsify path.)

### What (default behavior unchanged)
- Extract the two `reachOptionsList` post-passes into a **pure, unit-testable** `i_finalize_reach_options.m`
  (+ `i_is_probabilistic.m` = the single definition of "a method whose unsat is not a sound proof").
- Opt-in **cp-star quarantine**: env `NNV_QUARANTINE_CPSTAR` (**DEFAULT OFF**). When set, cp-star is
  stripped so a probabilistic `unsat` can never be emitted as sound in **any** reach branch. Strictly
  sound (only ever turns unsat → unknown).
- cp-star verdict **label parity**: `VERDICT VIA CP-STAR` now logs in all 3 reach branches (was single-spec only).
- `test_run_vnncomp_routing.m`: **11 deterministic routing tests** (no import/GPU/reach) pinning the
  per-category method order, that cp-star is last for cifar/tiny, that the quarantine removes every
  probabilistic method, and that ml4acopf-style cp-star-only on an invalid net is the −150 path. **11/11 pass on R2026a.**

### Soundness / scope
- **Default OFF ⇒ zero scorecard change.** Next step is to measure cp-star's actual +10 contribution on
  the gold-validated set before deciding whether to flip the default.
- Static-checks clean; routing tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
