### PR TITLE
acas: fix exact-star crash (parpool serial fallback) + serial acas + cache cfg-guard + PGD trim + sound reach time-cap

### DIFF
--- a/code/nnv/engine/nn/NN.m
+++ b/code/nnv/engine/nn/NN.m
@@ -254,8 +254,10 @@ classdef NN < handle
 
             % Parallel computation or single core?
             if  obj.numCores > 1
-                obj.start_pool;
-                obj.reachOption = 'parallel';
+                obj.start_pool;                 % may downgrade numCores->1 if the pool can't start
+                if obj.numCores > 1
+                    obj.reachOption = 'parallel';
+                end
             end
 
             % Debugging option
@@ -442,8 +444,10 @@ classdef NN < handle
 
             % Parallel computation or single core?
             if  obj.numCores > 1
-                obj.start_pool;
-                obj.reachOption = 'parallel';
+                obj.start_pool;                 % may downgrade numCores->1 if the pool can't start
+                if obj.numCores > 1
+                    obj.reachOption = 'parallel';
+                end
             end
 
             % Debugging option
@@ -1373,25 +1377,37 @@ classdef NN < handle
                 if ~isempty(getCurrentTask())
                     return;
                 end
-                poolobj = gcp('nocreate'); % If no pool, do not create new one.
-                if isempty(poolobj)
-                    cl = parcluster();
-                    if cl.NumWorkers < obj.numCores
-                        cl.NumWorkers = obj.numCores;
-                    end
-                    % evalc captures "Starting parallel pool..." / "Connected
-                    % to parallel pool with N workers." chatter; the pool is
-                    % otherwise unaffected (gcp/parfor pick it up normally).
-                    evalc('parpool(cl, obj.numCores);');
-                else
-                    if poolobj.NumWorkers ~= obj.numCores
-                        evalc('delete(poolobj);'); % delete old; suppress "shutting down" message
+                % GRACEFUL FALLBACK: a parpool can fail to start (e.g. a broken local
+                % cluster profile -> "MATLAB worker shut down ... status 1"). That must
+                % NOT crash reach into 'unknown' -- serial reach is the SAME result, just
+                % slower. On any failure, downgrade to serial (numCores=1); the dispatcher
+                % then leaves reachOption non-parallel and the reach parfor runs serially.
+                try
+                    poolobj = gcp('nocreate'); % If no pool, do not create new one.
+                    if isempty(poolobj)
                         cl = parcluster();
                         if cl.NumWorkers < obj.numCores
                             cl.NumWorkers = obj.numCores;
                         end
-                        evalc('parpool(cl, obj.numCores);'); % start new; suppress "Connected to" message
+                        % evalc captures "Starting parallel pool..." / "Connected
+                        % to parallel pool with N workers." chatter; the pool is
+                        % otherwise unaffected (gcp/parfor pick it up normally).
+                        evalc('parpool(cl, obj.numCores);');
+                    else
+                        if poolobj.NumWorkers ~= obj.numCores
+                            evalc('delete(poolobj);'); % delete old; suppress "shutting down" message
+                            cl = parcluster();
+                            if cl.NumWorkers < obj.numCores
+                                cl.NumWorkers = obj.numCores;
+                            end
+                            evalc('parpool(cl, obj.numCores);'); % start new; suppress "Connected to" message
+                        end
                     end
+                catch ME
+                    warning('NN:parpoolFallback', ...
+                        'parpool(%d) failed to start (%s) -> serial reach.', ...
+                        obj.numCores, regexprep(ME.message, '\s+', ' '));
+                    obj.numCores = 1;   % fall back to serial; reach result is identical
                 end
             end
         end

--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -409,7 +409,7 @@ classdef PosLin
                         In = PosLin.stepReachMultipleInputs(In, map(i), option, lp_solver);
                     end
                     S = In;
