### PR TITLE
matlab2nnv: support custom flatten layers (fixes official VGG16 import; cross-validated)

### DIFF
--- a/code/nnv/engine/utils/matlab2nnv.m
+++ b/code/nnv/engine/utils/matlab2nnv.m
@@ -209,6 +209,27 @@ for i=1:n
             || isa(L, 'nnet.onnx.layer.FlattenInto2dLayer') || isa(L, 'nnet.onnx.layer.Flatten3dInto2dLayer')
         Li = FlattenLayer.parse(L);
 
+    % Custom (importer-generated) flatten layer -- the MATLAB ONNX importer emits a per-model
+    % custom Formattable flatten (e.g. vgg16_7.FlattenLayer1000) for the NO-OP Flatten ops ONNX
+    % inserts before each Gemm: the operand is already a flat [N x C] vector, so the flatten is an
+    % identity reshape. (The order-critical conv->FC flatten is a standard nnet.onnx.layer.*Flatten*
+    % handled by the case above.) These custom classes are not in any isa() map, so they fall to the
+    % catch-all and error "Unsupported Class of Layer" -- which blocked the official VNN-COMP
+    % vgg16-7.onnx import. Map them to NNV's FlattenLayer (identity on already-flat input). The
+    % restriction to non-'nnet.' classes leaves the standard-layer handling and the placeholder
+    % flatten path below untouched. SOUNDNESS: validate a new architecture with a forward cross-check
+    % (NN.evaluate vs dlnetwork.predict) before trusting verdicts -- a custom flatten that is NOT a
+    % no-op would change element order; the cross-check catches that.
+    elseif contains(class(L), 'Flatten') && ~startsWith(class(L), 'nnet.')
+        Li = FlattenLayer(L.Name, L.NumInputs, L.NumOutputs, L.InputNames, L.OutputNames);
+        % NNV FlattenLayer.evaluate/reach switch on .Type, so it must be one of the KNOWN types,
+        % not the custom class string (else "Unknown type of flatten layer"). These custom layers
+        % are identity reshapes on an already-flat [N x C] operand (the layer's own predict does
+        % permute[2 1] -> flatten -> permute[2 1] = identity on 2D), so the straight-reshape
+        % 'nnet.cnn.layer.FlattenLayer' behavior (no permute -> preserves element order) is the
+        % correct, order-safe mapping. (Validated for vgg16-7 by NN.evaluate == dlnetwork.predict.)
+        Li.Type = 'nnet.cnn.layer.FlattenLayer';
+
     % Sigmoid Layer (also referred to as logsig)
     elseif isa(L, 'nnet.keras.layer.SigmoidLayer') || isa(L, 'nnet.onnx.layer.SigmoidLayer') || isa(L, 'nnet.cnn.layer.SigmoidLayer')
         Li = SigmoidLayer.parse(L);

