### PR TITLE
VNN-COMP: fix execute.py 2025/2026 harness shadowing (CRITICAL) + restore falsify guard + sound cifar GPU-BaB env

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/execute.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/execute.py
@@ -62,7 +62,16 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
         here = os.path.dirname(os.path.abspath(__file__))
         nnv_root = os.path.abspath(os.path.join(here, '..', '..', '..'))
     eng.addpath(eng.genpath(nnv_root))
-    print("Paths added (NNV root: %s)" % nnv_root)
+    # CRITICAL: genpath(nnv_root) adds BOTH this submission folder (VNN_COMP2026) AND the frozen
+    # sibling VNN_COMP2025. genpath lists them alphabetically (2025 before 2026) and addpath prepends,
+    # so VNN_COMP2025/run_vnncomp_instance.m would SHADOW the 2026 one -> the wrong (frozen 2025)
+    # harness runs (observed: "VNN_COMP2025/run_vnncomp_instance.m ... ONNX model not supported").
+    # os.getcwd() above does NOT fix this (run_instance.sh does not cd into the 2026 dir). addpath
+    # prepends, so adding THIS file's own directory LAST puts the 2026 submission at the top of the
+    # path and guarantees run_vnncomp_instance + its local helpers resolve to 2026.
+    here = os.path.dirname(os.path.abspath(__file__))
+    eng.addpath(here)
+    print("Paths added (NNV root: %s; prioritized submission dir: %s)" % (nnv_root, here))
     ## eng.addpath(eng.genpath('/root/Documents/MATLAB/SupportPackages/R2024a')) # This is where the support packages get installed from mpm
 
     status = 2 #initialize with an 'Unknown' status

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
@@ -22,5 +22,17 @@ if [ ! -f "$EXECUTE" ]; then
     echo "ERROR: execute.py not found at $EXECUTE"; exit 1
 fi
 
+# Conv GPU-BaB tuning (FIX A1/A3) -- exported into the MATLAB process via execute.py.
+# A1: default the slow UNSOUND FP32 GPU screen OFF so the cheap SOUND FP64-CPU confirm runs DIRECTLY
+#     (on hard cifar/tinyimagenet/challenging instances the screen never returns 'robust' in budget,
+#     starving the confirm that certifies in <31 nodes). The emit still comes from the FP64 double
+#     pass + argmax-spec + orientation guards -> sound; this only changes WHICH sound path runs first.
+# A3: widen the conv BaB frontier to fight the launch-bound tail (default 32). A frontier/node cap can
+#     only yield 'unknown', never a wrong verdict. Both vars affect ONLY the conv precheck path;
+#     non-conv categories ignore them. (NNV_SOUND_FP32_TIGHT / FIX A2 intentionally NOT set yet -- it
+#     needs the owed known-SAT conv soundness test first.)
+export NNV_CONV_GPU_SCREEN=0
+export NNV_CONV_FRONTIER=256
+
 echo "Running ${TOOL_NAME} on '$CATEGORY' (onnx='$ONNX_FILE', vnnlib='$VNNLIB_FILE', timeout=${TIMEOUT}s)"
 python3 "$EXECUTE" 'run_instance' "$CATEGORY" "$ONNX_FILE" "$VNNLIB_FILE" "$TIMEOUT" "$RESULTS_FILE"

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -781,7 +781,11 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     if nargin < 8 || isempty(needReshape), needReshape = 0; end
     if nargin < 9, inputSize = []; end
     isFC   = contains(category,"safenlp") || contains(category,"sat_relu") || contains(category,"relusplitter");
-    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet");
+    % challenging_certified_training is a cifar10 conv net; it was missing here so the GPU-BaB
+    % precheck early-returned (line below) -> Star dispatcher -> guaranteed timeout. Adding it routes
+    % challenging through the same sound conv GPU-BaB path as cifar100 (orientation guard skips to Star
+    % if the remap is wrong, so it is sound either way).
+    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet") || contains(category,"challenging");
     % General-halfspace control benchmarks (NOT argmax): prove the output avoids every unsafe
     % disjunct in prop.Hg. gpu_bab_halfspace_verify is sound-or-skip (FP64 CROWN + orientation
     % guard), so it can only ADD a sound unsat. Routed separately below (own predicate).