-                    if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; lpn=NNV_LP_N; if isempty(lpn), lpn=0; end; fz=fopen(getenv('NNV_LP_COUNT'),'a'); fprintf(fz,'reluLayer in=%d unstable=%d out=%d cumLP=%d\n', numel(I), m, numel(In), lpn); fclose(fz); end %#ok<TLEV>
+                    if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; lpn=NNV_LP_N; if isempty(lpn), lpn=0; end; fz=fopen(getenv('NNV_LP_COUNT'),'a'); if fz>0, fprintf(fz,'reluLayer in=%d unstable=%d out=%d cumLP=%d\n', numel(I), m, numel(In), lpn); fclose(fz); end, end %#ok<TLEV>
                 end
                 
             else

--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -397,8 +397,9 @@ classdef PosLin
                             fprintf('\nPerforming exact PosLin_%d operation using Star', map(i));
                         end
                         In = PosLin.stepReachMultipleInputs(In, map(i), option, lp_solver);
-                    end               
+                    end
                     S = In;
+                    if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; lpn=NNV_LP_N; if isempty(lpn), lpn=0; end; fz=fopen(getenv('NNV_LP_COUNT'),'a'); fprintf(fz,'reluLayer in=%d unstable=%d out=%d cumLP=%d\n', numel(I), m, numel(In), lpn); fclose(fz); end %#ok<TLEV>
                 end
                 
             else

--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -339,6 +339,16 @@ classdef PosLin
         
         % exact reachability analysis using star
         function S = reach_star_exact(varargin)
+            % SOUND time-budget cap (opt-in via globals set by the caller): exact-star is complete but
+            % can be slow (star/LP growth). When a per-instance reach budget is exceeded, abort with an
+            % error -> the harness maps it to UNKNOWN (sound -- claims nothing), instead of grinding to
+            % the OS timeout. Enables a persistent-session sweep runner (no per-instance OS kill needed)
+            % and turns hard-instance hangs into fast unknowns. No-op unless NNV_REACH_T0/_BUD are set.
+            global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+            if ~isempty(NNV_REACH_BUD) && NNV_REACH_BUD > 0 && ~isempty(NNV_REACH_T0) ...
+                    && toc(NNV_REACH_T0) > NNV_REACH_BUD
+                error('NNV:reachBudget', 'reach exceeded time budget (%.0fs) -> unknown', NNV_REACH_BUD);
+            end
             % @I: star input sets
             % @option: = 'parallel' using parallel computing
             %          = '[]'    do not use parallel computing

--- a/code/nnv/engine/utils/lpsolver.m
+++ b/code/nnv/engine/utils/lpsolver.m
@@ -1,7 +1,7 @@
 function [fval, exitflag] = lpsolver(f, A, b, Aeq, Beq, lb, ub, lp_solver, opts)
     % DIAGNOSTIC (gated): count every LP solve into a global, dumped by the reach instrumentation.
     if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; if isempty(NNV_LP_N), NNV_LP_N=0; end; NNV_LP_N=NNV_LP_N+1; end %#ok<TLEV>
-    % common function for al linear programming problems
+    % common function for all linear programming problems
     % for now we will set linprog with default options to solve every task,
     % seems to be faster than glpk or yalmip, and if it fails, we try glpk
     % (glpk seems a little more robust than linprog, fails less)

--- a/code/nnv/engine/utils/lpsolver.m
+++ b/code/nnv/engine/utils/lpsolver.m
@@ -1,4 +1,6 @@
 function [fval, exitflag] = lpsolver(f, A, b, Aeq, Beq, lb, ub, lp_solver, opts)
+    % DIAGNOSTIC (gated): count every LP solve into a global, dumped by the reach instrumentation.
+    if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; if isempty(NNV_LP_N), NNV_LP_N=0; end; NNV_LP_N=NNV_LP_N+1; end %#ok<TLEV>
     % common function for al linear programming problems
     % for now we will set linprog with default options to solve every task,
     % seems to be faster than glpk or yalmip, and if it fails, we try glpk

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -261,6 +261,7 @@ else
 end
 
 cEX_time = toc(t);
+if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE import+falsify cEX_time=%.2f\n', cEX_time); fclose(fpl); end
 
 
 %% 3) UNSAT?
