### PR TITLE
cctsdb_yolo 2.0: parse vnnlib2 bracket indices — recover the 0% category (sound)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/cctsdb_enumerate.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/cctsdb_enumerate.py
@@ -42,6 +42,7 @@ the margin keeps a borderline instance from flipping verdict on another machine.
 import argparse
 import gzip
 import math
+import os
 import re
 import sys
 import time
@@ -63,11 +64,21 @@ def unknown(why):
 
 
 def read_maybe_gz(path):
-    """Return file bytes, transparently gunzipping *.gz."""
-    if str(path).endswith(".gz"):
-        with gzip.open(path, "rb") as f:
+    """Return file bytes, transparently gunzipping *.gz.
+
+    If a non-.gz path is missing but a sibling ``<path>.gz`` exists, read that:
+    some cctsdb_yolo 2.0 specs ship gz-only while instances.csv names the plain
+    path. The fallback only triggers when the literal path is absent, so it never
+    changes behavior for an existing file (sound).
+    """
+    p = str(path)
+    if p.endswith(".gz"):
+        with gzip.open(p, "rb") as f:
             return f.read()
-    with open(path, "rb") as f:
+    if not os.path.exists(p) and os.path.exists(p + ".gz"):
+        with gzip.open(p + ".gz", "rb") as f:
+            return f.read()
+    with open(p, "rb") as f:
         return f.read()
 
 
@@ -76,8 +87,18 @@ def read_maybe_gz(path):
 # ---------------------------------------------------------------------------
 
 _NUM = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+# Accept BOTH the 1.0 token `X_0`/`Y_0` and the 2.0 bracket token `X[0]`/`Y[0]`.
+# The vnnlib bumped to 2.0 (declare-network/declare-input header + bracket indices) but the
+# ONNX is byte-identical and the spec numerically identical to 1.0, so this is a cosmetic
+# syntax change: widening the variable token recovers the category WITHOUT touching any of the
+# four soundness guards below (the count guard, complete-bound-set, single-Y0, free-set check),
+# which is what keeps the enumeration sound. Group numbering is unchanged (op, var, idx, val) so
+# parse_vnnlib needs no other edit, and the 1.0 underscore branch still matches (no regression).
+# Verified on real specs: 1.0 24593/24593 (unchanged), 2.0 0 -> 24593, parsed box byte-identical
+# 1.0<->2.0, all 39 referenced 2.0 specs pass every guard. (Deliberately NOT a swap to the vnnlib
+# pkg: that would accept the full grammar and DELETE the count guard -> a -150 surface.)
 _ASSERT_RE = re.compile(
-    r"\(\s*assert\s+\(\s*(<=|>=)\s+([XY])_(\d+)\s+(" + _NUM + r")\s*\)\s*\)"
+    r"\(\s*assert\s+\(\s*(<=|>=)\s+([XY])(?:_|\[)(\d+)\]?\s+(" + _NUM + r")\s*\)\s*\)"
 )
 
 


### PR DESCRIPTION
## What
`cctsdb_yolo_2023` 2.0 bumped its vnnlib to the **2.0 form** (`declare-network`/`declare-input` header + **bracket** variable indices `X[0]`/`Y[0]`) while keeping **byte-identical ONNX** and **numerically-identical specs**. `cctsdb_enumerate.py`'s regex required the 1.0 token `X_0`, so **0 of 24593 asserts matched** → the count guard fired → all 30/30 abstained to `unknown` (the cctsdb **100% → 0%** regression, a full ~100-point breadth-first hole).

## How (sound by construction)
- Widen the variable token in `_ASSERT_RE` to accept **both** `X_0` (1.0) and `X[0]` (2.0) — group numbering unchanged, so `parse_vnnlib` needs no other edit and the 1.0 branch still matches (no regression).
- Add a `.gz` read fallback (7 specs ship gz-only while `instances.csv` names the plain path).
- **Preserves all four soundness guards verbatim** (count == n_asserts, complete `X_0..X_{N-1}` bound set, single `Y[0]` half-space, free-set `{12288,12289}`). The count guard is exactly what confines the verifier to the provably-complete `Gather→Cast` unit-cell form.

## Why NOT the vnnlib pkg
A swap to the `vnnlib` pkg parser would accept the full grammar (And/Or/Negate/…) and **delete that count guard** — a **−150 surface** (adversarially confirmed: `X[0]`/`Y[0]` flat-index collision, safe-vs-asserted sense flip, and an **unrecoverable SAT→unsat** path since the runner writes `unsat` before any replay gate). The minimal regex achieves the same recovery at LOW risk. (The vnnlib pkg remains right for genuinely-new grammar — it backs adaptive_cruise #416.)

## Validation
- **Parse:** 1.0 `24593/24593` unchanged; 2.0 `0 → 24593`; parsed box **byte-identical** 1.0↔2.0; **all 39** referenced 2.0 specs pass every guard.
- **End-to-end gold-gate** (`run_instance.sh`): 2.0 UNSAT → `unsat`; 2.0 SAT → `sat`+witness; gz-only spec (fallback) → `unsat`.
- **SAT witness authoritatively REAL:** all 24593 assertions hold under the `vnnlib`-pkg parse + onnxruntime forward (`Y_0=0.0 ≤ 0.5`, input in-box) → **0 wrong**.
- ONNX byte-identity md5-verified (1.0 vs 2.0).

**Impact:** recovers up to **39/39** instances (the full category, 0% → ~100%), 0-wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
