### PR TITLE
gpu_bab: conv memory handling (eye(nk) seed chunking + first-layer IBP) + batched maxpool + dropout placeholders

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -181,7 +181,7 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 preU{k} = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
             elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add','concat'}))
                 error('gpu_bab_crown_spec_dag:op', ...
-                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/add/concat/product only).', tk);
+                    'Unsupported op "%s" (affine/conv/normaffine/avgpool/relu/maxpool/add/concat/product only).', tk);
             end
         end
     end
@@ -520,6 +520,10 @@ function [A2, d] = i_maxpool_backward_batched(A, d, op, l, u, precision)
 %          (an i_maxpool_relax 'decided' miss only loosens -- never unsound).
 % A: nSpec x n_out x B ; l,u: n_in x B ; d: nSpec x B. The window relaxation differs per node
 % column b, so build per-b selection and scatter (overlapping windows accumulate in the matmul).
+% PERF (known, sound): this gathers to host + forms CPU sparse [n_out x n_in] per b, so for large
+% HWC maxpools / large B it dominates and negates batching. The window->flat index maps are static
+% per op, so a GPU-resident scatter (precompute maps once, argmax/umax on-device, no dense matrices)
+% is the planned speedup -- tracked as future work; the current path is correct, just CPU-bound.
     nSpec = size(A,1); B = size(A,3);
     n_in = prod(op.inShape); n_out = prod(op.outShape);
     A2 = zeros(nSpec, n_in, B, 'like', A);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -128,6 +128,9 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                     cu{k+1} = (sf.*ub).*pos + (sf.*lb).*(~pos) + tf;
                 case 'avgpool'
                     [cl{k+1}, cu{k+1}] = i_avgpool_ibp(op, lb, ub, precision);
+                case 'maxpool'
+                    preL{k} = lb; preU{k} = ub;            % window input bounds for the backward relaxation
+                    [cl{k+1}, cu{k+1}] = i_maxpool_ibp(op, lb, ub, precision);
                 case 'relu'
                     if ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                         fx = fixings{k};
@@ -168,6 +171,12 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 % bilinear: reuse the root stacked input bounds (broadcast). No per-node clamp --
                 % products carry no ReLU fixings; root bounds hold over the full box >= node region
                 % (sound, possibly looser than re-concretizing). Backward reads preL{k}=[xb;yb].
+                preL{k} = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
+                preU{k} = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
+            elseif strcmp(tk, 'maxpool')
+                % maxpool: reuse the root window input bounds (broadcast) for the backward relaxation.
+                % No per-node ReLU clamp (maxpool carries no fixings); root bounds hold over the full
+                % box >= the node region (sound, possibly looser). Backward reads preL{k}/preU{k}.
                 preL{k} = repmat(cast(rootBounds.preL{k}, 'like', tmpl), 1, B);
                 preU{k} = repmat(cast(rootBounds.preU{k}, 'like', tmpl), 1, B);
             elseif ~any(strcmp(tk, {'affine','conv','normaffine','avgpool','add','concat'}))
@@ -333,6 +342,15 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 if doErr   % A is now on the INPUT; no bias -> no d-add
                     derr = derr + i_dterm_sd(A, reshape(double(vin), [], 1, 1), prod(op.pool), nSpec, B);
                 end
+            case 'maxpool'
+                % Sound CROWN LOWER relaxation through maxpool (ported batched from gpu_bab_crown_tight
+                % i_maxpool_backward; spec_dag is lower-direction only). soundFP32 emit is NOT supported
+                % for maxpool -> refuse (the trust-FP32 screen runs soundFP32=false, so it is unaffected).
+                if doErr
+                    error('gpu_bab_crown_spec_dag:maxpoolSoundFP32', ...
+                        'maxpool sound-FP32 emit not supported -- refused (use the FP64 confirm).');
+                end
+                [A, d] = i_maxpool_backward_batched(A, d, op, preL{k}, preU{k}, precision);
             case 'relu'
                 l = preL{k}; u = preU{k};                  % dim x B
                 ak = []; if ~isempty(alphaCell) && numel(alphaCell) >= k, ak = alphaCell{k}; end
@@ -468,6 +486,82 @@ function [A2, d2] = i_avgpool_backward(A, d, op, precision)
     Ain(1:hi,1:wi,:,:) = Aup(1:hi,1:wi,:,:);
     A2 = permute(reshape(Ain, [prod(ish) nSpec B]), [2 1 3]);
     d2 = d;
