### PR TITLE
adaptive_cruise: wall-clock-bound the falsifier (in-time unknown, never EMPTY)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/adaptive_cruise_falsify.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/adaptive_cruise_falsify.py
@@ -12,7 +12,7 @@ it), never emits a witness the authoritative parser doesn't confirm -> the only 
 Exit codes (mirrors cctsdb_enumerate.py protocol): 10=SAT (+ witness csv), 12=unknown, 1=error.
 Usage: adaptive_cruise_falsify.py <onnx> <vnnlib> <witness_out_csv> [--n N] [--seed S] [--tol T]
 """
-import sys, argparse
+import sys, argparse, time
 import numpy as np
 
 def eprint(*a): print(*a, file=sys.stderr)
@@ -84,9 +84,17 @@ def input_box(query, nin):
     return lb, ub
 
 def main():
+    # Stamp the wall clock at process entry so --max-seconds bounds the WHOLE run (the vnnlib/ort
+    # import, onnx load, dynamic-batch surgery, and to_dnf precompute below, plus the sampling loop) --
+    # not just the loop. The runner derives the budget from the OFFICIAL per-instance timeout so an
+    # UNFINDABLE instance returns a graceful `unknown` (exit 12) IN-TIME, instead of grinding --n
+    # samples past the official timeout and being hard-killed by the harness (no result -> EMPTY).
+    t_start = time.time()
     ap = argparse.ArgumentParser()
     ap.add_argument('onnx'); ap.add_argument('vnnlib'); ap.add_argument('witness_csv')
     ap.add_argument('--n', type=int, default=1_000_000)
+    ap.add_argument('--max-seconds', type=float, default=0.0,   # 0 = no wall bound (legacy/test callers)
+                    help='wall-clock budget from process entry; on expiry return unknown (sound, never unsat)')
     ap.add_argument('--seed', type=int, default=0)
     ap.add_argument('--tol', type=float, default=1e-2)     # ROBUST margin: excludes thin saturation
     # artifacts (the net saturates ~100.0011, only 1.2e-4 above the 100.001 threshold -> a fp-noise-grade
@@ -146,9 +154,18 @@ def main():
                all(holds_dnf(d, X, Y, tol) for d in out_dnf)
 
     found = None
-    BS = 200_000
+    # Per-sample input-assertion filtering below is a Python loop (~sub-ms/sample), so one batch is the
+    # deadline granularity: a big batch can't be interrupted and overshoots the wall budget by its whole
+    # duration (a 200k batch was ~136s here -> a 10s budget overshot to 136s, defeating the cap). Keep the
+    # batch SMALL so the deadline is re-checked every ~few seconds; throughput is ~unchanged (it's O(total
+    # samples), independent of batch size) but the worst-case overshoot is now one small batch, not 136s.
+    BS = 5_000
     done = 0
+    deadline = (t_start + args.max_seconds) if args.max_seconds > 0 else float('inf')
+    timed_out = False
     while done < args.n and found is None:
+        if time.time() >= deadline:        # wall budget hit before a witness -> sound `unknown`
+            timed_out = True; break
         m = min(BS, args.n - done); done += m
         X = lb + (ub - lb) * rng.random((m, nin))
         # keep only samples passing the (possibly nonlinear) input-only assertions
@@ -160,7 +177,12 @@ def main():
                 found = (Xk[r].copy(), Yk[r].copy()); break
 
     if found is None:
-        eprint("no strict witness in %d samples -> unknown" % args.n); sys.exit(12)
+        if timed_out:
+            eprint("no strict witness within %.1fs wall budget (%d samples drawn) -> unknown"
+                   % (args.max_seconds, done))
+        else:
+            eprint("no strict witness in %d samples -> unknown" % args.n)
+        sys.exit(12)
 
     Xw, _ = found
     # AUTHORITATIVE re-validation: fresh ORT forward + every assertion must hold (strict margin)

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -2193,8 +2193,21 @@ function [status, counterEx] = verify_adaptive_cruise_falsify(onnx, vnnlib)
             if s2 == 0, py = ['"' c '"']; break; end
         end
     end
-    cmd = sprintf('%s "%s" "%s" "%s" "%s" --n 1500000 --tol 0.01', ...
-        py, script, char(onnx), char(vnnlib), witness_csv);
+    % WALL BUDGET: bound the sampler to the OFFICIAL per-instance timeout so an UNFINDABLE instance
+    % returns a graceful `unknown` (exit 12) IN-TIME instead of grinding --n 1.5M samples past the
+    % official timeout and being hard-killed -> EMPTY result. execute.py exports NNV_REACH_BUDGET =
+    % 0.95*official_timeout; we leave a further ~15s of headroom for python+onnxruntime startup, the
+    % onnx load, and the harness's own slack. Falls back to a generous fixed cap for dev/test callers
+    % that run the runner without execute.py (NNV_REACH_BUDGET unset). Sound either way: the cap only
+    % ever turns a would-be timeout into `unknown`, never affects a found witness (which exits fast).
+    reachBudget = str2double(getenv('NNV_REACH_BUDGET'));
+    if isfinite(reachBudget) && reachBudget > 0
+        wallSec = max(5, reachBudget - 15);
+    else
+        wallSec = 90;   % dev/test default (< the uniform 100s official adaptive_cruise timeout)
+    end
+    cmd = sprintf('%s "%s" "%s" "%s" "%s" --n 1500000 --tol 0.01 --max-seconds %.1f', ...
+        py, script, char(onnx), char(vnnlib), witness_csv, wallSec);
     [st, out] = system(cmd);
     disp(strtrim(out));
     if st == 10                          % SAT: witness csv carries the flat input; stdout "SAT y0 y1 ..."


### PR DESCRIPTION
## Problem

The adaptive_cruise nonlinear-property falsifier (#416) sampled `--n 1500000` points with **no wall-clock bound**. On an *unfindable* instance it ran far past the 100s official per-instance timeout and was hard-killed by the harness → **no result file (EMPTY)** rather than a sound `unknown`. (This is the follow-on flagged in the PM sweep report and the `adaptive-cruise-falsifier-budget` note.)

## Fix

**`adaptive_cruise_falsify.py`** — add `--max-seconds`:
- Clock is stamped at **process entry**, so the budget bounds the *whole* run (vnnlib/ort import, onnx load, dynamic-batch surgery, `to_dnf` precompute, and the sampling loop), not just the loop.
- On expiry with no witness → `unknown` (exit 12). Never affects a found witness, never emits `unsat`.
- **Shrink the sampling batch `200_000` → `5_000`.** The per-sample input-assertion filtering is a Python loop, so *one batch is the deadline granularity* — a 200k batch measured ~136s here, so a 10s budget overshot all the way to 136s, defeating the cap. Throughput is `O(total samples)` (independent of batch size), so 5k leaves throughput ~unchanged while re-checking the deadline every few seconds; worst-case overshoot is now one small batch.

**`run_vnncomp_instance.m`** — derive the budget from `NNV_REACH_BUDGET` (= `0.95 × official_timeout`, exported by `execute.py`), leaving ~15s headroom for python+onnxruntime startup, the onnx load, and the harness's own slack. Generous fixed fallback (90s) for dev/test callers that invoke the runner without `execute.py`.

## Soundness

The cap only ever turns a would-be **timeout into `unknown`** (0 points either way) — it never affects a found witness and never emits `unsat`. The falsifier's authoritative re-validation (fresh ORT forward + every assertion under the `vnnlib` parser) is unchanged, so the −150 surface is untouched.

## Verification (on the official benchmark onnx + vnnlib)

| instance | budget | before | after |
|---|---|---|---|
| `instance_2` (findable) | 80s (runner's `wallSec` for the 100s timeout) | SAT | **SAT (exit 10) at ~42s** ✓ |
| `instance_1` (unfindable) | 10s | ran to ~136s (would be killed → EMPTY) | **graceful unknown (exit 12) at ~10.8s** ✓ |

Witness output for `instance_2` is byte-identical to before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
