### PR TITLE
[BANKED — DO NOT MERGE] cifar_biasfield ReshapeLayer import fix (prereq for Conv α/β)

### DIFF
--- a/code/nnv/engine/nn/layers/ReshapeLayer.m
+++ b/code/nnv/engine/nn/layers/ReshapeLayer.m
@@ -345,7 +345,7 @@ classdef ReshapeLayer < handle
                 params = struct2cell(params);
                 targetDim = extractdata(params{1});
                 targetDim = reshape(targetDim, [1 length(targetDim)]);
-                
+
 %             elseif length(par_fields) > 1
 %                 params = struct2cell(params);
 %                 for i  = 1: length(params)
@@ -357,7 +357,31 @@ classdef ReshapeLayer < handle
                 error('Parsing Reshape Layer was unsuccessful. We only support reshape layer with one Nonlearnable parameter.')
             end
 
+            % NCHW image reshape: the ONNX Reshape target is stored in ONNX
+            % dim order. A 4-element [N C H W] target with a leading batch dim
+            % (N in {1,-1,0}) reshapes a flat/2D operand into a 4D NCHW image
+            % that downstream Conv layers must see in NNV's MATLAB [H W C]
+            % image convention. ONNX reshape is row-major (C-order); MATLAB
+            % reshape is column-major, so a plain reshape(x,[1 C H W]) both
+            % keeps the batch dim AND mis-orders the axes -- the Conv then
+            % reads H/W as channels and evaluate() throws (Cin mismatch).
+            % Convert to a 3-element [H W C] target and flag OnnxBCHW so
+            % evaluate()/reach() use the ONNX C-order reshape + spatial-permute
+            % path (which reproduces output(h,w,c) = flat[c*H*W + h*W + w],
+            % i.e. the imported network's predict() exactly). Only fire when
+            % C,H,W are concrete (>=1); a -1 sentinel in a spatial dim is
+            % ambiguous, so fall back to the plain reshape (sound-or-skip via
+            % the IBP==evaluate orientation guard).
+            onnxBCHW = false;
+            if numel(targetDim) == 4 && any(targetDim(1) == [1 -1 0]) ...
+                    && all(targetDim(2:4) >= 1)
+                C = targetDim(2); H = targetDim(3); W = targetDim(4);
+                targetDim = [H W C];
+                onnxBCHW = true;
+            end
+
             L = ReshapeLayer(layer.Name, layer.NumInputs, layer.NumOutputs, layer.InputNames, layer.OutputNames, targetDim);
+            L.OnnxBCHW = onnxBCHW;
         end
 
     end


### PR DESCRIPTION
## Status: BANKED (draft for tracking — do not merge standalone)

Fixes `ReshapeLayer.parse` to import an ONNX `[N C H W]` reshape target as NNV `[H W C]` + `OnnxBCHW=true` (the old import mis-read NCHW → Conv saw C=32≠Cin=3 → `net.evaluate` threw). **Verified evaluate-parity maxdiff=0; set-level reach containment 300/300 sound.**

### Why this is correct but NOT merged yet
Gold-gate (official runner, αβ-CROWN 2025 gold, 8 instances) → decided **1/8, 0-wrong = same as pre-fix baseline**. The fix makes the *net* correct but does **not unlock** cifar_biasfield, because `nn_to_ops` refuses `ReshapeLayer` → no GPU-BaB → CPU Star reach → 60s timeout. Worse, **standalone this is a mild regression**: it turns a ~5s fast-abstain into a ~60s slow-timeout (same `unknown` verdict) that wastes the 6h/benchmark budget.

The real unlock needs **Conv α/β-CROWN** (IBP explodes to 10⁷ on the 7-conv net; root CROWN insufficient; needs neuron-branching NNV's GPU-BaB lacks). **Bundle this fix with that work (item #5)** and gold-gate the combined change before merging.

Full analysis: status-repo `research/NO_GO_FIX_PLANS_2026-06-22.md` (NO-GO 4) + `MEASURED_REBASELINE_2026-06-22.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)