### PR TITLE
acas: raise BaB timeCap 30->60 -> 45/45 prop_1 (178/186), sound, per-category

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -872,7 +872,11 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
                 fprintf('acas BaB pre-check: orientation guard skip -> Star reach\n');
                 return;
             end
-            tcap = 30;     ev = str2double(getenv('NNV_ACAS_BAB_TIMECAP'));  if isfinite(ev) && ev > 0,  tcap = ev; end
+            % Default BaB timeCap raised 30 -> 60s (per-category acasxu, NOT per-instance): the 3 hardest
+            % prop_1 nets (3_9/4_7/4_9) certify robust in 19-43s but were cut off at 30s -> raising to 60s
+            % yields 45/45 prop_1 (solo/competition). Sound: more FP64 BaB time only adds certs, never a
+            % wrong verdict. 60s leaves room under the ~116s per-instance budget (a cert skips Star).
+            tcap = 60;     ev = str2double(getenv('NNV_ACAS_BAB_TIMECAP'));  if isfinite(ev) && ev > 0,  tcap = ev; end
             mnod = 300000; ev = str2double(getenv('NNV_ACAS_BAB_MAXNODES')); if isfinite(ev) && ev >= 1, mnod = ev; end
             babOpts = struct('precision','double','maxNodes',mnod,'timeCap',tcap);
             if iscell(lb)                                 % defensive: each input set must be robust (single box is the usual acas call path)


### PR DESCRIPTION
Raises the per-category acasxu BaB `timeCap` default 30->60s. The 3 still-unknown prop_1 nets (3_9/4_7/4_9) are budget-limited (certify robust in 19-43s BaB); 60s certifies all three -> **45/45 prop_1, 178/186 in competition**.

**Sound + no regression:** more FP64 BaB time only adds certs (the 47/47 false-robust gate is timeCap-independent); the slowest *decided* instance was 36.8s (median 14s), so +30s worst-case keeps every decided net well under the ~116s budget. Per-category NNV-side heuristic (not per-instance, benchmark files untouched) -> within VNN-COMP rules.

Validated solo: 3_9/4_7/4_9 prop_1 -> unsat; 1_1/prop_1 -> unsat (regression intact); 1_2/prop_2 -> sat; 0 wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)