### PR TITLE
acas/competition: wire the official per-instance timeout into NNV's internal reach/BaB caps

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/execute.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/execute.py
@@ -74,6 +74,18 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
     print("Paths added (NNV root: %s; prioritized submission dir: %s)" % (nnv_root, here))
     ## eng.addpath(eng.genpath('/root/Documents/MATLAB/SupportPackages/R2024a')) # This is where the support packages get installed from mpm
 
+    # COMPETITION TIMEOUT WIRING: drive NNV's INTERNAL sound caps from the OFFICIAL per-instance timeout
+    # (the toolkit reads the benchmark instances.csv and passes it as run_instance.sh $6 -> here), so the
+    # Star/PosLin reach and the acas BaB abort to a sound IN-TIME 'unknown' rather than only being hard-
+    # killed by future.result(timeout) below (which remains the backstop). These are the SAME env knobs the
+    # dev sweeps use -- only the SOURCE of the budget changes (official timeout vs a fixed dev value), so the
+    # verification config/algorithm is unchanged. Per-category / NNV-side, NOT per-instance tuning. Set via
+    # eng.setenv so the value lands in the MATLAB engine process (os.environ set after start_matlab would not).
+    to = float(timeout)
+    eng.setenv('NNV_REACH_BUDGET', '%.3f' % max(1.0, 0.95 * to), nargout=0)   # reach/verify cap ~ official timeout
+    if 'NNV_ACAS_BAB_TIMECAP' not in os.environ:                              # let an explicit export win
+        eng.setenv('NNV_ACAS_BAB_TIMECAP', '%.3f' % min(60.0, max(2.0, 0.5 * to)), nargout=0)  # acas BaB share of the budget
+
     status = 2 #initialize with an 'Unknown' status
     future = eng.run_vnncomp_instance(category, onnx, vnnlib, outputlocation, nargout = 2, background=True)
 


### PR DESCRIPTION
## Competition timeout wiring

At competition the toolkit passes the official per-instance timeout (from the benchmark `instances.csv`) as `run_instance.sh $6` → `execute.py`. Previously that only drove the **external** hard kill (`future.result(timeout)`); NNV's **internal** sound caps (`NNV_REACH_BUDGET`, `NNV_ACAS_BAB_TIMECAP`) were unset in competition, so reach ran unbounded until the external kill.

Now `execute.py` sets those caps from the official timeout via `eng.setenv` (in the MATLAB engine process), so reach/BaB abort to a sound **in-time `unknown`**; `future.result(timeout)` remains the backstop.
- `NNV_REACH_BUDGET = 0.95*timeout`
- `NNV_ACAS_BAB_TIMECAP = min(60, 0.5*timeout)` (unless explicitly exported) — covers the 43s prop_1 certs at the 116s acas timeout, scales down for shorter timeouts.

**Same env knobs the dev sweeps use** → verification config/algorithm unchanged; only the *source* of the budget differs. NNV-side per-category heuristic, **not** per-instance tuning, benchmark files untouched → within VNN-COMP rules.

**Validated** (MATLAB side, with the derived 116s-timeout values reach=110.2/BaB=58): 1_1/prop_1 → unsat (19s, in-time); 3_9/prop_1 → unsat (55s, in-time, the +3 net); 3_3/prop_2 → unknown (hard, external-kill-bounded); **0 wrong**. `execute.py` py_compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)