### PR TITLE
relusplitter: pass through leading SequenceInputLayer in nn_to_ops (+14 sound unsat, 0 wrong)

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
+++ b/code/nnv/engine/nn/gpu_bab/nn_to_ops.m
@@ -236,6 +236,25 @@ function ops = nn_to_ops(nnvnet, flattenOrder, inputDim)
             end
             ops{end+1} = struct('type','product','inputs',inOps,'sizes',[wa wb],'src',inOps(1)); %#ok<AGROW>
             outShape = []; outFlat = wa;
+        elseif contains(cls, 'SequenceInput') && isempty(ops)
+            % LEADING SequenceInputLayer: matlab2nnv produces this for the 'BCT' ONNX import of a
+            % FLAT MNIST FC net (relusplitter mnist_fc) under R2026a (an older importer mapped it to
+            % a PlaceholderLayer, handled below). Like FeatureInput / Flatten / ImageInput-without-
+            % norm it carries no learnable transform on the VALUES when it has no active normalization
+            % (NNV SequenceInputLayer.evaluate is identity iff Mean is empty or Normalization=='none'),
+            % so treat it as the engine-input passthrough -- this UNBLOCKS these FC nets for the
+            % GPU-BaB pre-check (they previously errored -> Star). SOUNDNESS: a SequenceInputLayer WITH
+            % active normalization (zerocenter/zscore) WOULD change the values, so refuse that (sound-
+            % by-refusal; the mandatory IBP==evaluate orientation guard would also catch it). Only the
+            % no-normalization case becomes an op-list, so this only ADDS coverage, never a wrong graph.
+            hasNorm = isprop(L,'Normalization') && ~isempty(L.Normalization) ...
+                      && ~strcmpi(string(L.Normalization),'none') ...
+                      && isprop(L,'Mean') && ~isempty(L.Mean);
+            if hasNorm
+                error('nn_to_ops:seqInputNorm', ...
+                    'SequenceInputLayer Normalization "%s" is not folded yet -- refused for soundness.', string(L.Normalization));
+            end
+            emitted = false;
         elseif contains(cls, 'FeatureInput') && isempty(ops)
             % LEADING FeatureInputLayer: a flat [n] feature-vector input (e.g. sat_relu /
             % safenlp FC nets imported with InputDataFormats="BC"). It carries no learnable


### PR DESCRIPTION
## What

Adds a single **leading-`SequenceInputLayer` passthrough** to the GPU-BaB op-list builder `code/nnv/engine/nn/gpu_bab/nn_to_ops.m` so the **relusplitter `mnist_fc`** nets route to the sound FP64 ReLU-split BaB pre-check instead of being refused.

## Why

`matlab2nnv`'s R2026a `"BCT"` ONNX import of a flat MNIST FC net produces a leading `SequenceInputLayer`. `nn_to_ops` had no branch for it, so `gpu_bab_try_verify` returned `'skip'` and the instance fell back to the loose relax-star path — which itself **errors** on these nets (`SequenceInputLayer` has no `reach` method) → `unknown`. The existing pipeline therefore decides **0** of these instances.

A `SequenceInputLayer` with no active normalization carries no learnable transform on the values (`SequenceInputLayer.evaluate` is the identity iff `Mean` is empty or `Normalization=='none'`), so it is treated as the engine-input passthrough — exactly like the existing `FeatureInputLayer` / leading-`PlaceholderLayer` branches.

## Soundness (0 wrong is the hard rule)

- A `SequenceInputLayer` **with** active normalization is **refused** (sound-by-refusal); the mandatory `IBP == net.evaluate` orientation guard would also catch a wrong fold.
- The passthrough only ever turns a previous **error→skip** into an op-list that the orientation guard validates. A wrong order/shape fails the guard → `skip` → Star (never a wrong verdict). The FP32 emit fences and the guard are untouched.
- Smallest diff: **only `nn_to_ops.m`**, +19 lines, no new bounding math.

## cifar_biasfield (the other relusplitter conv net) intentionally NOT addressed

Its `matlab2nnv` import is broken independently of this builder: the static `ReshapeLayer` targets ONNX NCHW `[1 3 32 32]` but NNV's `Conv2DLayer` reads `[H W C]`, so `net.evaluate` itself throws (conv channel mismatch). The orientation guard calls `net.evaluate`, so it can never pass for that net. `nn_to_ops` keeps refusing the Reshape → clean `skip` (path byte-unchanged). Root cause is an importer bug, out of scope for the op-list builder.

## Validation (R2026a; FP64 CPU-double precheck = the exact harness FC call, `maxNodes=5000`)

Gold = `alpha_beta_crown` `2025_relusplitter` results.

| metric | result |
|---|---|
| mnist_fc + cifar_biasfield validated | 80 + 12 |
| gold-unsat **certified robust** | **14** |
| **WRONG** verdicts | **0** |
| gold-sat → robust | **0** |
| errors / Default-objects / getExternalLayers | **0** |
| cifar_biasfield | all 12 `skip` (Reshape still refused) |
| baseline (no patch, full harness) on sampled mnist_fc | reach error → **0** decided |

- Guard passes on **every** mnist_fc (`flatten=colmajor`, guardErr ~1e-7). The 33 uncertified gold-unsat all hit the node budget (sound `unknown`) — **0** guard failures. Even at 200k nodes / 32s a hard one (`prop_5`) stays `unknown`, so the remainder needs α/β-CROWN tightening (a separate, larger lever), not a budget bump.

Net effect on this subset: **0 → 14 decided, strictly additive, 0 wrong.**

**DO NOT MERGE without human review** (engine change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)