### PR TITLE
fix(conv β): scope to cifar100-only + make β env tunable (tinyimagenet/vggnet time out 100s)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
@@ -68,10 +68,10 @@ fi
 # spec-reduction these resnets keep ~1 unproven spec, so the autodiff tape is tiny and a large
 # beta-frontier (64) batches the per-node refine cheaply.
 case "$CATEGORY" in
-    cifar100_2024|tinyimagenet_2024)   # vggnet deferred: beta-unlock + OOM untested at 1200s (follow-on)
-        export NNV_BAB_BETA_ITERS=3
-        export NNV_CONV_BETA_FRONTIER=64
-        export NNV_AMORT_ALPHA=20
+    cifar100_2024)   # beta scoped to cifar100 ONLY: tinyimagenet (64x64) + vggnet beta time out the 100s budget (grind, no certs); env-tunable above for per-net experiments
+        export NNV_BAB_BETA_ITERS=${NNV_BAB_BETA_ITERS:-3}
+        export NNV_CONV_BETA_FRONTIER=${NNV_CONV_BETA_FRONTIER:-64}
+        export NNV_AMORT_ALPHA=${NNV_AMORT_ALPHA:-20}
         ;;
 esac
 


### PR DESCRIPTION
## What
Overnight gold-gate found the #413 conv α/β β-refinement **certifies cifar100** (9/12 gold-unsat in-sample, 0-wrong) but **times out tinyimagenet** (0/20 gold-unsat, at betaFrontier 64 AND 16) — its 64×64×3 net is ~4× cifar100's, so the per-node β-refine doesn't fit the 100s budget and just grinds to maxNodes.

- **Scope the β env default to `cifar100_2024)` only** — tinyimagenet/vggnet revert to the baseline fixed-α screen (their SAT side via PGD is unaffected; β was additive, so no certs are lost — they weren't certifying *via β* anyway).
- **Make `NNV_BAB_BETA_ITERS` / `NNV_CONV_BETA_FRONTIER` / `NNV_AMORT_ALPHA` respect a pre-set env** (`${VAR:-default}`) so per-net β experiments don't require editing the script.

## Why this is sound (0-wrong preserved)
β-refinement is purely **additive** (`margin = max(screen, refined)` — a max of two valid lower bounds). Disabling it for a category cannot make a verdict *wrong*; it only reverts that category to the already-validated TIER-1 fixed-α screen. No instance that was certifying via β loses its cert (tinyimagenet had 0 such certs). cifar100 — the only category β actually unlocks — keeps β on and stays 0-wrong (re-validation 18/18, 0 false-robust).

## Test
- cifar100_2024 resnet_medium: 9/12 gold-unsat certify, 0-wrong (unchanged from #413).
- tinyimagenet_2024: was 0/20 via β (timeout); now reverts to baseline screen + PGD-sat, no β grind.
- Config-only change (run_instance.sh env scope); no engine code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
