### PR TITLE
VNN-COMP: sound manifest routing (ml4acopf, pensieve) + falsification crash guard + acasxu approx-first ladder

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -32,16 +32,16 @@ gen_manifest() {
     fi
 }
 case "$2" in
-    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*|*vit*|*test*|*linearize*)
+    *lsnc_relu*|*traffic_signs*|*cgan*|*soundnessbench*|*vit*|*test*|*linearize*|*ml4acopf*)
         gen_manifest "$3"
         ;;
     *nn4sys*)
-        # Only the mscn models route via the manifest (lindex/pensieve use MATLAB's
-        # importNetworkFromONNX). mscn_2048d_dual.onnx is corrupt upstream and abstains
-        # to unknown in run_vnncomp_instance, so don't waste time trying to convert it.
+        # mscn + pensieve route via the manifest (lindex uses MATLAB's importNetworkFromONNX).
+        # mscn_2048d_dual.onnx is corrupt upstream and abstains to unknown in run_vnncomp_instance,
+        # so don't waste time trying to convert it.
         case "$3" in
             *mscn_2048d_dual*) : ;;
-            *mscn*) gen_manifest "$3" ;;
+            *mscn*|*pensieve*) gen_manifest "$3" ;;
         esac
         ;;
 esac

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1245,15 +1245,25 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         reachOptionsList{2} = reachOptions;
 
     elseif contains(category, "ml4acopf")
-        % ml4acopf: matlab2nnv cannot soundly convert this ACOPF net, so there is no sound reach
-        % path. The old code set reachOptionsList = {cp-star} -- a PROBABILISTIC reach whose 'unsat'
-        % is NOT a proof (a -150 exposure on a general benchmark). Restrict to FALSIFICATION-ONLY
-        % (reachOptionsList = {}), exactly like vit / nn4sys-mscn: PGD can still find SAT witnesses
-        % (replayed through onnxruntime before emission), and a non-falsified instance returns a
-        % sound 'unknown'. No probabilistic 'unsat' can ever be emitted.
-        net = importNetworkFromONNX(onnx, "InputDataFormats","BC", "OutputDataFormats","BC");
-        nnvnet = "";
-        reachOptionsList = {};
+        % ml4acopf: matlab2nnv cannot parse the ACOPF net (custom fused Slice_To_MatMul/Mul/Transpose +
+        % Gather_To_Sub). Route through the Python importer manifest (onnx2nnv.py lowers those static
+        % ops); the net's nonlinear ElementwiseProduct layers ARE soundly OVER-APPROXIMATED by
+        % approx-star (validated: approx-star reaches in ~8s with no refusal), so run the SOUND
+        % approx-star reach -- an upgrade from the prior falsification-only/cp-star (cp-star was a -150
+        % exposure). PGD still provides SAT. Robust: if the manifest is unavailable, fall back to
+        % FALSIFICATION-ONLY (sat-or-unknown), never cp-star. Manifest built untimed at prepare
+        % (prepare_instance.sh gen_manifest *ml4acopf*).
+        try
+            nnvnet = load_manifest_net(onnx);
+            net = nnvnet;   % falsify_single dispatches NN.evaluate for NNV nets
+            inputSize = nnvnet.Layers{1}.InputSize;
+            reachOptions = struct; reachOptions.reachMethod = 'approx-star';
+            reachOptionsList{1} = reachOptions;
+        catch
+            net = importNetworkFromONNX(onnx, "InputDataFormats","BC", "OutputDataFormats","BC");
+            nnvnet = "";
+            reachOptionsList = {};
+        end
 
     elseif contains(category, "nn4sys")
         if contains(onnx, "mscn")
@@ -1277,27 +1287,37 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             reachOptions.reachMethod = 'approx-star'; % default parameters
             reachOptionsList{1} = reachOptions;
         else