+end
+
+function [olb, oub] = i_maxpool_ibp(op, lb, ub, precision)
+% Interval maxpool (batched): max over each window is monotone, so the exact interval is the
+% maxpool of the bounds. lb/ub prod(inShape)-by-B.
+    ish = op.inShape; osh = op.outShape; B = size(lb,2);
+    L4 = reshape(cast(lb,precision), [ish(1) ish(2) ish(3) B]);
+    U4 = reshape(cast(ub,precision), [ish(1) ish(2) ish(3) B]);
+    olb = reshape(i_pool_max(L4, op), [prod(osh) B]);
+    oub = reshape(i_pool_max(U4, op), [prod(osh) B]);
+end
+
+function Y = i_pool_max(X, op)
+% Max pool of X [H W C B] (stride/overlap allowed, unpadded -- enforced at extraction).
+    osh = op.outShape; kh = op.pool(1); kw = op.pool(2); B = size(X,4);
+    Y = -inf([osh(1) osh(2) osh(3) B], 'like', X);
+    for oh = 1:osh(1)
+        for ow = 1:osh(2)
+            rh = (oh-1)*op.stride(1) + (1:kh); rw = (ow-1)*op.stride(2) + (1:kw);
+            Y(oh,ow,:,:) = max(max(X(rh,rw,:,:),[],1),[],2);
+        end
+    end
+end
+
+function [A2, d] = i_maxpool_backward_batched(A, d, op, l, u, precision)
+% Batched (over the B node columns) sound CROWN LOWER backward through maxpool, ported from the
+% serial gpu_bab_crown_tight i_maxpool_backward (LOWER direction only -- spec_dag computes lower
+% margins). For each output cell o = max over its window:
+%   lower  y_o >= x_m       (m = argmax of the window's LOWER bounds; max >= any element)
+%   upper  y_o <= x_m       if m DOMINATES (l_m >= u_i for every other window i) -- exact
+%          y_o <= max_i u_i otherwise (a constant; sound). The constant upper is robust-by-default
+%          (an i_maxpool_relax 'decided' miss only loosens -- never unsound).
+% A: nSpec x n_out x B ; l,u: n_in x B ; d: nSpec x B. The window relaxation differs per node
+% column b, so build per-b selection and scatter (overlapping windows accumulate in the matmul).
+    nSpec = size(A,1); B = size(A,3);
+    n_in = prod(op.inShape); n_out = prod(op.outShape);
+    A2 = zeros(nSpec, n_in, B, 'like', A);
+    for b = 1:B
+        [mIdx, decided, umax] = i_maxpool_relax(op, gather(l(:,b)), gather(u(:,b)));
+        Lmat  = sparse(1:n_out, mIdx, 1, n_out, n_in);             % y_o >= x_{m_o}
+        dec   = find(decided);
+        Umat  = sparse(dec, mIdx(dec), 1, n_out, n_in);            % decided: y_o <= x_{m_o}
+        Ubias = zeros(n_out, 1); Ubias(~decided) = umax(~decided); % undecided: y_o <= umax
+        Ab = double(gather(A(:,:,b))); Apos = max(Ab,0); Aneg = min(Ab,0);
+        A2(:,:,b) = cast(Apos*Lmat + Aneg*Umat, precision);
+        d(:,b)    = d(:,b) + cast(Aneg*Ubias, precision);
+    end
+end
+
+function [mIdx, decided, umax] = i_maxpool_relax(op, l, u)
+% Per output cell: m = flat input index of the window's argmax-LOWER element; decided = that
+% element dominates (its lower bound >= every other window upper => max is exactly it); umax =
+% max window upper. Unpadded windows (enforced at extraction); overlap allowed. (Verbatim port
+% of gpu_bab_crown_tight i_maxpool_relax.)
+    ish = op.inShape; osh = op.outShape;
+    H = ish(1); W = ish(2); C = ish(3); Ho = osh(1); Wo = osh(2);
+    kh = op.pool(1); kw = op.pool(2); sh = op.stride(1); sw = op.stride(2);
+    L = reshape(double(l), [H W C]); U = reshape(double(u), [H W C]);
+    n_out = prod(osh);
+    mIdx = ones(n_out, 1); decided = false(n_out, 1); umax = zeros(n_out, 1);
+    for c = 1:C
+        for ow = 1:Wo
+            rw = (ow-1)*sw + (1:kw);
+            for oh = 1:Ho
+                rh = (oh-1)*sh + (1:kh);
+                lw = L(rh, rw, c); uw = U(rh, rw, c);
+                [maxl, p] = max(lw(:));
+                [pr, pc] = ind2sub([kh kw], p);
+                o = sub2ind([Ho Wo C], oh, ow, c);
+                mIdx(o) = sub2ind([H W C], rh(pr), rw(pc), c);
+                uw2 = uw; uw2(p) = -inf;
+                decided(o) = maxl >= max(uw2(:));               % argmax-lower dominates others
+                umax(o) = max(uw(:));
+            end
+        end
+    end
 end
 
 function v = i_bcast_flat(x, sh, precision)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -63,6 +63,21 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
     % a non-sound 'single' result must never be trusted as 'robust'. (Double is always exact-enough.)
     soundFP32 = strcmp(precision, 'single') && ~isempty(vmag);
 
+    % FIRST-LAYER IBP short-circuit data: per-op IBP bounds (in `precision`) + box-exactness. Where an
+    % op's INPUT set is exactly a box, its IBP per-coordinate bound is EXACT (== CROWN), so that layer's
+    % tight bound needs no eye(nk) seed/backward -- this removes the WIDEST, input-fed seeds (vgg conv1
+    % 3.21M, tinyimagenet first conv 262144) for free + exact. IBP is always sound; the box-exact gate
+    % means no looseness. Disabled on the sound-FP32 emit path (vmag set), which needs the outward-rounded
+    % CROWN derr widening -- there the chunked CROWN runs instead (sound).
+    ibpL = {}; ibpU = {}; boxExact = {};
+    if ~soundFP32
+        try
+            [~, ~, ~, ibpL, ibpU, boxExact] = gpu_bab_ibp(ops, x_lb, x_ub, precision);
+        catch
+            boxExact = {};   % any failure -> no short-circuit (fall back to chunked CROWN; still sound)
+        end
+    end
+
     % ---- tight intermediate bounds, layer by layer ----
     % Compute input bounds for every op whose backward relaxation needs them: ReLU (the
     % pre-activation) AND maxpool (the window inputs that decide the sound max relaxation).
@@ -73,14 +88,25 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             % not assumed k-1). Bound each of its elements via a backward DAG-CROWN pass over
             % ops[1..src], reusing preL/preU of strictly-earlier ReLUs/maxpools (sound by induction).
             src = ops{k}.src;
