### PR TITLE
gpu_bab: auto-halve CROWN chunk size on OOM (self-tuning conv memory, sound)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -193,6 +193,7 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
             % so halve B and RETRY the SAME block. SOUND: cannot change a verdict, only memory/speed.
             % Non-memory errors (a genuine bug) rethrow immediately; at B==1 there is no smaller retry.
             if B <= 1 || ~i_is_oom(ME), rethrow(ME); end
+            clear Ck;                    % release the (nb x nk) seed so the smaller-B retry has headroom
             Bn = max(1, floor(B / 2));
             fprintf('[crown-chunk] OOM at B=%d (nk=%d, op %d): %s -> halving to B=%d\n', ...
                 B, nk, src, i_first_line(ME.message), Bn);
@@ -207,9 +208,9 @@ function tf = i_is_oom(ME)
 % slow retries. Matches both identifier and message text (the device-size error carries no id).
     id = ME.identifier; m = lower(ME.message);
     tf = strcmp(id, 'parallel:gpu:array:OOM') || strcmp(id, 'MATLAB:nomem') ...
-        || contains(m, 'out of memory') || contains(m, 'maximum variable size') ...
-        || contains(m, 'maximum array size') || contains(m, 'exceeds available memory') ...
-        || (contains(m, 'gpu') && contains(m, 'memory'));
+        || contains(m, 'out of memory') || contains(m, 'insufficient memory') ...
+        || contains(m, 'maximum variable size') || contains(m, 'maximum array size') ...
+        || contains(m, 'exceeds available memory');
 end
 
 function s = i_first_line(m)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -175,13 +175,58 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
 % Replaces a dense Ck = eye(nk) (the O(nk^2) memory blow-up) with row-blocks; EXACT -- each seed row
 % is bounded independently of the others, so union(blocks) == full. B>=nk => the original single pass.
     B = i_chunk_rows(nk, precision);
+    oomTest = getenv('NNV_CROWN_TEST_OOM');                  % test seam (empty in production)
     pl = zeros(nk, 1, precision); pu = zeros(nk, 1, precision);
-    for s0 = 1:B:nk
+    s0 = 1;
+    while s0 <= nk
         rows = s0:min(s0 + B - 1, nk); nb = numel(rows);
