### PR TITLE
linearizenn: route to the sound FP64 input-bisection halfspace BaB (+58 decided, 0 wrong)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -901,7 +901,7 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
     % 0.05-5.9s). Sound-or-unknown by construction (children partition the parent box): validated
     % 0/5 gold-SAT falsely certified (they hit the minWidth barrier -> 'unknown' -> upstream PGD
     % finds the sat), gold-UNSAT certified via partition-covering FP64. Backstop is gated to these.
-    isInputBab = contains(category,"tllverifybench") || contains(category,"cersyve");
+    isInputBab = contains(category,"tllverifybench") || contains(category,"cersyve") || contains(category,"linearize");
     % ACAS-Xu (Phase 2): low-dim (5-input) pure-ReLU, general-halfspace specs. Certified via FP64
     % input-bisection CROWN BaB (gpu_bab_halfspace_input_bab). That routine targets product/bilinear
     % nets, but for the 5-D acas boxes input bisection DOES converge (validated: prop_1 8/8 certified,


### PR DESCRIPTION
## What
linearizenn nets are pure-ReLU FC with general-halfspace specs (structurally ACAS-like). They were already in the `isHalfspace` gate but only got the root-only CROWN check (decides few). Add linearizenn to the **`isInputBab`** gate so the acas-proven FP64 input-bisection CROWN BaB backstop (`i_halfspace_input_bab` → `gpu_bab_halfspace_input_bab`, merged in #408) runs when the root check leaves `status==2`. **Strictly additive + sound** (1-line gate change): emits unsat only on a partition-covering FP64 `robust` proof; otherwise status unchanged → existing ladder runs. No engine bounding-math change.

## Validation (all 60 linearizenn_2024 instances, competition config; gold = αβ-CROWN 2025)
- **decided 2 → 60 (+58):** 1 sat + 59 unsat; 0 unknown/timeout.
- **GOLD GATE: 60/60 CONFIRMED, 0 WRONG.**
- Attribution: **49/60 decided by the input-bisection backstop (this lever)**, 10 by the root halfspace check, 1 PGD-sat.

## ⚠ Prepare-env prerequisite (not part of this diff)
linearizenn routes via the python manifest importer, so it needs the per-onnx `.nnv.mat` manifests. `prepare_instance.sh` generates them (`gen_manifest *linearize*`) — **ensure the prepare/install env has the `tools/onnx2nnv_python/requirements.txt` deps installed** (a bare system python lacks `onnx` → manifest generation fails → linearizenn + other manifest-routed categories error). Flagged for prepare-env hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)