### PR TITLE
acas Phase 0 reliability: prop_6 ERR fix + parfor reach-budget arming + sound verify_specification/PosLin guards

### DIFF
--- a/code/nnv/engine/nn/funcs/PosLin.m
+++ b/code/nnv/engine/nn/funcs/PosLin.m
@@ -401,12 +401,23 @@ classdef PosLin
                     
                     In = Star(V, I.C, I.d, I.predicate_lb, I.predicate_ub, new_Z);                    
                     map = find(lb < 0 & ub > 0);
-                    m = length(map);                    
+                    m = length(map);
+                    i_star_cap = str2double(getenv('NNV_STAR_CAP'));  % optional belt-and-suspenders cap (NaN if unset)
                     for i=1:m
                         if strcmp(dis_opt, 'display')
                             fprintf('\nPerforming exact PosLin_%d operation using Star', map(i));
                         end
                         In = PosLin.stepReachMultipleInputs(In, map(i), option, lp_solver);
+                        % SOUND within-layer caps: a single layer with many unstable neurons can blow the
+                        % time budget or memory before the next per-layer entry check; abort -> unknown
+                        % rather than overrun/OOM. Both are no-ops unless the env/globals are armed.
+                        if ~isempty(NNV_REACH_BUD) && NNV_REACH_BUD > 0 && ~isempty(NNV_REACH_T0) ...
+                                && toc(NNV_REACH_T0) > NNV_REACH_BUD
+                            error('NNV:reachBudget', 'reach exceeded time budget (%.0fs) -> unknown', NNV_REACH_BUD);
+                        end
+                        if ~isnan(i_star_cap) && i_star_cap > 0 && numel(In) > i_star_cap
+                            error('NNV:starCap', 'exact-star cardinality %d exceeded cap (%d) -> unknown', numel(In), i_star_cap);
+                        end
                     end
                     S = In;
                     if ~isempty(getenv('NNV_LP_COUNT')), global NNV_LP_N; lpn=NNV_LP_N; if isempty(lpn), lpn=0; end; fz=fopen(getenv('NNV_LP_COUNT'),'a'); if fz>0, fprintf(fz,'reluLayer in=%d unstable=%d out=%d cumLP=%d\n', numel(I), m, numel(In), lpn); fclose(fz); end, end %#ok<TLEV>

--- a/code/nnv/engine/utils/verify_specification.m
+++ b/code/nnv/engine/utils/verify_specification.m
@@ -17,7 +17,16 @@ function result = verify_specification(reachSet, property)
 
     R = reachSet;
     nr = length(R);    % number of output sets (for approx should be 1)
-    
+
+    % SOUND per-instance reach time budget (opt-in; same globals PosLin.reach_star_exact uses,
+    % armed by the harness / i_arm_reach_budget). The disjunctive-output path below is
+    % O(np disjuncts x nr stars) intersectHalfSpace/LP calls with no inherent bound, so on an
+    % exact-star set with many stars it can run far past the per-instance budget (the acasxu
+    % prop_7 overrun that previously needed an OS kill). When the budget is exceeded we return 2
+    % (UNKNOWN) -- sound, claims nothing -- rather than grind on. No-op unless the globals are set.
+    global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+    i_budget_on = ~isempty(NNV_REACH_BUD) && NNV_REACH_BUD > 0 && ~isempty(NNV_REACH_T0);
+
     % Process property to verify
     if iscell(property) % created from vnnlib (one or multiple halfSpaces)
         property = property{1};
@@ -28,6 +37,7 @@ function result = verify_specification(reachSet, property)
     np = length(property);
     if np == 1 % only one halfspace
         for k = 1:nr
+            if i_budget_on && toc(NNV_REACH_T0) > NNV_REACH_BUD, result = 2; return; end % budget -> sound unknown
             Set = R(k);
             if ~isa(Set, "Star")
                 Set = Set.toStar;
@@ -48,6 +58,7 @@ function result = verify_specification(reachSet, property)
         result = 1; % start assuming property is unsat (no intersection)
         while cp <= np % multiple halfspaces, which means OR assertion
             for k = 1:nr % check every reach set vs OR property