-        Ck = zeros(nb, nk, precision);
-        Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
-        pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
-        pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+        try
+            i_maybe_inject_oom(B, oomTest);
+            Ck = zeros(nb, nk, precision);
+            Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
+            pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
+            pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+            s0 = s0 + B;
+        catch ME
+            % AUTO-CHUNK: a memory budget B chosen too large for the live device/host still OOMs. B
+            % only sets PEAK memory -- the bounds are EXACT for any B (each seed row is independent) --
+            % so halve B and RETRY the SAME block. SOUND: cannot change a verdict, only memory/speed.
+            % Non-memory errors (a genuine bug) rethrow immediately; at B==1 there is no smaller retry.
+            if B <= 1 || ~i_is_oom(ME), rethrow(ME); end
+            Bn = max(1, floor(B / 2));
+            fprintf('[crown-chunk] OOM at B=%d (nk=%d, op %d): %s -> halving to B=%d\n', ...
+                B, nk, src, i_first_line(ME.message), Bn);
+            B = Bn;
+        end
+    end
+end
+
+function tf = i_is_oom(ME)
+% True only for MEMORY-pressure errors (device gpuArray cap, GPU OOM, host OOM, "Maximum variable
+% size ... device"). Kept targeted so a genuine logic bug rethrows fast instead of after log2(B)
+% slow retries. Matches both identifier and message text (the device-size error carries no id).
+    id = ME.identifier; m = lower(ME.message);
+    tf = strcmp(id, 'parallel:gpu:array:OOM') || strcmp(id, 'MATLAB:nomem') ...
+        || contains(m, 'out of memory') || contains(m, 'maximum variable size') ...
+        || contains(m, 'maximum array size') || contains(m, 'exceeds available memory') ...
+        || (contains(m, 'gpu') && contains(m, 'memory'));
+end
+
+function s = i_first_line(m)
+    nl = find(m == newline, 1); if isempty(nl), s = m; else, s = m(1:nl-1); end
+end
+
+function i_maybe_inject_oom(B, spec)
+% TEST SEAM -- no-op unless NNV_CROWN_TEST_OOM is set; lets the soundness suite exercise the
+% auto-chunk catch/halve/retry path deterministically (real OOMs are not reproducible in a unit test).
+%   '<thr>' -> throw a synthetic device OOM while B > thr (B halves down to <= thr, then proceeds);
+%              the retried bounds must match a clean run (B-invariant) -> proves the retry is correct.
+%   'bug'   -> throw a NON-memory error; it must propagate (verifies i_is_oom does not swallow real bugs).
+    if isempty(spec), return; end
+    if strcmp(spec, 'bug'), error('NNV:test:notMemory', 'synthetic non-memory failure (must propagate)'); end
+    thr = str2double(spec);
+    if isfinite(thr) && B > thr
+        error('parallel:gpu:array:OOM', 'Out of memory on device (synthetic test injection at B=%d).', B);
     end
 end
 

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
@@ -58,18 +58,27 @@ assert(all(mc(:) <= trueMin + 1e-6), 'chunk+short-circuit composed margin must b
 %% Test 7: AUTO-CHUNK halve-on-OOM yields the SAME bounds as a clean run (retry is exact + B-invariant)
 % NNV_CROWN_TEST_OOM forces a synthetic device OOM while B > thr, so the catch/halve/retry path runs:
 % B steps 64 -> 32 -> 16 -> 8, then proceeds. The result must be bit-identical to a clean B=64 pass.
+g7 = onCleanup(@i_clear_oom_env);  % restore (clear) the test env vars even if an assert fails -> hermetic
 setenv('NNV_CROWN_CHUNK','64'); mClean = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
 setenv('NNV_CROWN_TEST_OOM','8'); mHalved = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
-setenv('NNV_CROWN_TEST_OOM',''); setenv('NNV_CROWN_CHUNK','');
 assert(max(abs(mHalved(:) - mClean(:))) == 0, 'auto-chunk halved result must be bit-identical to a clean run');
 assert(all(mHalved(:) <= trueMin + 1e-6), 'auto-chunk halved margin must be sound');
+clear g7;   % restore env now (do not leak into later sections)
 
 %% Test 8: a NON-memory error inside the chunk loop PROPAGATES (i_is_oom must not swallow real bugs)
+g8 = onCleanup(@i_clear_oom_env);  % restore (clear) the test env vars even if an assert fails -> hermetic
 setenv('NNV_CROWN_CHUNK','64'); setenv('NNV_CROWN_TEST_OOM','bug');
 threw = false;
 try, gpu_bab_crown_tight(ops, lb, ub, C, 'double'); catch ME, threw = strcmp(ME.identifier, 'NNV:test:notMemory'); end
-setenv('NNV_CROWN_TEST_OOM',''); setenv('NNV_CROWN_CHUNK','');
 assert(threw, 'a non-memory error must propagate out of the auto-chunk retry (not be retried as OOM)');
+clear g8;
 
 %% Summary
 disp('test_soundness_gpu_bab_crown_memory: all sections passed');
+
+function i_clear_oom_env()
+% onCleanup target for Tests 7-8: clear the test-only auto-chunk env vars (normally empty) so a
+% mid-section assert failure cannot leak NNV_CROWN_CHUNK / NNV_CROWN_TEST_OOM into later sections.
+    setenv('NNV_CROWN_CHUNK', '');
+    setenv('NNV_CROWN_TEST_OOM', '');
+end

--- a/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
+++ b/code/nnv/tests/soundness/test_soundness_gpu_bab_crown_memory.m
@@ -55,5 +55,21 @@ assert(any(cellfun(@(v) ~isempty(v) && ~all(logical(v)), boxExact)), ...
 setenv('NNV_CROWN_CHUNK','2');  mc = gpu_bab_crown_tight(ops, lb, ub, C, 'double'); setenv('NNV_CROWN_CHUNK','');
 assert(all(mc(:) <= trueMin + 1e-6), 'chunk+short-circuit composed margin must be sound');
 
+%% Test 7: AUTO-CHUNK halve-on-OOM yields the SAME bounds as a clean run (retry is exact + B-invariant)
+% NNV_CROWN_TEST_OOM forces a synthetic device OOM while B > thr, so the catch/halve/retry path runs:
+% B steps 64 -> 32 -> 16 -> 8, then proceeds. The result must be bit-identical to a clean B=64 pass.
+setenv('NNV_CROWN_CHUNK','64'); mClean = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+setenv('NNV_CROWN_TEST_OOM','8'); mHalved = gpu_bab_crown_tight(ops, lb, ub, C, 'double');
+setenv('NNV_CROWN_TEST_OOM',''); setenv('NNV_CROWN_CHUNK','');
+assert(max(abs(mHalved(:) - mClean(:))) == 0, 'auto-chunk halved result must be bit-identical to a clean run');
+assert(all(mHalved(:) <= trueMin + 1e-6), 'auto-chunk halved margin must be sound');
+
+%% Test 8: a NON-memory error inside the chunk loop PROPAGATES (i_is_oom must not swallow real bugs)
+setenv('NNV_CROWN_CHUNK','64'); setenv('NNV_CROWN_TEST_OOM','bug');
+threw = false;
+try, gpu_bab_crown_tight(ops, lb, ub, C, 'double'); catch ME, threw = strcmp(ME.identifier, 'NNV:test:notMemory'); end
+setenv('NNV_CROWN_TEST_OOM',''); setenv('NNV_CROWN_CHUNK','');
+assert(threw, 'a non-memory error must propagate out of the auto-chunk retry (not be retried as OOM)');
+
 %% Summary
 disp('test_soundness_gpu_bab_crown_memory: all sections passed');


### PR DESCRIPTION
Follow-up to #396. Makes the conv GPU-BaB pathway **self-tune to the live device** instead of needing a hand-set `NNV_CROWN_MEM_GB`.

## Change
`i_interm_bounds_chunked` (in `gpu_bab_crown_tight`) now catches a device/host OOM, **halves `B`, and retries the same row-block**. `B` only sets *peak* memory — the per-neuron intermediate bounds are EXACT for any `B` (each seed row is bounded independently, proven bit-identical in #396's Tests 1–2) — so this can only change memory/speed, **never a verdict**.

## Why it matters
`run_instance.sh` (the competition entry) sets **no** `NNV_CROWN_MEM_GB`. Before this, tinyimagenet/cifar-large/vgg at default budget device-errored → Star → timeout. Now they self-tune:

> **tinyimagenet `resnet_medium`, default env, end-to-end:** completes in **104s** with a sound verdict. The halve fires on real OOMs at the deep wide layers (`[crown-chunk] OOM at B=4982 (nk=25088) -> halving to 2491`, …) and emits — no device-error.

## Soundness
- `i_is_oom` is targeted to memory errors only (`parallel:gpu:array:OOM`, `MATLAB:nomem`, the device "Maximum variable size" message, "out of memory") so a genuine logic bug rethrows immediately, not after `log2(B)` slow retries.
- A non-memory error inside the loop propagates (verified by a test).

## Validation
- `test_soundness_gpu_bab_crown_memory` extended to **9/9**: Test 7 forces the catch/halve path via a no-op-in-production `NNV_CROWN_TEST_OOM` seam and asserts the halved result is **bit-identical** to a clean run; Test 8 asserts a non-memory error propagates.
- tinyimagenet end-to-end at default env (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)