-            if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
-            % MEMORY: tile the eye(nk) identity seed into row-blocks so peak memory is O(B*width)
-            % instead of O(nk*width) -- the eye(nk) seed is the SOLE O(nk^2) blow-up (the conv adjoint
-            % i_conv_backward is already structural; VGG conv1 nk=3.21M -> eye is ~38 TB). EXACT: each
-            % seed row is bounded independently (the relaxations read only preL/preU of strictly-earlier
-            % ops + the input box, never other seed rows), so per-block bounds == the full-seed bounds.
-            % B from NNV_CROWN_CHUNK / NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
-            [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
+            if src == 0
+                % the bounded value IS the engine input box -> exact, no seed needed
+                nk = numel(x_lb); pl = cast(x_lb(:), precision); pu = cast(x_ub(:), precision);
+            elseif src >= 1 && ~isequal(getenv('NNV_CROWN_NO_SHORTCUT'), '1') ...
+                    && isfield(ops{src}, 'src') && i_box_exact(boxExact, ops{src}.src)
+                % FIRST-LAYER IBP short-circuit: op `src`'s input set is exactly a box -> its IBP
+                % per-coordinate bound is EXACT (== CROWN). Skip the eye(nk) seed + backward entirely --
+                % this removes the WIDEST, input-fed seeds (vgg conv1 3.21M, tiny first conv 262144) for
+                % free + exact. IBP is always sound; the box-exact gate means zero looseness vs CROWN.
+                nk = i_layer_width(ops, src);
+                pl = ibpL{src+1}; pu = ibpU{src+1};
+            else
+                % MEMORY: tile the eye(nk) seed into row-blocks so peak memory is O(B*width) instead of
+                % O(nk*width) -- the eye(nk) seed is the sole O(nk^2) blow-up (the conv adjoint is already
+                % structural). EXACT: each seed row is bounded independently. B from NNV_CROWN_CHUNK /
+                % NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
+                nk = i_layer_width(ops, src);
+                [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
+            end
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
                 pl(fx == 1)  = max(pl(fx == 1),  0);
@@ -127,6 +153,16 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
 
     % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
     [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true, vmag);
+end
+
+function tf = i_box_exact(boxExact, idx)
+% True iff op `idx`'s output set is exactly a box (idx = the op feeding the op being bounded; 0 = input).
+% gpu_bab_ibp marks box-exactness (true through the input + per-element relu/normaffine, false at any
+% coordinate-mixing op). Fail-safe: empty/missing/multi-col -> false (fall back to chunked CROWN; sound).
+    tf = false;
+    if isempty(boxExact) || idx < 0 || idx + 1 > numel(boxExact), return; end
+    v = boxExact{idx + 1};
+    tf = ~isempty(v) && all(logical(v(:)));
 end
 
 function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -74,9 +74,13 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             % ops[1..src], reusing preL/preU of strictly-earlier ReLUs/maxpools (sound by induction).
             src = ops{k}.src;
             if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
-            Ck = eye(nk, precision);
-            pu = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
-            pl = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true, vmag);
+            % MEMORY: tile the eye(nk) identity seed into row-blocks so peak memory is O(B*width)
+            % instead of O(nk*width) -- the eye(nk) seed is the SOLE O(nk^2) blow-up (the conv adjoint
+            % i_conv_backward is already structural; VGG conv1 nk=3.21M -> eye is ~38 TB). EXACT: each
+            % seed row is bounded independently (the relaxations read only preL/preU of strictly-earlier
+            % ops + the input box, never other seed rows), so per-block bounds == the full-seed bounds.
+            % B from NNV_CROWN_CHUNK / NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
+            [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
                 pl(fx == 1)  = max(pl(fx == 1),  0);
@@ -123,6 +127,33 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
 
     % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
     [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true, vmag);
+end
+
+function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag)
+% Tight per-neuron intermediate bounds (lower pl / upper pu, nk x 1) via a CHUNKED identity seed.
+% Replaces a dense Ck = eye(nk) (the O(nk^2) memory blow-up) with row-blocks; EXACT -- each seed row
+% is bounded independently of the others, so union(blocks) == full. B>=nk => the original single pass.
+    B = i_chunk_rows(nk, precision);
+    pl = zeros(nk, 1, precision); pu = zeros(nk, 1, precision);
+    for s0 = 1:B:nk
+        rows = s0:min(s0 + B - 1, nk); nb = numel(rows);
+        Ck = zeros(nb, nk, precision);
+        Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
+        pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
+        pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+    end
+end
+
+function B = i_chunk_rows(nk, precision)
+% Seed-row block size. NNV_CROWN_CHUNK overrides explicitly (control/testing); else from a memory
+% budget NNV_CROWN_MEM_GB (default 2 GB), with a /4 safety factor for the backward intermediates
+% beyond the [B x nk] seed. Clamp to [1, nk] (B == nk reproduces the dense eye(nk) single pass).
+    e = str2double(getenv('NNV_CROWN_CHUNK'));
+    if isfinite(e) && e >= 1, B = max(1, min(round(e), nk)); return; end
+    bytes = 4; if strcmp(precision, 'double'), bytes = 8; end
+    gb = str2double(getenv('NNV_CROWN_MEM_GB')); if ~isfinite(gb) || gb <= 0, gb = 2; end
+    B = floor(gb * 1e9 / (max(nk, 1) * bytes * 4));
+    B = max(1, min(B, nk));
 end
 
 function w = i_layer_width(ops, upto)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -88,8 +88,12 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             % not assumed k-1). Bound each of its elements via a backward DAG-CROWN pass over
             % ops[1..src], reusing preL/preU of strictly-earlier ReLUs/maxpools (sound by induction).
             src = ops{k}.src;