+                if i_budget_on && toc(NNV_REACH_T0) > NNV_REACH_BUD, result = 2; return; end % budget -> sound unknown
                 Set = R(k);
                 if ~isa(Set, "Star")
                     Set = Set.toStar;

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -5,6 +5,15 @@ function [status, tTime] = run_vnncomp_instance(category, onnx, vnnlib, outputfi
 t = tic;
 status = 2; % unknown (to start with)
 
+% SOUNDNESS HARDENING (persistent/shared-session safety): the per-instance reach budget lives in GLOBALS
+% (NNV_REACH_T0/_BUD) that ANOTHER verifier entry point (NN.verify_vnnlib / NN.verify_robustness) reads via
+% verify_specification, where under exactReach a result==2 is promoted to 0 (sat). A budget left ARMED after
+% this instance could make a LATER exactReach call in the SAME MATLAB session read a "gave-up -> 2" as a
+% FALSE sat. So clear any stale budget on ENTRY and guarantee teardown on EXIT (normal return OR error) via
+% onCleanup. No effect on the scored one-process-per-instance harness; matters for the persistent sweep.
+clear global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+reachBudgetCleanup = onCleanup(@() i_arm_reach_budget(NaN)); %#ok<NASGU> % disarm budget globals on any exit
+
 % disp("We are running...")
 
 %% 0) cctsdb_yolo: complete-enumeration path (bypasses net import + reach)
@@ -406,9 +415,12 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
     elseif isa(lb, "cell") && length(lb) == length(prop) % multiple inputs, multiple outputs
         
         local_status = 2*ones(length(lb),1); % track status for each specification in the vnnlib
-        
+        i_reachbud = str2double(getenv('NNV_REACH_BUDGET'));  % broadcast the per-instance reach budget into the parfor
+                                                             % (globals do not cross to workers; arms the SOUND PosLin cap per worker)
+
         parfor spc = 1:length(lb) % We can compute these in parallel for faster computation
 
+            i_arm_reach_budget(i_reachbud);  % arm NNV_REACH_T0/_BUD on THIS worker (global decls are illegal in a parfor body -> helper)
             lb_spc = lb{spc};
             ub_spc = ub{spc};
 
@@ -485,9 +497,14 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
     elseif isa(lb, "cell") && length(prop) == 1 % one specification, multiple input definitions 
 
         local_status = 2*ones(length(lb),1); % track status for each specification in the vnnlib, initialize as unknown
-        
+        i_reachbud = str2double(getenv('NNV_REACH_BUDGET'));  % broadcast the per-instance reach budget into the parfor:
+                                                             % globals set on the client do NOT cross to parfor workers,
+                                                             % so without this the SOUND cap in PosLin.reach_star_exact is a
+                                                             % no-op on every multi-input-box prop (disjunctive-input overruns).
+
         parfor spc = 1:length(lb) % We can compute these in parallel for faster computation
 
+            i_arm_reach_budget(i_reachbud);  % arm NNV_REACH_T0/_BUD on THIS worker (global decls are illegal in a parfor body -> helper)
             reachOptPar = reachOptionsList;
             
             lb_spc = lb{spc};
@@ -522,8 +539,16 @@ if status == 2 && ~quickRun % no counterexample found and supported for reachabi
                             ySet = Prob_reach(net, IS, reachOptions);
                         end
 
-                        % Add verification status
-                        tempStatus = verify_specification(ySet, prop(spc));
+                        % Add verification status.
+                        % This branch is "one output spec, MULTIPLE input boxes"
+                        % (length(prop)==1, lb is a cell): each input box is verified
+                        % against the SINGLE shared spec prop{1}. The old prop(spc) made
+                        % parfor try to SLICE prop by spc=1..length(lb), but prop has only
+                        % one element -> "Index exceeds the number of array elements" thrown
+                        % at the parfor supply stage (OUTSIDE this try/catch), surfacing as
+                        % an uncaught ERR for disjunctive-input props (e.g. acasxu prop_6).
+                        % prop(1) is a constant index -> parfor broadcasts prop, no slicing.
+                        tempStatus = verify_specification(ySet, prop(1));
                         if tempStatus == 1 && i_is_probabilistic(reachOptions.reachMethod)
                             i_log_cpstar(onnx);   % parity: parfor cp-star verdicts were previously unlogged
                         end
@@ -567,9 +592,9 @@ vT = toc(vT);
 
 tTime = toc(t); % save total computation time
 