@@ -343,6 +344,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
             while ~isempty(reachOptionsList)
 
                 reachOptions = reachOptionsList{1};
+                rt0 = tic;
 
                 IS = create_input_set(lb, ub, inputSize, needReshape, useImageStar);
 
@@ -359,6 +361,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
                             fprintf('reach skipped: matlab2nnv conversion failed earlier -> unknown\n');
                             status = 2; break;
                         end
+                        if ~isempty(getenv('NNV_PHASE_LOG')), nc=1; if isfield(reachOptions,'numCores'), nc=reachOptions.numCores; end; fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE reachcall %s START t=%.2f numCores=%g\n', reachOptions.reachMethod, toc(rt0), nc); fclose(fpl); end
                         ySet = nnvnet.reach(IS, reachOptions);
                     else
                         ySet = Prob_reach(net, IS, reachOptions);
@@ -373,6 +376,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                 % Verify property
                 status = verify_specification(ySet, prop);
+                if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE reach %s %.2fs status=%d\n', reachOptions.reachMethod, toc(rt0), status); fclose(fpl); end
                 if status == 1 && i_is_probabilistic(reachOptions.reachMethod)
                     % cp-star 'unsat' is PROBABILISTIC (conformal), not a sound proof -> tracked.
                     % (When NNV_QUARANTINE_CPSTAR is set, cp-star is stripped upstream so this
@@ -1022,7 +1026,9 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         reachOptions = struct; reachOptions.reachMethod = 'approx-star';
         reachOptionsList{1} = reachOptions;
         reachOptions = struct; reachOptions.reachMethod = 'exact-star';
-        reachOptions.numCores = feature('numcores');
+        % acasxu nets are tiny (5->5): parpool gives NO speedup (1 input set) and is BROKEN on some boxes
+        % (worker status-1 crash -> exact-star errored->unknown). Run serial; speed comes from the prefilter.
+        reachOptions.numCores = 1;
         reachOptionsList{2} = reachOptions;
         nRand = 500;
 
@@ -1625,7 +1631,8 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             S = load(p, 'C'); C = S.C;
             if isfield(C,'onnx_bytes') && isequal(C.onnx_bytes, d.bytes) ...
                     && abs(C.onnx_datenum - d.datenum) < 1e-9 ...
-                    && isfield(C,'nnv_ver') && strcmp(C.nnv_ver, i_nnv_ver())
+                    && isfield(C,'nnv_ver') && strcmp(C.nnv_ver, i_nnv_ver()) ...
+                    && isfield(C,'cfg_ver') && strcmp(C.cfg_ver, i_cfg_ver())   % invalidate on config change
                 net=C.net; nnvnet=C.nnvnet; needReshape=C.needReshape; reachOptionsList=C.reachOptionsList;
                 inputSize=C.inputSize; inputFormat=C.inputFormat; nRand=C.nRand; falsifyOpts=C.falsifyOpts;
                 fprintf('net cache HIT (%s)\n', p);
@@ -1641,7 +1648,7 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             C = struct();
             C.net=net; C.nnvnet=nnvnet; C.needReshape=needReshape; C.reachOptionsList=reachOptionsList;
             C.inputSize=inputSize; C.inputFormat=inputFormat; C.nRand=nRand; C.falsifyOpts=falsifyOpts;
-            C.onnx_bytes=d.bytes; C.onnx_datenum=d.datenum; C.nnv_ver=i_nnv_ver();
+            C.onnx_bytes=d.bytes; C.onnx_datenum=d.datenum; C.nnv_ver=i_nnv_ver(); C.cfg_ver=i_cfg_ver();
             tmp = [p '.tmp'];   % same dir as p; no two workers write the same onnx's cache concurrently
             save(tmp, 'C', '-v7.3');
             movefile(tmp, p, 'f');
@@ -1654,6 +1661,15 @@ end
 
 function v = i_nnv_ver()
     try, v = char(NNVVERSION()); catch, v = 'na'; end
+end
+
+function v = i_cfg_ver()
+% Config version for the net cache: the .netcache.mat stores reachOptionsList/nRand/falsifyOpts (the
+% verification CONFIG), but the cache validity guard otherwise only checks the onnx+NNV version -- so a
+% CODE change to load_vnncomp_network's config (e.g. acasxu reach ladder / numCores / PGD budget) would
+% be masked by a stale cache (served the OLD config -> wrong/slow verdicts). BUMP this string whenever
+% the config logic in load_vnncomp_network changes, to invalidate all stale caches.
+    v = '2026-06-20.acas-serial-numcores1';
 end
 
 function xRand = create_random_examples(net, lb, ub, nR, inputSize, needReshape,inputFormat)

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -261,7 +261,7 @@ else
 end
 
 cEX_time = toc(t);
-if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE import+falsify cEX_time=%.2f\n', cEX_time); fclose(fpl); end
+if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); if fpl>0, fprintf(fpl,'PHASE import+falsify cEX_time=%.2f\n', cEX_time); fclose(fpl); end, end
 
 
 %% 3) UNSAT?
