### PR TITLE
Fix dist_shift/relusplitter codegen-package netcache resilience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,11 @@ code/nnv/examples/Tutorial/NN/WeizmannHorse/
 code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
 code/nnv/examples/Submission/VNN_COMP2025/results_*.md
 code/nnv/examples/Submission/VNN_COMP2025/+*/
+# VNN-COMP 2026: importNetworkFromONNX writes a generated custom-layer +package (named after the onnx,
+# e.g. +mnist_concat, +cifar_biasfield_*, +mnist_fc_*) into code/nnv (startup_nnv's genpath root) so the
+# per-onnx .netcache.mat can reconstruct its custom layers. These are REQUIRED RUNTIME ARTIFACTS
+# (prepare_instance.sh pre-generates them; never delete the live copy) but are regenerated, not source.
+code/nnv/+*/
 code/nnv/tests/nn/layers/+pgd_2_3_16/
 code/nnv/tests/utils/+ACASXU_run2a_1_1_batch_2000/
 code/nnv/tests/utils/+cartpole/

--- a/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/prepare_instance.sh
@@ -63,8 +63,13 @@ build_netcache() {
     local cache="${onnx}.netcache.mat"
     [ -f "${cache}" ] && return
     echo "Pre-building NNV net cache: ${cache}"
+    # cwd stays at code/nnv (NNV_ROOT) for the import: importNetworkFromONNX writes the generated
+    # custom-layer +package into cwd, and code/nnv is what startup_nnv genpath'd, so the package lands
+    # ON the path and PERSISTS for every later timed run's netcache load (without it MATLAB silently
+    # substitutes default layers -> degraded net -> 'unknown'). Keeping it in code/nnv root (not the
+    # VNN_COMP2026 subdir) matches the .gitignore rule (code/nnv/+*/) and the cwd==code/nnv assumption.
     NNV_PREP_CACHE=1 "${MATLAB_BIN}" -batch \
-        "cd('${NNV_ROOT}'); startup_nnv; addpath('${NNV_ROOT}/examples/Submission/VNN_COMP2026'); cd('${NNV_ROOT}/examples/Submission/VNN_COMP2026'); try, run_vnncomp_instance('${cat}','${onnx}','${vnnlib}',tempname); catch ME, fprintf(2,'%s\n',ME.message); end" \
+        "cd('${NNV_ROOT}'); startup_nnv; addpath('${NNV_ROOT}/examples/Submission/VNN_COMP2026'); try, run_vnncomp_instance('${cat}','${onnx}','${vnnlib}',tempname); catch ME, fprintf(2,'%s\n',ME.message); end" \
         >/dev/null 2>&1 || echo "WARN: net cache pre-build failed; run_instance converts on first use."
 }
 # matlab2nnv (non-manifest) categories whose single (or few) network(s) are reused across many

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -14,6 +14,21 @@ status = 2; % unknown (to start with)
 clear global NNV_REACH_T0 NNV_REACH_BUD %#ok<GVMIS>
 reachBudgetCleanup = onCleanup(@() i_arm_reach_budget(NaN)); %#ok<NASGU> % disarm budget globals on any exit
 