-            if src == 0
-                % the bounded value IS the engine input box -> exact, no seed needed
+            if src == 0 && ~soundFP32
+                % the bounded value IS the engine input box -> exact, no seed needed (double / unsound
+                % screen). NOT under sound-FP32: a naive single cast rounds to NEAREST, which can move a
+                % lower bound UP / an upper bound DOWN (inward) -> breaks the outward-widening guarantee.
+                % There we fall through to the chunked backward (else), whose i_backward(ops,0,...) applies
+                % the vmag/derr OUTWARD widening -- the same sound path the product input already uses.
                 nk = numel(x_lb); pl = cast(x_lb(:), precision); pu = cast(x_ub(:), precision);
             elseif src >= 1 && ~isequal(getenv('NNV_CROWN_NO_SHORTCUT'), '1') ...
                     && isfield(ops{src}, 'src') && i_box_exact(boxExact, ops{src}.src)
@@ -104,7 +108,8 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 % O(nk*width) -- the eye(nk) seed is the sole O(nk^2) blow-up (the conv adjoint is already
                 % structural). EXACT: each seed row is bounded independently. B from NNV_CROWN_CHUNK /
                 % NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
-                nk = i_layer_width(ops, src);
+                % src==0 here is the sound-FP32 input-fed case routed off the fast cast above (widened).
+                if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
                 [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
             end
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_ibp.m
@@ -1,4 +1,4 @@
-function [out_lb, out_ub, vmag] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
+function [out_lb, out_ub, vmag, cl, cu, boxExact] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
 % GPU_BAB_IBP  Sound interval bound propagation for a feedforward ReLU net.
 %
 %   [out_lb, out_ub] = GPU_BAB_IBP(ops, in_lb, in_ub, precision) forward-
@@ -62,6 +62,7 @@ function [out_lb, out_ub, vmag] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
     % so conv-on-skip branches bound correctly; 'add' sums its two inputs. Interval ops EXACT.
     cl = cell(nOps + 1, 1); cu = cell(nOps + 1, 1);
     cl{1} = lb; cu{1} = ub;
+    boxExact = cell(nOps + 1, 1); boxExact{1} = true;   % the input set is exactly a box
     for k = 1:nOps
         op = ops{k};
         if strcmp(op.type, 'add')
@@ -78,6 +79,15 @@ function [out_lb, out_ub, vmag] = gpu_bab_ibp(ops, in_lb, in_ub, precision)
         else
             s = op.src + 1;
             [cl{k+1}, cu{k+1}] = i_apply_ibp(op, cl{s}, cu{s}, precision);
+        end
+        % box-exactness: relu/normaffine are per-element (box -> box); every other op mixes
+        % coordinates (conv/affine/avgpool/maxpool/add/concat/product) so its output set is NOT a
+        % box. gpu_bab_crown_tight uses this: an op's IBP per-coord bounds are EXACT (== CROWN) iff
+        % its INPUT set is a box -> short-circuit those layers' tight bounds (the widest, input-fed ones).
+        if strcmp(op.type, 'relu') || strcmp(op.type, 'normaffine')
+            boxExact{k+1} = boxExact{op.src + 1};
+        else
+            boxExact{k+1} = false;
         end
     end
     out_lb = cl{nOps + 1};

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -59,7 +59,7 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     badIdx = find(cellfun(@(o) ~any(strcmp(o.type, supported)), ops), 1);
     if ~isempty(badIdx)
         error('gpu_bab_relu_split_batched:unsupportedOp', ...
-            'op "%s" unsupported (affine/relu/conv/normaffine/avgpool/maxpool/add only).', ops{badIdx}.type);
+            'op "%s" unsupported (affine/relu/conv/normaffine/avgpool/maxpool/add/concat/product only).', ops{badIdx}.type);
     end
 
     nOps    = numel(ops);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -52,13 +52,14 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
     % conv nets). The batched bounding (gpu_bab_crown_spec_dag) is sound for these -- conv/BN/
     % avgpool/add are LINEAR (exact interval forward + exact adjoint backward; 'add' routes its
     % backward coefficient unchanged to both summands, gpu_bab_crown_spec_dag handles the DAG via
-    % op.src/op.inputs), only ReLU is relaxed. 'maxpool' needs a per-node window relaxation not
-    % yet batched -> refuse (sound-by-refusal -> caller runs the serial tight path / Star).
-    supported = {'affine','relu','conv','normaffine','avgpool','add','concat','product'};
+    % op.src/op.inputs), only ReLU is relaxed. 'maxpool' is now batched too (gpu_bab_crown_spec_dag
+    % i_maxpool_backward_batched: sound CROWN window relaxation, lower-direction; soundFP32 emit
+    % refused so the FP64 confirm handles sound-emit).
+    supported = {'affine','relu','conv','normaffine','avgpool','maxpool','add','concat','product'};
     badIdx = find(cellfun(@(o) ~any(strcmp(o.type, supported)), ops), 1);
     if ~isempty(badIdx)
         error('gpu_bab_relu_split_batched:unsupportedOp', ...
-            'op "%s" unsupported (affine/relu/conv/normaffine/avgpool/add only; maxpool needs gpu_bab_relu_split tight).', ops{badIdx}.type);
+            'op "%s" unsupported (affine/relu/conv/normaffine/avgpool/maxpool/add only).', ops{badIdx}.type);
     end
 
     nOps    = numel(ops);