@@ -344,9 +344,9 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
             % Per-instance reach time budget (opt-in NNV_REACH_BUDGET seconds): arms the SOUND cap in
             % PosLin.reach_star_exact so a slow exact-star aborts -> unknown instead of hanging. Reset
             % here per instance so a persistent-session runner gets a fresh budget each instance.
-            i_reachbud = str2double(getenv('NNV_REACH_BUDGET'));
+            clear global NNV_REACH_T0 NNV_REACH_BUD; global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+            i_reachbud = str2double(getenv('NNV_REACH_BUDGET'));   % reset EVERY instance (no budget leak in a persistent session); arm only when valid
             if isfinite(i_reachbud) && i_reachbud > 0
-                clear global NNV_REACH_T0 NNV_REACH_BUD; global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
                 NNV_REACH_T0 = tic; NNV_REACH_BUD = i_reachbud;
             end
 
@@ -370,7 +370,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
                             fprintf('reach skipped: matlab2nnv conversion failed earlier -> unknown\n');
                             status = 2; break;
                         end
-                        if ~isempty(getenv('NNV_PHASE_LOG')), nc=1; if isfield(reachOptions,'numCores'), nc=reachOptions.numCores; end; fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE reachcall %s START t=%.2f numCores=%g\n', reachOptions.reachMethod, toc(rt0), nc); fclose(fpl); end
+                        if ~isempty(getenv('NNV_PHASE_LOG')), nc=1; if isfield(reachOptions,'numCores'), nc=reachOptions.numCores; end; fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); if fpl>0, fprintf(fpl,'PHASE reachcall %s START t=%.2f numCores=%g\n', reachOptions.reachMethod, toc(rt0), nc); fclose(fpl); end, end
                         ySet = nnvnet.reach(IS, reachOptions);
                     else
                         ySet = Prob_reach(net, IS, reachOptions);
@@ -385,7 +385,7 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
 
                 % Verify property
                 status = verify_specification(ySet, prop);
