### PR TITLE
competition: quarantine cp-star probabilistic verdicts (0-wrong insurance)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
@@ -35,6 +35,13 @@ fi
 export NNV_CONV_TRUST_FP32=1
 export NNV_CONV_NO_STAR=1
 export NNV_CONV_FRONTIER=512
+# QUARANTINE_CPSTAR: strip the PROBABILISTIC (conformal) cp-star reach method so a cp-star 'unsat' can
+# never be emitted as a sound verdict. cp-star is NOT an FP64 proof -- under the absolute 0-wrong rule a
+# probabilistic unsat is a latent -150 (correct only with some confidence -> over the field some would be
+# wrong). STRICTLY SOUND: only ever converts a cp-star unsat -> unknown (never adds a verdict); the sound
+# FP64 / GPU-BaB / exact paths still decide what they can. Competition-scoped (set here, not the code
+# default) so tests / other callers are unaffected.
+export NNV_QUARANTINE_CPSTAR=1
 
 echo "Running ${TOOL_NAME} on '$CATEGORY' (onnx='$ONNX_FILE', vnnlib='$VNNLIB_FILE', timeout=${TIMEOUT}s)"
 python3 "$EXECUTE" 'run_instance' "$CATEGORY" "$ONNX_FILE" "$VNNLIB_FILE" "$TIMEOUT" "$RESULTS_FILE"


### PR DESCRIPTION
Exports `NNV_QUARANTINE_CPSTAR=1` in run_instance.sh so probabilistic (conformal) cp-star unsats are never emitted as sound verdicts — a latent −150 surface under the 0-wrong rule. **Strictly sound** (only cp-star unsat→unknown; sound FP64/GPU-BaB/exact paths still decide). Competition-scoped (env, not code default) → tests/other callers unaffected. The overnight full sweep (via run_instance.sh) inherits it and will quantify the expected ~0 point cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)