@@ -980,19 +984,22 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         % acasxu: onnx to nnv
         net = importNetworkFromONNX(onnx, "InputDataFormats","BCSS");
         nnvnet = matlab2nnv(net);
-        if ~contains(vnnlib, "prop_3.") && ~contains(vnnlib, "prop_4.")
-            reachOptions.reachMethod = 'exact-star';
-            reachOptions.numCores = 1;  % Phase 1.3: avoid nested-parpool errors when called inside parfeval workers
-            reachOptionsList{1} = reachOptions;
-            nRand = 500;
-        else
-            reachOptions = struct;
-            reachOptions.reachMethod = 'approx-star'; % default parameters
-            reachOptionsList{1} = reachOptions;
-            reachOptions.reachMethod = 'exact-star';
-            reachOptions.numCores = 1;  % Phase 1.3: avoid nested-parpool errors when called inside parfeval workers
-            reachOptionsList{2} = reachOptions;
-        end
+        % SOUND-FIRST ladder for ALL props: fast approx-star (tightest non-exact; ~1-2s on these
+        % tiny 5->5 nets, settles the robust/UNSAT props) then MULTI-CORE exact-star as the complete
+        % closer, run only if approx returns unknown. Fixes two regressions: (1) prop_1/2/5-10
+        % previously ran exact-star ONLY (no approx rung) -> timed out the easy props; (2) numCores
+        % was pinned to 1 -> single-core exact-star blew past the 116s budget on the hard props.
+        % Restored to feature('numcores') (the 2024 strong config). SAFE: NN.start_pool returns early
+        % inside a parfeval worker (NN.m:1373 getCurrentTask) and the official harness runs ONE
+        % instance per process, so no nested parpool. approx-star is sound (no-intersection = proof);
+        % no cp-star; PGD (nRand) still finds SAT. (relax-star rungs omitted: relax is LOOSER than
+        % approx, so on these tiny nets it can never decide what approx couldn't.)
+        reachOptions = struct; reachOptions.reachMethod = 'approx-star';
+        reachOptionsList{1} = reachOptions;
+        reachOptions = struct; reachOptions.reachMethod = 'exact-star';
+        reachOptions.numCores = feature('numcores');
+        reachOptionsList{2} = reachOptions;
+        nRand = 500;
 
     elseif contains(category, "adaptive_cruise")
         % adaptive_cruise_control_non_linear_2026: a pure FFNN (8x Gemm + 5x Relu,

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1806,7 +1806,17 @@ function counterEx = falsify_single(net, lb, ub, inputSize, nRand, Hs, needResha
             % fall through to random sampling
         end
     end
-    xRand = create_random_examples(net, lb, ub, nRand, inputSize, needReshape, inputFormat);
+    try
+        xRand = create_random_examples(net, lb, ub, nRand, inputSize, needReshape, inputFormat);
+    catch
+        % Random-sampling falsification unavailable for this instance -- e.g. inputSize/vnnlib
+        % element-count mismatch makes the reshape in create_random_examples throw ("Number of
+        % elements must not change"), as seen on nn4sys pensieve_*_parallel under the manifest
+        % route. Skip it: sound (no counterexample found -> the reach verdict / 'unknown' stands;
+        % falsification can only ever ADD a sound SAT, never decide UNSAT), and it stops one bad
+        % input shape from crashing the whole instance to NO output.
+        return;
+    end
     s = size(xRand);
     n = length(s);
     %  look for counterexamples

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -781,11 +781,11 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     if nargin < 8 || isempty(needReshape), needReshape = 0; end
     if nargin < 9, inputSize = []; end
     isFC   = contains(category,"safenlp") || contains(category,"sat_relu") || contains(category,"relusplitter");
-    % challenging_certified_training is a cifar10 conv net; it was missing here so the GPU-BaB
-    % precheck early-returned (line below) -> Star dispatcher -> guaranteed timeout. Adding it routes
-    % challenging through the same sound conv GPU-BaB path as cifar100 (orientation guard skips to Star
-    % if the remap is wrong, so it is sound either way).
-    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet") || contains(category,"challenging");
+    % NOTE: challenging_certified is deliberately NOT added here. Routing it to the conv GPU-BaB
+    % precheck CRASHED MATLAB on the box (hard std::exception "MATLAB process cannot be terminated" --
+    % the orientation guard did NOT catch it, so it is NOT a safe sound-or-skip). Needs the conv
+    % GPU-BaB path hardened against challenging's net before it can be enabled. Left on Star for now.
+    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet");
     % General-halfspace control benchmarks (NOT argmax): prove the output avoids every unsafe
     % disjunct in prop.Hg. gpu_bab_halfspace_verify is sound-or-skip (FP64 CROWN + orientation
     % guard), so it can only ADD a sound unsat. Routed separately below (own predicate).
@@ -981,7 +981,13 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
                          'max_time',15, 'seed',0);
 
     if contains(category, "acasxu")
-        % acasxu: onnx to nnv
+        % acasxu: MUST import as BCSS -- BC (FeatureInputLayer) makes matlab2nnv fail with
+        % "Unsupported Class of Layer" (tested on the box). BCSS yields an ImageInputLayer that
+        % matlab2nnv converts, but create_input_set then builds an ImageStar whose per-layer spatial
+        % overhead makes exact-star slow on these props. NOTE: acasxu is NOT a cheap win -- BCSS exact
+        % times out on the hard props even multi-core, and approx-star (DeepZ-level) is too loose to
+        % decide them. The approx-first + multi-core ladder below is SOUND and helps any approx-
+        % decidable prop, but the CROWN-needing props need a tighter method (separate, deeper work).
         net = importNetworkFromONNX(onnx, "InputDataFormats","BCSS");
         nnvnet = matlab2nnv(net);
         % SOUND-FIRST ladder for ALL props: fast approx-star (tightest non-exact; ~1-2s on these


### PR DESCRIPTION
Three sound, box-validated changes (one critical), from the P0 round:

1. **CRITICAL — execute.py harness shadowing.** `execute.py` did `addpath(genpath(nnv_root))`, which adds BOTH the frozen `VNN_COMP2025` and `VNN_COMP2026`; genpath lists 2025 first and addpath prepends, so `run_vnncomp_instance` resolved to the **frozen 2025 harness** (observed on box: `VNN_COMP2025/run_vnncomp_instance.m ... ONNX model not supported` on challenging; cp-star Prob_reach on tinyimagenet/cifar). The real `run_instance.sh`→`execute.py` path was running the wrong harness. Fix: addpath THIS submission dir LAST so 2026 wins. (sweep_inst/`matlab -batch` was unaffected — it addpath'd 2026 explicitly.)

2. **Restore the falsification guard** (was committed but never pushed before PR #393, so it never merged). Wraps the random-sampling `create_random_examples` call so a reshape mismatch can't crash the whole instance → degrades to a sound verdict. Validated: fixed pensieve_*_parallel + relusplitter crashes, CRASH=0 across 151 re-sweep runs.

3. **cifar conv GPU-BaB env (run_instance.sh): `NNV_CONV_GPU_SCREEN=0` + `NNV_CONV_FRONTIER=256`.** The default slow UNSOUND FP32 screen gated the cheap SOUND FP64-CPU confirm; disabling it lets the sound precheck run. **Box-validated via the fixed 2026 path: cifar100_resnet_medium → SOUND unsat in 315s** (≈25% decide rate; was previously a 2025 cp-star probabilistic verdict). Emit still from FP64 + argmax + orientation guards.

Also: acasxu kept on a sound approx-first + multi-core exact-star ladder (BCSS import required — BC breaks matlab2nnv). Honest note: acasxu's hard props still time out (ImageStar exact-star + DeepZ-loose approx) — NOT a cheap win, deeper tightness work needed. cifar FIX B (challenging→GPU-BaB) was tried and REVERTED (crashed MATLAB).

Sound-or-skip discipline preserved; no cp-star introduced. 🤖 Generated with [Claude Code](https://claude.com/claude-code)