-            net = importNetworkFromONNX(onnx);
-            if contains(onnx, "pensieve_big_parallel")
-                inputSize = [12,8];
-                inputFormat = "UU";
-                X = dlarray(rand(12,8), inputFormat);
-            elseif contains(onnx, "pensieve_small_parallel")
-                inputSize = [12,8];
-                inputFormat = "UU";
-                X = dlarray(rand(12,8), inputFormat);
-                needReshape = 1;
-            else
-                inputSize = [1,6,8];
-                inputFormat = "UUU";
-                X = dlarray(rand(1,6,8), inputFormat);
+            % pensieve: matlab2nnv cannot parse it (custom Reshape_To_GemmLayer + a generic
+            % nnet InputLayer). Route through the Python importer manifest -> the net is FC/Relu/
+            % Reshape/Concat only -> SOUND approx-star (validated: approx-star -> unsat in ~1.6s),
+            % an upgrade from the prior probabilistic cp-star. PGD provides SAT. Robust: if the
+            % manifest is unavailable, fall back to FALSIFICATION-ONLY (sat-or-unknown), never cp-star.
+            try
+                nnvnet = load_manifest_net(onnx);
+                net = nnvnet;
+                inputSize = nnvnet.Layers{1}.InputSize;
+                reachOptions = struct; reachOptions.reachMethod = 'approx-star';
+                reachOptionsList{1} = reachOptions;
+            catch
+                net = importNetworkFromONNX(onnx);
+                if contains(onnx, "pensieve_big_parallel")
+                    inputSize = [12,8];
+                    inputFormat = "UU";
+                    X = dlarray(rand(12,8), inputFormat);
+                elseif contains(onnx, "pensieve_small_parallel")
+                    inputSize = [12,8];
+                    inputFormat = "UU";
+                    X = dlarray(rand(12,8), inputFormat);
+                    needReshape = 1;
+                else
+                    inputSize = [1,6,8];
+                    inputFormat = "UUU";
+                    X = dlarray(rand(1,6,8), inputFormat);
+                end
+                net = initialize(net, X);
+                nnvnet = "";
+                reachOptionsList = {};   % falsify-only (was cp-star -- probabilistic)
             end
-            net = initialize(net, X);
-            nnvnet = "";
-            reachOptions = struct;
-            reachOptions.inputFormat = inputFormat;
-            reachOptions.reachMethod = 'cp-star'; % default parameters
-            reachOptionsList{1} = reachOptions;
         end
         % Somehow, some of these networks have discrepancies  (all sat (invalid))
         


### PR DESCRIPTION
Four sound changes to run_vnncomp_instance.m, validated against an overnight 3-sweep capability run (628 instance-runs, 0 wrong verdicts):

1. **ml4acopf -> manifest + approx-star** (drop cp-star). matlab2nnv can't parse the ACOPF net; the Python importer loads it and approx-star soundly over-approximates the nonlinear ElementwiseProduct. Removes a probabilistic cp-star (-150 risk). *Validated:* CPU sweep 2 unsat, cp-star=0.
2. **nn4sys-pensieve -> manifest + approx-star** (drop cp-star). *Validated:* CPU sweep 6 unsat, 0 crash.
3. **Falsification guard:** wrap the random-sampling `create_random_examples` call (the PGD rung was already guarded). A `reshape(xRand,[inputSize nR])` mismatch (`prod(inputSize)!=numel(lb)`) previously crashed the whole instance to no-output. Now it skips random falsification and lets the reach verdict / `unknown` stand. Strictly sound (falsification only ever ADDS a sound SAT). *Validated:* fixed BOTH pensieve_*_parallel and relusplitter split-variant crashes; CRASH=0 across 151 re-sweep runs.
4. **acasxu: approx-star FIRST for all props** (was single-core exact-star only for prop_1/2/5-10; prop_3/4 already did this). Sound ladder improvement — approx-star settles robust props fast, exact-star stays the complete closer. NOTE: this is *not* a timeout fix on its own — hard props still fall to single-core exact-star, which is the real acasxu bottleneck (separate work).

Sound-or-unknown discipline preserved throughout. Part of the all-34-routable effort (see status repo BENCHMARK_ROUTING_PLAN + OVERNIGHT_SUMMARY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)