### PR TITLE
safenlp: cap falsify-first PGD budget so the reach proof keeps its window within the 20s timeout

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
@@ -43,5 +43,17 @@ export NNV_CONV_FRONTIER=512
 # default) so tests / other callers are unaffected.
 export NNV_QUARANTINE_CPSTAR=1
 
+# FALSIFY_MAXTIME: cap the falsify-first PGD budget so the SOUND reach proof keeps its window within the
+# OFFICIAL timeout. safenlp's ftab PGD budget (30s) EXCEEDS its 20s timeout, so on a ROBUST instance PGD
+# burns the whole wall finding nothing and the external kill fires BEFORE the ~0.4s reach proof runs -> a
+# decidable unsat is lost to timeout. Measured: 25/25 over-timeout safenlp unsats recover (decide at
+# 8.5-14s) and 10/10 sat are preserved (found <3.3s), 0 gold-contradictions. STRICTLY SOUND: less PGD only
+# ever yields fewer SAT (-> unknown), never a wrong verdict; reach is untouched. Scoped to safenlp (the one
+# category where PGD>=timeout AND reach is sub-second); NOT applied to falsify-primary cats (cgan/sat_relu/
+# traffic_signs) whose SAT need the full PGD budget, nor to reach-slow cats (cora) the cap can't help.
+if [ "$CATEGORY" = "safenlp_2024" ]; then
+    export NNV_FALSIFY_MAXTIME=8
+fi
+
 echo "Running ${TOOL_NAME} on '$CATEGORY' (onnx='$ONNX_FILE', vnnlib='$VNNLIB_FILE', timeout=${TIMEOUT}s)"
 python3 "$EXECUTE" 'run_instance' "$CATEGORY" "$ONNX_FILE" "$VNNLIB_FILE" "$TIMEOUT" "$RESULTS_FILE"

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -115,6 +115,23 @@ try
     if isempty(inputSize)
         inputSize = net.Layers(1, 1).InputSize;
     end
+
+    % Competition lever (NNV_FALSIFY_MAXTIME, seconds): cap the falsify-first PGD budget so the SOUND reach
+    % ladder keeps its window within the OFFICIAL per-instance timeout. Several ftab rows set a PGD max_time
+    % >= the timeout (safenlp 30s/to=20s, cora 30s/to=30s): on a ROBUST instance PGD burns the whole wall
+    % finding nothing and the external kill fires BEFORE the (often <1s) reach proof -> a decidable unsat is
+    % lost to timeout. Capping PGD leaves reach its window. STRICTLY SOUND: falsification is SAT-or-unknown
+    % only, so less PGD only ever yields fewer SAT (-> unknown), never a wrong verdict; reach is untouched.
+    % Applied HERE (after the cached load) so it covers BOTH the cache-hit and cache-miss paths -- the cached
+    % falsifyOpts otherwise carries the un-capped ftab max_time. No-op when unset (tests/other callers
+    % unaffected); the competition harness sets it, mirroring how execute.py drives NNV_REACH_BUDGET.
+    fmt = getenv('NNV_FALSIFY_MAXTIME');
+    if ~isempty(fmt) && isstruct(falsifyOpts) && isfield(falsifyOpts, 'max_time')
+        fv = str2double(fmt);
+        if isfinite(fv) && fv > 0
+            falsifyOpts.max_time = min(falsifyOpts.max_time, fv);
+        end
+    end
 catch loadME
     fprintf('LOAD FAILED for %s -> unknown: %s\n', category, loadME.message);
     status = 2; tTime = toc(t);


### PR DESCRIPTION
## Problem (a sound −0 score leak, found during the 2026-06-21 full sweep)

safenlp's per-category PGD falsify budget in the ftab is **30 s**, but its **official timeout is 20 s**.
On a **robust (unsat)** safenlp instance the falsify-first PGD runs its full 30 s finding nothing, then the
sound reach proof (which takes **~0.4 s** for these FC nets) would decide `unsat` — but the external 20 s
competition kill fires first, so a **decidable unsat is lost to timeout**.

Diagnosed via the standalone split on a gold-`unsat` safenlp instance:
`Counterexample search time: 30.45s` / `Reachability time: 0.42s` → killed at 20 s before reach runs.

## Fix

- `run_vnncomp_instance.m`: a `NNV_FALSIFY_MAXTIME` env override that caps `falsifyOpts.max_time`. Applied
  **after the cached network load** so it covers the cache-hit path too (the cached `falsifyOpts` otherwise
  carries the un-capped ftab value). No-op when unset → tests / other callers unaffected.
- `run_instance.sh`: exports `NNV_FALSIFY_MAXTIME=8` **for `safenlp_2024` only**, mirroring how
  `execute.py` already drives `NNV_REACH_BUDGET` from the official timeout.

## Soundness

**Strictly sound.** Falsification is SAT-or-unknown only (witness gated by `validate_witness` + onnxruntime
replay), so a smaller PGD budget can only ever yield **fewer SAT (→ unknown), never a wrong verdict**;
the reach ladder is untouched. No-op outside safenlp.

Scoped to safenlp — the one category where PGD budget ≥ timeout **and** reach is sub-second. **Not** applied
to falsify-primary cats (`cgan`/`sat_relu`/`traffic_signs`) whose SAT need the full PGD budget, nor to
reach-slow cats (`cora`, verified) the cap cannot help.

## Evidence (gold-gated vs vnncomp2025 α-β-CROWN)

- 35-instance sample: **25/25** over-timeout unsats recover (decide 8.5–14 s), **10/10** sat preserved
  (found < 3.3 s), **0** gold-contradictions.
- **Full 1080-instance safenlp bank** with the cap: **895 decided (633 sat + 262 unsat), ALL within the
  20 s timeout, 0 wrong.** Without the cap, only **635** decided within 20 s (the 262 unsats ran 29–36 s →
  killed). **Net: +260 competition-faithful safenlp decisions, sound** (≈3 sat that needed > 8 s PGD become
  a sound `unknown`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)