### PR TITLE
chore(.gitignore): ignore VNN_COMP2026 importer-generated +package dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ code/nnv/examples/Tutorial/NN/WeizmannHorse/
 code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
 code/nnv/examples/Submission/VNN_COMP2025/results_*.md
 code/nnv/examples/Submission/VNN_COMP2025/+*/
+code/nnv/examples/Submission/VNN_COMP2026/+*/
 # VNN-COMP 2026: importNetworkFromONNX writes a generated custom-layer +package (named after the onnx,
 # e.g. +mnist_concat, +cifar_biasfield_*, +mnist_fc_*) into code/nnv (startup_nnv's genpath root) so the
 # per-onnx .netcache.mat can reconstruct its custom layers. These are REQUIRED RUNTIME ARTIFACTS


### PR DESCRIPTION
Mirror the existing VNN_COMP2025 + `code/nnv/+*/` rules for VNN_COMP2026: `importNetworkFromONNX` writes custom-layer `+package` dirs (e.g. `+TinyYOLO`) there; they're required runtime artifacts (regenerated, not source) and shouldn't show as untracked or be accidentally committed. 1-line, no code impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)