-                if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); fprintf(fpl,'PHASE reach %s %.2fs status=%d\n', reachOptions.reachMethod, toc(rt0), status); fclose(fpl); end
+                if ~isempty(getenv('NNV_PHASE_LOG')), fpl=fopen(getenv('NNV_PHASE_LOG'),'a'); if fpl>0, fprintf(fpl,'PHASE reach %s %.2fs status=%d\n', reachOptions.reachMethod, toc(rt0), status); fclose(fpl); end, end
                 if status == 1 && i_is_probabilistic(reachOptions.reachMethod)
                     % cp-star 'unsat' is PROBABILISTIC (conformal), not a sound proof -> tracked.
                     % (When NNV_QUARANTINE_CPSTAR is set, cp-star is stripped upstream so this

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -341,6 +341,15 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
             % sound unsat -> emit + skip Star. Anything else falls through unchanged.
             [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, ub, prop, status, reachOptionsList, needReshape, inputSize);
 
+            % Per-instance reach time budget (opt-in NNV_REACH_BUDGET seconds): arms the SOUND cap in
+            % PosLin.reach_star_exact so a slow exact-star aborts -> unknown instead of hanging. Reset
+            % here per instance so a persistent-session runner gets a fresh budget each instance.
+            i_reachbud = str2double(getenv('NNV_REACH_BUDGET'));
+            if isfinite(i_reachbud) && i_reachbud > 0
+                clear global NNV_REACH_T0 NNV_REACH_BUD; global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+                NNV_REACH_T0 = tic; NNV_REACH_BUD = i_reachbud;
+            end
+
             while ~isempty(reachOptionsList)
 
                 reachOptions = reachOptionsList{1};
@@ -1574,7 +1583,10 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
     % (pgd_falsify is dlnetwork-gated): lsnc_relu and traffic_signs -- rely on random
     % sampling, so keep their nRand higher until PGD reaches the NN path (a follow-up).
     ftab = {
-        "acasxu",            60, 80, 30,  200
+        "acasxu",            20, 40, 8,   100   % trimmed PGD (was 60,80,30,200): the 30s budget was
+                                                % wasted in full on the many SAFE acasxu props (exact/approx
+                                                % is complete, so PGD is only a SAT accelerator). 8s still
+                                                % finds easy counterexamples. Sound (falsify = SAT-or-unknown).
         "sat_relu",          60, 100,30,  200
         "cersyve",           30, 50, 4,   150
         "lsnc_relu",         50, 80, 4,   500   % manifest: no PGD -> random is primary


### PR DESCRIPTION
Makes ACAS-Xu actually decidable+fast on the competition pathway. Profiling (net 1_1/prop_3, gold=UNSAT;
NNV had returned **unknown in ~140s**) found the acasxu failures were NOT primarily algorithmic:

## Root causes + fixes
1. **Broken parpool crashed exact-star.** acasxu exact-star ran `numCores=feature('numcores')` ->
   `NN.start_pool` -> `parpool` THREW on boxes with a broken local cluster ("MATLAB worker shut down ...
   status 1") -> caught -> **UNKNOWN**. `NN.start_pool` now catches a parpool failure and **falls back to
   serial** (numCores=1; the dispatchers set `reachOption='parallel'` only if a pool actually started).
   General, **sound** (serial == parallel result) robustness fix benefiting every benchmark on such boxes.
2. **acasxu exact-star -> serial** (numCores=1): tiny 5->5 nets get no pool speedup anyway.
3. **Stale net-cache served the OLD config.** `.netcache.mat` cached `reachOptionsList` but its validity
   guard only checked onnx+NNV version -> a config code-change was masked. Added a **`cfg_ver` guard**.
4. **PGD budget 30s->8s** for acasxu: the 30s falsify budget was wasted in full on the many SAFE props
   (exact/approx is complete -> PGD is only a SAT accelerator). Sound (falsify = SAT-or-unknown, witness-gated).
5. **Sound per-instance reach time-cap** (opt-in `NNV_REACH_BUDGET`): `PosLin.reach_star_exact` aborts ->
   harness maps to UNKNOWN, turning hard-instance hangs into fast unknowns + enabling a persistent-session
   sweep runner. No-op unless the env is set (competition default unchanged).
Plus gated diagnostics (`NNV_PHASE_LOG`, `NNV_LP_COUNT`), no-ops unless set.

## Validation (sound-or-unknown, 0 wrong)
16-instance acasxu batch (props 1-4 x nets 1_1/2_3/3_5/4_5), persistent session, `NNV_REACH_BUDGET=120`:
**8/16 decided in 1.6-10.9s each, 0 wrong vs alpha-beta-CROWN gold** (3 sat + 5 unsat); 8/16 sound
`unknown` (the hard nets, at the cap). *Before these fixes every acasxu instance crashed->unknown or
hung->timeout.* acasxu uses exact-star (CPU Star/PosLin) -- not the gpu_bab path -- so the soundness
suite + CI regression cover the changed reach code.

Remaining (separate, deeper work): the hard nets need the nnenum zonotope prefilter (carry+contract Z);
the cheap box-only LP-free shortcut explodes (LPs->~0 but stars->16x), confirmed empirically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)