### PR TITLE
crash-resilience: malformed-net crash → sound unknown (no empty result; fixes traffic_signs EMPTY)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/execute.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/execute.py
@@ -98,7 +98,8 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
 
     # [status, total_time] = future.result()
     
-    try: 
+    crashed = False
+    try:
         [status, total_time] = future.result(timeout)
         #print('extra time = ',int(toc-tic))
     except matlab.engine.TimeoutError:
@@ -106,14 +107,36 @@ def run_instance(category, onnx, vnnlib, timeout, outputlocation) -> None:
         #print('extra time = ',int(toc-tic))
         total_time = timeout
         status = 3
-        
+    except Exception as e:
+        # Any uncaught MATLAB execution error (e.g. a malformed imported net) used to
+        # propagate here and leave NO result file -> the harness sees an empty/missing
+        # result. A crash means NNV could not decide, so the SOUND verdict is `unknown`
+        # (0 points, never a wrong verdict). We never overwrite a verdict the runner
+        # already wrote (a late crash after emit), only fill an empty/missing file.
+        print("run_vnncomp_instance raised -> sound unknown:", repr(e))
+        total_time = timeout
+        status = 4
+        crashed = True
+
     future.cancel()
-    eng.quit() 
+    eng.quit()
 
     if status == 3:
         resultfile = outputlocation
         with open(resultfile, 'w') as f:
             f.write('timeout')
+    elif crashed:
+        # write `unknown` ONLY if the runner did not already write a (valid) verdict
+        existing = ''
+        try:
+            with open(outputlocation) as f:
+                existing = f.read().strip()
+        except Exception:
+            existing = ''
+        if not existing:
+            with open(outputlocation, 'w') as f:
+                f.write('unknown')
+            print("wrote sound 'unknown' for crashed instance (no result file was produced)")
     # All the other results are written from matlab
 
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -205,13 +205,22 @@ end
 % ("Input is not an ImageStar"). Using [] for the unknown case (not false) avoids
 % forcing a Star on a non-dlnetwork image net (which would reintroduce that bug).
 useImageStar = [];
-if isprop(net, 'Layers') && ~isempty(net.Layers)
-    L1 = net.Layers(1);
-    if isa(L1, 'nnet.cnn.layer.ImageInputLayer') || isa(L1, 'nnet.cnn.layer.Image3DInputLayer')
-        useImageStar = true;
-    elseif isa(L1, 'nnet.cnn.layer.FeatureInputLayer') || isa(L1, 'nnet.onnx.layer.FeatureInputLayer')
-        useImageStar = false;
+% Guard the net.Layers access: a malformed imported dlnetwork (e.g. some quantized
+% traffic_signs nets under R2026a) throws "Undefined function 'getExternalLayers' for
+% input arguments of type 'double'" from dlnetwork.get.Layers. Catching it here keeps
+% useImageStar = [] (the sound shape-heuristic fallback) and lets the normal reach path
+% run -> a sound 'unknown' instead of an uncaught crash that writes NO result file.
+try
+    if isprop(net, 'Layers') && ~isempty(net.Layers)
+        L1 = net.Layers(1);
+        if isa(L1, 'nnet.cnn.layer.ImageInputLayer') || isa(L1, 'nnet.cnn.layer.Image3DInputLayer')
+            useImageStar = true;
+        elseif isa(L1, 'nnet.cnn.layer.FeatureInputLayer') || isa(L1, 'nnet.onnx.layer.FeatureInputLayer')
+            useImageStar = false;
+        end
     end
+catch ME
+    fprintf('net.Layers inspection failed (%s) -> useImageStar=[] (shape heuristic)\n', ME.message);
 end
 
 % Load property to verify


### PR DESCRIPTION
## What
19/30 `traffic_signs_recognition_2023` instances produced an **EMPTY result file** in the regression sweep (no verdict written). Root cause: the quantized nets carry custom `Sign_To_SignLayer` classes whose definitions don't load under R2026a → MATLAB substitutes default objects → a **malformed dlnetwork** whose `net.Layers` access throws `Undefined function 'getExternalLayers' for input arguments of type 'double'`. That error propagated **uncaught** out of `run_vnncomp_instance` → `execute.py`'s `future.result` raised → **no result file written**.

## Fix (two sound guards — both only ever yield `unknown`)
1. **`run_vnncomp_instance.m`**: wrap the `net.Layers` inspection (~line 208) in `try/catch` → on failure keep `useImageStar = []` (the shape-heuristic fallback) so the normal reach path runs and emits a sound `unknown`.
2. **`execute.py`**: catch any uncaught MATLAB execution error from `future.result` and write `unknown` — **but only if the runner did not already write a verdict** (never clobber a real result). General safety net so no category can ever produce an empty/missing result file from a crash.

## Why sound (0-wrong)
A crash means NNV could not decide → `unknown` is the correct sound verdict (0 points, never a wrong verdict). traffic_signs stays a genuine NO-GO (binarized Sign net; sound reach infeasible — the 10 non-crashing instances already returned `unknown` via the approx-star Transpose guard); this just makes the crashing ones return the **same sound `unknown` instead of EMPTY**.

## Validation
- The previously-crashing `model_64_idx_10495_eps_1.0` (net `3_64_64_QConv…Dense_43`) now runs end-to-end → `unknown` (log shows `net.Layers inspection failed … -> useImageStar=[]`), no EMPTY.
- Guard 1 is purely additive (identical behavior for nets with valid Layers); guard 2 only fires on an exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