-% if status == 2 && strcmp(reachOptions.reachMethod, 'exact-star')
-%     status = 0;
-% end
+% (removed) a dead, commented-out "status==2 && exact-star -> status=0" promotion used to live here.
+% Deleted as a soundness trap: re-enabling it would turn any exact-star UNKNOWN (incl. a sound budget/cap
+% abort) into a FALSE sat. Unknown must never be promoted to a verdict.
 
 disp("Verification result: " + string(status));
 disp("Counterexample search time: " + string(cEX_time));
@@ -765,6 +790,21 @@ function ok = is_nnvnet_valid(nnvnet)
 % matlab2nnv conversion fails inside a try/catch). We need an NN object,
 % not a string sentinel.
     ok = ~isempty(nnvnet) && ~ischar(nnvnet) && ~isstring(nnvnet);
+end
+
+function i_arm_reach_budget(bud)
+% Arm (or clear) the SOUND per-instance reach time budget on the CURRENT MATLAB
+% workspace by setting the globals PosLin.reach_star_exact / verify_specification read.
+% Routed through a helper because `global` declarations are ILLEGAL inside a parfor
+% body -- calling this from a parfor iteration sets the globals on that WORKER (where
+% the reach actually runs), which a client-side assignment cannot do (globals do not
+% cross the parfor boundary). Sound: an exceeded budget only ever aborts to unknown.
+    global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
+    if isfinite(bud) && bud > 0
+        NNV_REACH_T0 = tic; NNV_REACH_BUD = bud;
+    else
+        NNV_REACH_T0 = []; NNV_REACH_BUD = [];   % no budget configured -> cap stays a no-op
+    end
 end
 
 function i_log_cpstar(onnx)


### PR DESCRIPTION
## ACAS-Xu Phase 0 — reliability (sound-or-unknown, 0 wrong)

Turns two ACAS failure modes into **sound** outcomes and closes per-instance-timeout gaps that protect the whole sweep. No verdict can change to wrong; the worst case is a lost decision (sound unknown).

### Fixes
- **prop_6 ERR** (uncaught `Index exceeds the number of array elements`): the "one output spec, multiple input boxes" branch (`length(prop)==1`, cell `lb`) called `verify_specification(ySet, prop(spc))` with `spc=1..length(lb)`; `prop` has 1 element, so `parfor` tried to **slice** `prop` by `spc` → error thrown at the parfor **supply** stage, *outside* the body try/catch → uncaught ERR. Fixed to `prop(1)` (constant index → broadcast); parser-confirmed this is the single shared spec for every box.
- **prop_7 999s overrun**: `verify_specification`'s disjunctive-output loop is `O(np × nr)` `intersectHalfSpace` with no bound. Added a **sound budget guard** (returns `2`=unknown when the armed `NNV_REACH_T0/_BUD` budget is exceeded). No-op when unarmed → inert for all non-acas callers.
- **parfor reach budget**: globals don't cross to parfor workers and `global` is illegal in a parfor body, so the `PosLin` reach cap was a no-op on every multi-input-box prop. Now armed per-worker via a helper (`i_arm_reach_budget`).
- **PosLin within-layer caps**: re-check the time budget + optional `NNV_STAR_CAP` inside the neuron loop; both `error()` → caught → unknown. `NNV_STAR_CAP` ships **inert** (unset).

### Soundness hardening (from adversarial review)
- Clear `NNV_REACH_T0/_BUD` on entry + `onCleanup` teardown on any exit → a budget can't leak to a later `NN.verify_*`/exactReach call (which promotes `result==2 → 0`=sat) in a persistent session. Verified: budget global `== []` after each run.
- Deleted the dead commented-out `status==2 && exact-star → status=0` promotion (a one-uncomment false-sat trap).

### Validation
- Per-instance: 1_1/prop_6 **ERR→unknown**; 1_9/prop_7 **999s→81s unknown**; 4_5/prop_3 **unsat→unsat**; 3_3/prop_2 unknown→unknown. **0 wrong, 0 ERR, 0 regression.**
- Routing test **11/11**; PosLin reach tests pass with no budget env (default no-op).
- 4-skeptic adversarial soundness review: **GO/SHIP**, 0-wrong invariant preserved on every reachable path.
- Full 186 gold-gated regression sweep: in progress (gate = 0 gold disagreements AND decided ≥ 96 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)