### PR TITLE
chore(.gitignore): ignore repo-root importer-generated +package dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,11 @@ code/nnv/examples/Submission/VNN_COMP2026/+*/
 # per-onnx .netcache.mat can reconstruct its custom layers. These are REQUIRED RUNTIME ARTIFACTS
 # (prepare_instance.sh pre-generates them; never delete the live copy) but are regenerated, not source.
 code/nnv/+*/
+# Same importer-generated +package dirs can also land at the REPO ROOT when a run is
+# launched from there (genpath root), e.g. +AllInOne_*, +vgg16_7. Same rationale as above:
+# REQUIRED RUNTIME ARTIFACTS, regenerated not source, never deleted. The leading slash
+# anchors to the repo root so this does NOT shadow code/nnv/+*/ above (#411 follow-up).
+/+*/
 code/nnv/tests/nn/layers/+pgd_2_3_16/
 code/nnv/tests/utils/+ACASXU_run2a_1_1_batch_2000/
 code/nnv/tests/utils/+cartpole/


### PR DESCRIPTION
## What

Add `/+*/` to the tracked `.gitignore` so importer-generated `+package` dirs that land at the **repo root** are durably ignored — a follow-up to #411, which only covered `code/nnv/+*/`.

## Why

`importNetworkFromONNX` writes a generated custom-layer `+package` dir (named after the onnx) into the genpath root so the per-onnx `.netcache.mat` can reconstruct its custom layers. When a VNN-COMP run is launched **from the repo root**, those dirs land at the repo root (e.g. `+AllInOne_120_120/` … `+AllInOne_80_80/`, `+vgg16_7/` — 18 of them currently). They are **required runtime artifacts** (regenerated, never deleted — see #411 / the codegen-packages note) but are not source, so they should not show as untracked.

Until now they were only excluded via a local-only `.git/info/exclude` entry; this makes the rule durable and shared.

## Safety

- The leading slash `/+*/` anchors the pattern to the repo root, so it does **not** shadow the existing `code/nnv/+*/` rule (verified: `code/nnv/+cifar_biasfield_*` still matches `.gitignore:100`; root `+AllInOne_*`/`+vgg16_7` now match `.gitignore:105`).
- 0 tracked `+*/` dirs exist at the repo root, so this gitignores nothing that is currently versioned (no files removed).
- gitignore-only change; no `+package` dir is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