--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -260,6 +260,14 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
             % a wrong order fails the guard -> caller runs Star), so this only ADDS coverage
             % (previously these nets errored -> Star) and never yields a wrong graph.
             emitted = false;
+        elseif contains(cls, 'Placeholder') && i_placeholder_is_identity(L)
+            % MID-NETWORK identity Placeholder: the ONNX importer leaves Dropout (and Identity) as a
+            % PlaceholderLayer it can't map. At INFERENCE Dropout IS the identity, so this is a sound
+            % value-preserving pass-through (like Flatten) -- emit no op. Gated on the placeholder's
+            % recorded Type (Dropout/Identity) AND empty Perm/Constant, so a Transpose/Constant
+            % placeholder still refuses (sound-by-refusal). Unblocks vgg16 (2 dropout placeholders
+            % between its FC layers) for the GPU-BaB pre-check.
+            emitted = false;
         elseif contains(cls, 'Softmax') || contains(cls, 'Classification') ...
                 || contains(cls, 'Output') || contains(cls, 'Regression') ...
                 || contains(cls, 'Placeholder')
@@ -497,4 +505,19 @@ function srcs = i_concat_sources(conns, name)
     end
     [~, ord] = sort(ports);
     srcs = cand(ord);
+end
+
+function tf = i_placeholder_is_identity(L)
+% True iff a PlaceholderLayer is an INFERENCE-IDENTITY op (Dropout / Identity) that the ONNX importer
+% could not map -- sound to treat as a value-preserving pass-through. Gated on the recorded Type AND
+% empty Perm/Constant, so a Transpose/Constant-bearing placeholder is NOT treated as identity
+% (sound-by-refusal). (vgg16's dropout placeholders report Type "nnet.cnn.layer.DropoutLayer".)
+    tf = false;
+    props = properties(L);
+    if ~any(strcmp(props, 'Type')), return; end
+    t = lower(string(L.Type));
+    isId       = contains(t, "dropout") || contains(t, "identity");
+    permEmpty  = ~any(strcmp(props, 'Perm'))     || isempty(L.Perm);
+    constEmpty = ~any(strcmp(props, 'Constant')) || isempty(L.Constant);
+    tf = isId && permEmpty && constEmpty;
 end

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -785,7 +785,7 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     % precheck CRASHED MATLAB on the box (hard std::exception "MATLAB process cannot be terminated" --
     % the orientation guard did NOT catch it, so it is NOT a safe sound-or-skip). Needs the conv
     % GPU-BaB path hardened against challenging's net before it can be enabled. Left on Star for now.
-    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet");
+    isConv = contains(category,"cifar100") || contains(category,"tinyimagenet") || contains(category,"vggnet");
     % General-halfspace control benchmarks (NOT argmax): prove the output avoids every unsafe
     % disjunct in prop.Hg. gpu_bab_halfspace_verify is sound-or-skip (FP64 CROWN + orientation
     % guard), so it can only ADD a sound unsat. Routed separately below (own predicate).

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
@@ -1,0 +1,59 @@
+% test_soundness_gpu_bab_crown_memory
+% Soundness + equivalence tests for the GPU-BaB conv MEMORY handling in gpu_bab_crown_tight:
+%   (1) chunked eye(nk) intermediate-bound seed (NNV_CROWN_CHUNK) -- bit-identical (B>=2) + sound (B=1);
+%   (2) first-layer IBP short-circuit (box-exact inputs, NNV_CROWN_NO_SHORTCUT kill-switch) -- transparent
+%       (== full CROWN, since IBP of an affine map of a box is exact) + sound + no looser than IBP.
+% Net is small so the dense eye(nk) pass and the chunked/short-circuit paths all fit and can be compared.
+
+rng(7);
+layers = [imageInputLayer([8 8 3],'Normalization','none','Name','in')
+          convolution2dLayer(3,5,'Padding',1,'Name','c1'); reluLayer('Name','r1')
+          convolution2dLayer(3,4,'Padding',1,'Name','c2'); reluLayer('Name','r2')
+          fullyConnectedLayer(6,'Name','fc')];
+nnvnet = matlab2nnv(dlnetwork(layers));
+ops = nn_to_ops(nnvnet);
+ish = [8 8 3];
+C   = [eye(5) -ones(5,1)];
+xc  = rand(ish); lb = xc(:) - 0.05; ub = xc(:) + 0.05;
+Xs  = lb + (ub - lb) .* rand(numel(lb), 4000);
+tmp = inf(5,1);
+for s = 1:size(Xs,2), y = nnvnet.evaluate(reshape(Xs(:,s), ish)); tmp = min(tmp, C * y(:)); end
+trueMin = tmp;
+
+%% Test 1: chunked seed (B>=2) is BIT-IDENTICAL to the dense single eye(nk) pass
+setenv('NNV_CROWN_CHUNK','1000000'); mFull = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+for B = [2 3 7]
+    setenv('NNV_CROWN_CHUNK', num2str(B));
+    mB = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+    assert(max(abs(mB(:) - mFull(:))) == 0, sprintf('chunked B=%d must be bit-identical to the dense pass', B));
+end
+setenv('NNV_CROWN_CHUNK','');
+
+%% Test 2: chunking is SOUND under maximal chunking (B=1)
+setenv('NNV_CROWN_CHUNK','1'); m1 = gpu_bab_crown_tight(ops, lb, ub, C, 'double'); setenv('NNV_CROWN_CHUNK','');
+assert(all(m1(:) <= trueMin + 1e-6), 'chunked B=1 margin must be sound (<= true min)');
+
+%% Test 3: first-layer IBP short-circuit is TRANSPARENT (== full CROWN, to FP rounding)
+setenv('NNV_CROWN_NO_SHORTCUT','');  mON  = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+setenv('NNV_CROWN_NO_SHORTCUT','1'); mOFF = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+setenv('NNV_CROWN_NO_SHORTCUT','');
+assert(max(abs(mON(:) - mOFF(:))) < 1e-9, 'IBP short-circuit must match full CROWN (box-exact => exact)');
+
+%% Test 4: short-circuit margins are SOUND and no looser than IBP
+mON = gpu_bab_crown_tight(ops, lb, ub, C, 'double');   % short-circuit is on by default
+assert(all(mON(:) <= trueMin + 1e-6), 'short-circuit margin must be sound (<= true min)');
+[ilb, iub] = gpu_bab_ibp(ops, lb, ub, 'double');
+assert(all(mON(:) >= max(C,0)*ilb + min(C,0)*iub - 1e-6), 'short-circuit CROWN must be no looser than IBP');
+
+%% Test 5: gpu_bab_ibp box-exactness flags the input (true) and a coordinate-mixing op (false)
+[~, ~, ~, ~, ~, boxExact] = gpu_bab_ibp(ops, lb, ub, 'double');
+assert(~isempty(boxExact) && boxExact{1} == true, 'the input set must be box-exact');
+assert(any(cellfun(@(v) ~isempty(v) && ~all(logical(v)), boxExact)), ...
+    'a coordinate-mixing op (conv) must break box-exactness downstream');
+
+%% Test 6: chunking + short-circuit COMPOSED is still sound (the production default config)
+setenv('NNV_CROWN_CHUNK','2');  mc = gpu_bab_crown_tight(ops, lb, ub, C, 'double'); setenv('NNV_CROWN_CHUNK','');
+assert(all(mc(:) <= trueMin + 1e-6), 'chunk+short-circuit composed margin must be sound');
+
+%% Summary
+disp('test_soundness_gpu_bab_crown_memory: all sections passed');

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_maxpool.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_maxpool.m
@@ -56,5 +56,22 @@ assert(all(mt <= trueMin + 1e-4), 'maxpool CROWN-tight margin must be sound (<= 
 Cp = max(Cspec, 0); Cn = min(Cspec, 0);
 assert(all(mt >= Cp*ilb + Cn*iub - 1e-6), 'maxpool CROWN-tight must be no looser than IBP');
 
+%% Test 6: BATCHED spec_dag maxpool CROWN -- sound, matches serial crown_tight, exact at a point
+% (this is the GPU-screen path: gpu_bab_crown_spec_dag / gpu_bab_relu_split_batched)
+mb = gpu_bab_crown_spec_dag(ops, lb, ub, Cspec, 'double', {}, [], {}, []);
+assert(all(mb <= trueMin + 1e-4), 'batched maxpool CROWN margin must be sound (<= true min)');
+% a real CROWN bound: sound AND no looser than IBP. (The batched relu relaxation differs in
+% tightness from serial crown_tight -- both sound -- so check the IBP floor, not exact equality.)
+[ilb6, iub6] = gpu_bab_ibp(ops, lb, ub, 'double');
+assert(all(mb >= max(Cspec,0)*ilb6 + min(Cspec,0)*iub6 - 1e-6), 'batched maxpool CROWN must be no looser than IBP');
+mb0 = gpu_bab_crown_spec_dag(ops, xc(:), xc(:), Cspec, 'double', {}, [], {}, []);
+assert(max(abs(mb0(:) - Cspec*reshape(nnvnet.evaluate(xc),[],1))) < 1e-4, 'batched maxpool degenerate == C*evaluate');
+
+%% Test 7: BATCHED root-tight reuse path + B>1 (the trust-FP32 screen feeds rootBounds)
+[~, preLr, preUr] = gpu_bab_crown_spec_dag(ops, lb, ub, Cspec, 'double', {}, [], {}, []);
+rb = struct('preL', {preLr}, 'preU', {preUr});
+mrt = gpu_bab_crown_spec_dag(ops, [lb lb], [ub ub], Cspec, 'double', {}, rb, {}, []);   % B=2 node columns
+assert(all(mrt(:) <= repmat(trueMin,2,1) + 1e-4), 'batched maxpool root-tight margin must be sound (B>1)');
+
 %% Summary
 disp('test_soundness_gpu_bab_maxpool: all sections passed');


### PR DESCRIPTION
Unblocks the GPU-BaB pathway for **wide / maxpool / dropout-containing conv nets** (tinyimagenet, cifar resnet_large, vgg16) by removing the memory wall and adding the missing layer support. All changes are **sound-or-unknown** and additive (no master engine work reverted).

## Changes
1. **`nn_to_ops`: Dropout/Identity placeholder pass-through.** The ONNX importer leaves Dropout as a `PlaceholderLayer`; at inference Dropout is the identity, so it's a sound value-preserving pass-through (gated on the recorded `Type` + empty `Perm`/`Constant`, so a Transpose/Constant placeholder still refuses). Unblocks vgg16 (2 dropout placeholders between its FC layers).
2. **`gpu_bab_crown_spec_dag`: batched maxpool.** Ports the validated serial maxpool relaxation (`gpu_bab_crown_tight.i_maxpool_relax`) into the batched CROWN engine (lower = argmax-lower input; upper = that input if it dominates else the constant window max-upper; overlap accumulates). sound-FP32 emit refused for maxpool (the trust-FP32 screen runs `soundFP32=false`). Drops maxpool from the `gpu_bab_relu_split_batched` pre-check.
3. **`gpu_bab_crown_tight`: chunk the `eye(nk)` intermediate-bound seed.** The dense `eye(nk)` seed was the sole O(nk^2) blow-up (vgg conv1 nk=3.21M -> ~38 TB; tinyimagenet/cifar_resnet_large also exceed the device gpuArray limit). `i_interm_bounds_chunked` tiles it into row-blocks -> peak memory O(B*width). EXACT: each seed row is bounded independently. Knobs `NNV_CROWN_CHUNK` / `NNV_CROWN_MEM_GB`.
4. **`gpu_bab_crown_tight` + `gpu_bab_ibp`: first-layer IBP short-circuit.** Where a layer's input set is exactly a box (the input + per-element relu/normaffine ancestors), IBP per-coordinate bounds are EXACT == CROWN, so the seed is skipped entirely -- removing the widest, input-fed seeds (vgg conv1, tinyimagenet first conv) for free. `gpu_bab_ibp` now also returns per-op bounds + a `boxExact` flag. Disabled on the sound-FP32 emit path; kill-switch `NNV_CROWN_NO_SHORTCUT`.
5. `run_vnncomp_instance`: route `vggnet` through the conv GPU-BaB gate (exploratory).

## Soundness
- Chunking is **exact** (tiling; same bounds): B>=2 FP64 bit-identical to the dense pass (maxdiff=0); B=1 differs only by a 1-ULP BLAS GEMV-vs-GEMM accumulation.
- First-layer IBP is used **only** where the input is provably a box (IBP exact there); IBP is always an over-approximation, so the gate means zero looseness vs CROWN. ON==OFF to 1e-15.
- Maxpool relaxation is the validated serial one; sound + no looser than IBP.

## Validation
Full gpu_bab soundness suite **90/90** (15 files), incl. new `test_soundness_gpu_bab_crown_memory` (7/7) + `test_soundness_gpu_bab_maxpool` extended to the batched path (8/8); no regression to conv/residual/batched/alpha/beta/dispatch/root_tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)