+% CODEGEN PACKAGES (custom-layer +package, e.g. +mnist_concat / +<relusplitter-onnx>). importNetworkFromONNX
+% writes a GENERATED custom-layer +package (named after the onnx) into the CURRENT FOLDER, and the per-onnx
+% netcache (.netcache.mat, built at prepare) stores a dlnetwork that REFERENCES those custom-layer classes.
+% So a cache load only reconstructs the real net when that +package is present on the MATLAB path -- if it is
+% missing, MATLAB SILENTLY substitutes default layer objects ("Unable to load instances of class ... default
+% objects will be substituted") and the net degrades to a useless 'unknown'. The packages are therefore
+% REQUIRED ARTIFACTS: prepare_instance.sh pre-generates them into code/nnv (on startup_nnv's genpath) and they
+% must persist (never delete; .gitignore'd). At a timed run the netcache HITS, so importNetworkFromONNX is NOT
+% re-invoked -> no regeneration, no concurrent-write 'getExternalLayers' collision, and no per-instance cwd
+% juggling is needed. (An earlier "give each instance a fresh scratch cwd" isolation was REMOVED: it sent any
+% regeneration to an ephemeral tempdir that was then deleted, so the NEXT process's cache load could not find
+% the package -> silent degrade -> 'unknown'. It was incompatible with the netcache and is the regression that
+% broke dist_shift + relusplitter.) Competition runs one process per instance (no concurrent import), so a
+% rare cache miss regenerates into code/nnv safely; the sweep relies on a serially pre-warmed cache.
+
 % disp("We are running...")
 
 %% 0) cctsdb_yolo: complete-enumeration path (bypasses net import + reach)
@@ -1786,7 +1801,20 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
     d = dir(char(onnx));
     if isfile(p) && ~isempty(d)
         try
+            % SELF-HEAL against a missing custom-layer +package. The cache stores a dlnetwork that
+            % REFERENCES importer-generated custom-layer classes (+<onnx>, e.g. +mnist_concat). If that
+            % package is absent from the path, load() does NOT error -- it SILENTLY substitutes default
+            % layer objects (warning "...Default objects will be substituted") and the net degrades to a
+            % useless 'unknown'. Force warnings ON so lastwarn captures the substitution, then treat a
+            % degraded load as a cache MISS: the fresh import below regenerates the +package AND re-warms
+            % the cache. Sound either way (worst case = an extra re-import); makes a deleted/absent package
+            % auto-recover instead of silently producing unknowns in a sweep or the competition.
+            owarn = warning('on','all'); lastwarn('');
             S = load(p, 'C'); C = S.C;
+            wmsg = lastwarn; warning(owarn);
+            if contains(wmsg,'Default objects will be substituted') || contains(wmsg,'Unable to load instances of class')
+                error('netcache:degraded','custom-layer +package missing -> re-import (%s)', wmsg);
+            end
             if isfield(C,'onnx_bytes') && isequal(C.onnx_bytes, d.bytes) ...
                     && abs(C.onnx_datenum - d.datenum) < 1e-9 ...
                     && isfield(C,'nnv_ver') && strcmp(C.nnv_ver, i_nnv_ver()) ...

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1809,9 +1809,12 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             % degraded load as a cache MISS: the fresh import below regenerates the +package AND re-warms
             % the cache. Sound either way (worst case = an extra re-import); makes a deleted/absent package
             % auto-recover instead of silently producing unknowns in a sweep or the competition.
-            owarn = warning('on','all'); lastwarn('');
+            owarn = warning('on','all');
+            restoreWarn = onCleanup(@() warning(owarn));  % restore warning state even if load() THROWS
+            lastwarn('');
             S = load(p, 'C'); C = S.C;
-            wmsg = lastwarn; warning(owarn);
+            wmsg = lastwarn;
+            clear restoreWarn;                            % success path: restore immediately
             if contains(wmsg,'Default objects will be substituted') || contains(wmsg,'Unable to load instances of class')
                 error('netcache:degraded','custom-layer +package missing -> re-import (%s)', wmsg);
             end


### PR DESCRIPTION
## Problem
`importNetworkFromONNX` writes a generated **custom-layer `+package`** (named after the onnx, e.g. `+mnist_concat`, `+cifar_biasfield_*`, `+mnist_fc_*`) into the cwd, and the per-onnx `.netcache.mat` stores a `dlnetwork` that **references those custom-layer classes**. So the `+package` is a **required runtime artifact**:

- If it's missing, `load()` does **not** error — MATLAB **silently substitutes default layer objects** (`"Default objects will be substituted"`) → degraded net → useless `unknown` (broke **dist_shift**: 0/72 decided).
- On a concurrent cache-miss re-import, the half-written package collides → `Undefined function 'getExternalLayers'` (broke **relusplitter**: 70 crashes).

A prior "codegen isolation" cd made it worse: it regenerated packages into **per-process tempdirs that were then deleted**, so the next process's cache load could not resolve the classes — fundamentally incompatible with the netcache, and the proximate regression.

## Fix
- **`run_vnncomp_instance.m`**: remove the ephemeral-tempdir codegen-isolation cd; add a **self-heal** to `i_load_vnncomp_network_cached` — force warnings on, capture `lastwarn`, and treat a degraded (default-substituted) load as a cache MISS → fresh re-import regenerates the `+package` and re-warms the cache. A missing package now **auto-recovers** instead of silently producing `unknown`.
- **`prepare_instance.sh`**: keep cwd at `code/nnv` when pre-building the netcache, so the generated `+package` lands on `startup_nnv`'s genpath and **persists** for every later timed run (competition runs one process per instance → no concurrent import).
- **`.gitignore`**: ignore `code/nnv/+*/` (importer-generated; regenerated, not source — *untracked ≠ deletable*).

## Validation
- N=4 concurrent fresh processes over dist_shift + relusplitter → **every load a clean cache HIT, 0 degraded, 0 getExternalLayers**.
- dist_shift decides unsat; **54/54 decided match alpha-beta-CROWN gold**.
- Self-heal: delete a package → run → auto re-imports, regenerates it, decides correctly.
- Full re-sweep of the 412 affected instances: **0 errors, 0 wrong** (raw + faithful gold-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)