--- a/code/nnv/tests/nn/test_vgg_custom_flatten_import.m
+++ b/code/nnv/tests/nn/test_vgg_custom_flatten_import.m
@@ -1,0 +1,56 @@
+function tests = test_vgg_custom_flatten_import
+% Regression test for matlab2nnv support of importer-generated CUSTOM flatten layers.
+%
+% The MATLAB ONNX importer emits per-model custom Formattable flatten layers (e.g.
+% vgg16_7.FlattenLayer1000) for the no-op Flatten ops ONNX inserts before each Gemm. matlab2nnv
+% had no mapping for these -> "Unsupported Class of Layer", which blocked the official VNN-COMP
+% vgg16-7.onnx. matlab2nnv now maps custom (non-'nnet.') flatten classes to NNV's FlattenLayer
+% (identity on already-flat input). This test imports the official VGG16, converts it, and
+% CROSS-VALIDATES that NN.evaluate matches the imported dlnetwork's predict (translation
+% correctness) -- a custom flatten that was NOT a true no-op would change element order and fail.
+%
+% Requires vgg16-7.onnx (553 MB, not in the repo): set env NNV_VGG_ONNX, or it is auto-detected at
+% the lambda-box benchmark path. The test SKIPS (assumeTrue) when the onnx is unavailable, so it is
+% a no-op in environments without the model.
+%
+% Run: runtests('test_vgg_custom_flatten_import')
+    tests = functiontests(localfunctions);
+end
+
+function onnx = i_locate_vgg_onnx()
+    onnx = getenv('NNV_VGG_ONNX');
+    if ~isempty(onnx) && isfile(onnx), return; end
+    cands = {
+        '/home/johnsott/vsc_nnv-2026/vnncomp2026_benchmarks/benchmarks/vggnet16_2022/2.0/onnx/vgg16-7.onnx'
+        '/home/johnsott/vsc_nnv-2026/vnncomp2026_benchmarks/benchmarks/vggnet16_2022/1.0/onnx/vgg16-7.onnx'
+        };
+    onnx = '';
+    for k = 1:numel(cands)
+        if isfile(cands{k}), onnx = cands{k}; return; end
+    end
+end
+
+function test_matlab2nnv_imports_custom_flatten(tc)
+    onnx = i_locate_vgg_onnx();
+    tc.assumeTrue(~isempty(onnx) && isfile(onnx), ...
+        'vgg16-7.onnx not available -> skip (set NNV_VGG_ONNX to the official onnx path)');
+
+    net = importNetworkFromONNX(onnx, "InputDataFormats","BCSS", "OutputDataFormats","BC");
+
+    % matlab2nnv must NOT throw "Unsupported Class of Layer" on the custom flatten layers.
+    nnvnet = matlab2nnv(net);
+    tc.verifyClass(nnvnet, 'NN');
+
+    % TRANSLATION CORRECTNESS: NN.evaluate must match the imported dlnetwork's predict. A custom
+    % flatten mapped with the wrong element order would diverge here.
+    x = rand([224 224 3], 'single');
+    yref = predict(net, dlarray(x, 'SSCB'));
+    yref = double(gather(extractdata(yref))); yref = yref(:);
+    ynnv = double(nnvnet.evaluate(double(x))); ynnv = ynnv(:);
+
+    tc.verifyEqual(numel(ynnv), numel(yref), 'output size mismatch');
+    tc.verifyLessThan(max(abs(ynnv - yref)), 1e-2, ...
+        'NN.evaluate must match dlnetwork.predict (custom-flatten translation correctness)');
+    [~, amr] = max(yref); [~, amn] = max(ynnv);
+    tc.verifyEqual(amn, amr, 'argmax must agree between NN.evaluate and dlnetwork.predict');
+end


### PR DESCRIPTION
## matlab2nnv: support importer-generated custom flatten layers (fixes official VGG16 import)

### Problem
MATLAB's ONNX importer emits per-model **custom Formattable flatten layers** (e.g.
`vgg16_7.FlattenLayer1000/1001`) for the no-op `Flatten` ops ONNX inserts before each `Gemm` — the
operand is already a flat `[N x C]` vector, so the flatten is an identity reshape. `matlab2nnv` had no
class mapping for these, so they hit the catch-all → **"Unsupported Class of Layer"**, blocking import
of the official VNN-COMP `vggnet16_2022` net (`vgg16-7.onnx`). (The order-critical conv→FC flatten is a
standard `nnet.onnx.layer.FlattenInto2dLayer`, already handled.)

### Fix
Map custom (non-`nnet.`) flatten classes → NNV `FlattenLayer` with the straight-reshape
`nnet.cnn.layer.FlattenLayer` Type (no permute → preserves element order = identity on already-flat
input). The `non-'nnet.'` restriction leaves the standard-layer handling and the placeholder-flatten
path untouched.

### Validation (official `vgg16-7.onnx`, lambda box R2026a)
- `matlab2nnv` now converts the full VGG16 (was: error).
- **Translation correctness:** `NN.evaluate` matches the imported `dlnetwork.predict` to
  **maxAbsDiff = 3.8e-6** (argmax + margin identical).
- **End-to-end sound verification:** official spec0 (1-pixel L∞ eps 1e-5) → **UNSAT/robust via approx-star
  ImageStar in 18.3 s**, exercising the maxpool path on CPU.

### Test
`tests/nn/test_vgg_custom_flatten_import.m` — imports the official VGG16, asserts `matlab2nnv` succeeds
and `NN.evaluate` matches `dlnetwork.predict` (the translation-correctness guard). Skips (`assumeTrue`)
when `vgg16-7.onnx` is unavailable (553 MB, not in the repo; set `NNV_VGG_ONNX`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
