### PR TITLE
VNN-COMP 2026 eval-infra hardening: sweep witness gate + iso/mono soundness + parpool/python/env robustness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,9 @@ code/nnv/examples/Tutorial/NN/WeizmannHorse/
 code/nnv/examples/Submission/VNN_COMP2025/results_*.csv
 code/nnv/examples/Submission/VNN_COMP2025/results_*.md
 code/nnv/examples/Submission/VNN_COMP2025/+*/
+code/nnv/examples/Submission/VNN_COMP2026/results_*.csv
+code/nnv/examples/Submission/VNN_COMP2026/results_*.md
+code/nnv/examples/Submission/VNN_COMP2026/sweep_witnesses_*/
 code/nnv/examples/Submission/VNN_COMP2026/+*/
 # VNN-COMP 2026: importNetworkFromONNX writes a generated custom-layer +package (named after the onnx,
 # e.g. +mnist_concat, +cifar_biasfield_*, +mnist_fc_*) into code/nnv (startup_nnv's genpath root) so the

--- a/code/nnv/examples/Submission/VNN_COMP2026/authoritative_witness_gate.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/authoritative_witness_gate.m
@@ -1,0 +1,74 @@
+function [verdict, detail] = authoritative_witness_gate(onnx, vnnlib, resultfile)
+%AUTHORITATIVE_WITNESS_GATE  Re-validate an emitted `sat` result file against the AUTHORITATIVE
+%   vnnlib parser + a real-onnx onnxruntime forward -- the SAME check execute.py runs on the
+%   official path (validate_witness_authoritative.py). This is the run_all_benchmarks (dev-sweep)
+%   twin of that gate: the sweep bypasses execute.py, so without this a sweep scorecard's `sat`
+%   verdicts are only consensus-level-checked, never per-witness-checked. Wiring it into the sweep
+%   makes a scorecard per-witness trustworthy (the 2026-06-24 sweep's 0-wrong was consensus-level).
+%
+%   verdict (char):
+%     'valid'    -- the witness is a real counterexample on the real ONNX -> keep `sat`.
+%     'spurious' -- some assertion fails on the real ONNX -> the caller MUST downgrade sat->unknown
+%                   (a would-be -150 turned into 0 points). The ONLY non-fail-open outcome.
+%     'cant'     -- could not check (missing deps / parse fail / shape mismatch / non-sat file /
+%                   timeout) -> FAIL OPEN: the caller keeps today's verdict. The gate is then
+%                   monotonically no-worse than not running it.
+%
+%   SOUND DIRECTION: the gate can only ever turn sat->unknown (lose +10), never manufacture a
+%   verdict. The single source of truth for the actual check is validate_witness_authoritative.py
+%   (exit 0=valid / 1=spurious / 2=cant); this wrapper only resolves a deps-complete python, bounds
+%   the wall time, and maps the exit code. Disable via NNV_SWEEP_WITNESS_GATE=0 (caller's choice).
+    verdict = 'cant'; detail = '';
+    here = fileparts(mfilename('fullpath'));
+    gate = fullfile(here, 'validate_witness_authoritative.py');
+    if ~isfile(gate),        detail = 'validate_witness_authoritative.py missing'; return; end
+    if ~isfile(char(resultfile)), detail = 'result file missing'; return; end
+
+    py = i_ort_vnnlib_python();   % needs onnx+onnxruntime+vnnlib; '' if none on this box
+    if isempty(py), detail = 'no python imports onnx+onnxruntime+vnnlib'; return; end
+
+    % Bound the wall time so a hung onnxruntime can never stall the sweep loop. `timeout` exists on
+    % the Linux eval/dev boxes; skip the prefix on Windows (rc 124 from timeout -> 'cant' = fail open).
+    if ispc
+        cmd = sprintf('%s "%s" "%s" "%s" "%s"', py, gate, char(onnx), char(vnnlib), char(resultfile));
+    else
+        cmd = sprintf('timeout 90 %s "%s" "%s" "%s" "%s"', py, gate, char(onnx), char(vnnlib), char(resultfile));
+    end
+    [rc, out] = system(cmd);
+    detail = strtrim(out);
+    switch rc
+        case 0, verdict = 'valid';
+        case 1, verdict = 'spurious';
+        otherwise, verdict = 'cant';   % rc==2 (cant-check) or 124 (timeout) or anything else -> fail open
+    end
+end
+
+function py = i_ort_vnnlib_python()
+%I_ORT_VNNLIB_PYTHON  First interpreter that imports onnx+onnxruntime+vnnlib (quoted), else ''.
+%   Mirrors run_vnncomp_instance/python_exe's probe order (NNV_ORT_PYTHON -> taylor_venv -> pyenv ->
+%   system) but REQUIRES vnnlib too (the authoritative gate's parser). Kept SEPARATE from python_exe
+%   on purpose: python_exe is shared with cctsdb_enumerate.py, which needs only onnx+ort -- requiring
+%   vnnlib there would let a no-vnnlib box fall through to a no-ort interpreter (the cctsdb 39->0
+%   regression). Cached for the MATLAB-process lifetime.
+    persistent cached
+    if ~isempty(cached), py = cached{1}; return; end
+    cands = {};
+    e = strtrim(getenv('NNV_ORT_PYTHON'));
+    if ~isempty(e), cands{end+1} = e; end
+    home = getenv('HOME');
+    if ~isempty(home), cands{end+1} = fullfile(home, 'taylor_venv', 'bin', 'python'); end
+    try
+        pe = pyenv;
+        if ~isempty(pe.Executable) && isfile(pe.Executable), cands{end+1} = char(pe.Executable); end
+    catch
+    end
+    cands = [cands, {'python3', 'python'}];
+    py = '';
+    for i = 1:numel(cands)
+        c = cands{i};
+        if isempty(c), continue; end
+        [st, ~] = system(sprintf('"%s" -c "import onnx, onnxruntime, vnnlib"', c));
+        if st == 0, py = ['"' c '"']; break; end
+    end
+    cached = {py};
+end

--- a/code/nnv/examples/Submission/VNN_COMP2026/doctor.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/doctor.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# VNN-COMP 2026 NNV preflight "doctor" -- verify the eval/sweep environment is COMPLETE before a run,
+# so a missing dep / wrong python / unset asset fails LOUDLY here instead of silently degrading a whole
+# sweep to `unknown` or, worse, FAIL-OPENING the authoritative witness gate (-> a spurious sat stands =
+# a -150). READ-ONLY: it imports + version-checks, never installs. Exit 0 = ready, 1 = a FATAL gap.
+#
+#   bash doctor.sh [bench_root]        # bench_root default: ../../../../../../vnncomp2026_benchmarks/benchmarks
+#
+# What it checks (and who needs it):
+#   - python with onnx+onnxruntime+vnnlib   -> the witness gate (BOTH the official path AND the sweep) +
+#                                              the python falsifiers; vnnlib-less => gate fail-opens.
+#   - python with the full onnx2nnv stack   -> prepare_instance.sh manifest generation (lsnc/traffic/...).
+#   - matlab on PATH                         -> every run.
+#   - matlab.engine                          -> the OFFICIAL execute.py path only (sweeps use matlab -batch).
+#   - key harness files + benchmark assets present.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REQ="$(realpath -m "$HERE/../../../tools/onnx2nnv_python/requirements.txt" 2>/dev/null || echo "$HERE/../../../tools/onnx2nnv_python/requirements.txt")"
+BENCH="${1:-$HERE/../../../../../../vnncomp2026_benchmarks/benchmarks}"
+BENCH="$(realpath -m "$BENCH" 2>/dev/null || echo "$BENCH")"
+
+FATAL=0; WARN=0
+pass(){ printf '  \033[32mPASS\033[0m %s\n' "$1"; }
+warn(){ printf '  \033[33mWARN\033[0m %s\n' "$1"; WARN=$((WARN+1)); }
+fail(){ printf '  \033[31mFAIL\033[0m %s\n' "$1"; FATAL=$((FATAL+1)); }
+hdr(){  printf '\n== %s ==\n' "$1"; }
+
+# Resolve the FIRST python that imports a given module set (mirrors python_exe / i_ort_vnnlib_python:
+# NNV_ORT_PYTHON -> ~/taylor_venv -> python3 -> python). Echoes the interpreter or '' .
+resolve_py(){
+  local mods="$1" c
+  for c in "${NNV_ORT_PYTHON:-}" "$HOME/taylor_venv/bin/python" python3 python; do
+    [ -z "$c" ] && continue
+    if "$c" -c "import $mods" >/dev/null 2>&1; then echo "$c"; return 0; fi
+  done
+  echo ""
+}
+
+hdr "VNN-COMP 2026 NNV environment doctor"
+echo "  submission dir: $HERE"
+echo "  bench root:     $BENCH"
+echo "  requirements:   $REQ"
+
+hdr "1) Witness-gate / falsifier python (onnx + onnxruntime + vnnlib)"
+GPY="$(resolve_py 'onnx, onnxruntime, vnnlib')"
+if [ -n "$GPY" ]; then
+  pass "found: $GPY"
+  V=$("$GPY" -c 'import onnx,onnxruntime as o; print(onnx.__version__, o.__version__)' 2>/dev/null)
+  echo "        onnx=$(echo "$V" | awk '{print $1}')  onnxruntime=$(echo "$V" | awk '{print $2}')"
+  # Compare to the requirements.txt pins; a divergence is non-fatal (the gate uses a lenient tol) but
+  # is the class that bit adaptive_cruise (dev ort != witness-generation ort) -> surface it.
+  if [ -f "$REQ" ]; then
+    PIN_ONNX=$(grep -oE 'onnx==[0-9.]+' "$REQ" | cut -d= -f3)
+    PIN_ORT=$(grep -oE 'onnxruntime==[0-9.]+' "$REQ" | cut -d= -f3)
+    HAVE_ONNX=$(echo "$V" | awk '{print $1}'); HAVE_ORT=$(echo "$V" | awk '{print $2}')
+    [ -n "$PIN_ONNX" ] && [ "$PIN_ONNX" != "$HAVE_ONNX" ] && warn "onnx $HAVE_ONNX != requirements pin $PIN_ONNX (eval box should match; dev tolerable)"
+    [ -n "$PIN_ORT" ]  && [ "$PIN_ORT"  != "$HAVE_ORT"  ] && warn "onnxruntime $HAVE_ORT != requirements pin $PIN_ORT (the adaptive_cruise mismatch class)"
+  fi
+else
+  fail "no python imports onnx+onnxruntime+vnnlib -> the witness gate FAIL-OPENS (spurious sats stand). Install: <python> -m pip install -r $REQ"
+fi
+
+hdr "2) Manifest importer python (onnx2nnv full stack)"
+IPY="$(resolve_py 'numpy, scipy, onnx, onnxruntime, onnxsim, onnxoptimizer, vnnlib')"
+if [ -n "$IPY" ]; then
+  pass "found: $IPY"
+else
+  fail "no python imports the full onnx2nnv stack (numpy scipy onnx onnxruntime onnxsim onnxoptimizer vnnlib) -> manifest categories (lsnc/traffic/cgan/soundnessbench/nn4sys/vit) error. Install: <python> -m pip install -r $REQ"
+fi
+
+hdr "3) MATLAB"
+if command -v matlab >/dev/null 2>&1; then
+  pass "matlab on PATH: $(command -v matlab)"
+else
+  fail "matlab not on PATH (set it or pass MATLAB explicitly to the sweep launcher)"
+fi
+
+hdr "4) matlab.engine (official execute.py path only; sweeps use matlab -batch)"
+EPY="$(resolve_py 'matlab.engine')"
+if [ -n "$EPY" ]; then pass "matlab.engine importable via: $EPY"
+else warn "matlab.engine not importable (FATAL only for the official execute.py path; dev sweeps via sweep_lambda are unaffected)"; fi
+
+hdr "5) Harness files present"
+for f in run_vnncomp_instance.m run_all_benchmarks.m authoritative_witness_gate.m \
+         validate_witness_authoritative.py execute.py; do
+  [ -f "$HERE/$f" ] && pass "$f" || fail "missing: $f"
+done
+
+hdr "6) Benchmark assets"
+if [ -d "$BENCH" ]; then
+  pass "bench root exists"
+  N=$(find "$BENCH" -maxdepth 3 -name instances.csv 2>/dev/null | wc -l)
+  [ "$N" -gt 0 ] && pass "instances.csv files found: $N" || warn "no instances.csv under bench root (run setup.sh + gunzip?)"
+else
+  warn "bench root not found: $BENCH (pass it as arg 1, or run setup.sh)"
+fi
+
+hdr "Summary"
+printf '  %d fatal, %d warn\n' "$FATAL" "$WARN"
+if [ "$FATAL" -gt 0 ]; then
+  printf '\033[31mNOT READY\033[0m -- resolve the FAIL items above before running.\n'; exit 1
+fi
+printf '\033[32mREADY\033[0m -- environment looks complete%s.\n' "$([ "$WARN" -gt 0 ] && echo " (review WARNs)")"
+exit 0

--- a/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/install_tool.sh
@@ -77,8 +77,13 @@ apt-get install -y python3 python3-pip
 pip3 install --no-cache-dir -r "${TOOLKIT}/tools/onnx2nnv_python/requirements.txt"
 # PREFLIGHT GATE: verify the importer deps actually import in THIS python -- catches a
 # venv-vs-system mismatch BEFORE a sweep wastes hours erroring on every manifest benchmark.
-python3 -c "import numpy, scipy, onnx, onnxruntime, onnxsim, onnxoptimizer" \
-    || { echo "ERROR: onnx2nnv.py deps failed to import after install (check the active python vs ${TOOLKIT}/tools/onnx2nnv_python/requirements.txt)" >&2; exit 1; }
+# `vnnlib` is included here on purpose: it backs the AUTHORITATIVE SAT-witness gate
+# (validate_witness_authoritative.py + run_all_benchmarks' authoritative_witness_gate.m). It is
+# listed in requirements.txt, but without it in THIS check a failed/partial vnnlib install slips
+# through and the gate silently fail-opens -- every spurious sat then stands (the exact -150 class
+# the gate exists to stop). Single source of truth for the version pins: requirements.txt.
+python3 -c "import numpy, scipy, onnx, onnxruntime, onnxsim, onnxoptimizer, vnnlib" \
+    || { echo "ERROR: onnx2nnv.py / witness-gate deps failed to import after install (check the active python vs ${TOOLKIT}/tools/onnx2nnv_python/requirements.txt)" >&2; exit 1; }
 
 # MATLAB Engine API for Python: execute.py (the run_instance.sh bridge) does
 # `import matlab.engine`; without it EVERY instance fails instantly (caught in

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_all_benchmarks.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_all_benchmarks.m
@@ -113,7 +113,12 @@ sub_dirs = dir(bench_root);
 sub_dirs = sub_dirs([sub_dirs.isdir] & ~startsWith({sub_dirs.name}, '.'));
 folders = {sub_dirs.name};
 if ~isempty(only_folders)
-    folders = folders(ismember(folders, only_folders));
+    % Respect the CALLER's order (only_folders) rather than alphabetical dir order, so a launcher
+    % (sweep_lambda.sh) can place CHEAP categories first and slow leaders last. The alphabetical
+    % default starved later categories in the 2026-06-24 sweep (metaroom/nn4sys ran last and were
+    % cut by the wall cap). Keep only folders that actually exist on disk.
+    present = only_folders(ismember(only_folders, folders));
+    folders = reshape(present, 1, []);
 end
 n = numel(folders);
 
@@ -122,9 +127,28 @@ ts = datestr(now, 'yyyymmdd_HHMMSS');
 csv_path = fullfile(script_dir, sprintf('results_%s.csv', ts));
 md_path  = fullfile(script_dir, sprintf('results_%s.md', ts));
 fid = fopen(csv_path, 'w');
-fprintf(fid, 'subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message\n');
+fprintf(fid, 'subfolder,category,onnx,vnnlib,status,status_str,time_s,error_message,witness_status\n');
 
-results = cell(0, 8);   % grows per instance (all-instances mode -> count unknown up front)
+results = cell(0, 9);   % grows per instance (all-instances mode -> count unknown up front)
+
+% --- Witness capture + authoritative re-check (sat only) ---------------------------------------
+% Make the sweep scorecard PER-WITNESS trustworthy, not just consensus-level: the sweep bypasses
+% execute.py, so without this every emitted `sat` is unchecked against the authoritative vnnlib
+% parser + real-onnx onnxruntime forward. We SAVE each sat witness and re-validate it via
+% authoritative_witness_gate; a `spurious` witness is sound-downgraded sat->unknown (a would-be
+% -150 -> 0). Default ON; set NNV_SWEEP_WITNESS_GATE=0 to skip (it adds one ort forward per sat, run
+% serially between instances). Witnesses are saved regardless so a post-hoc audit is always possible.
+witness_gate_on = ~strcmp(strtrim(getenv('NNV_SWEEP_WITNESS_GATE')), '0');
+witness_root = fullfile(script_dir, sprintf('sweep_witnesses_%s', ts));
+if ~isfolder(witness_root), mkdir(witness_root); end
+fprintf('Witness gate: %s; witnesses saved under %s\n', ternary(witness_gate_on,'ON','OFF'), witness_root);
+
+% --- Pool-restart circuit breaker --------------------------------------------------------------
+% Restart the pool on a timeout (zombie kill) OR a pool/queue exception (the FevalQueue error that
+% silently killed grp7 -> metaroom on 2026-06-24). A GLOBAL cap stops a persistently-dead pool (OOM)
+% from looping ~15s restarts forever: past the cap, abort this group cleanly (partial CSV is kept;
+% other sweep_lambda groups are separate processes and continue).
+pool_restarts = 0; max_pool_restarts = 8; aborted = false;
 
 % --- Use Processes pool with 1 worker for clean timeouts and real error msgs ---
 existing_pool = gcp('nocreate');
@@ -171,14 +195,14 @@ for i = 1:n
         end
     end
     if ~isfile(inst_csv)
-        row = {sub, cat, '', '', -2, 'no_instances_csv', 0, ''};
+        row = {sub, cat, '', '', -2, 'no_instances_csv', 0, '', ''};
         results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
         fprintf('  -> no instances.csv\n');
         continue;
     end
     pairs = pick_instances(inst_csv, bench_root, sub, run_which);
     if isempty(pairs)
-        row = {sub, cat, '', '', -2, 'no_resolvable_instance', 0, ''};
+        row = {sub, cat, '', '', -2, 'no_resolvable_instance', 0, '', ''};
         results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
         fprintf('  -> no resolvable instance in CSV\n');
         continue;
@@ -192,55 +216,100 @@ for i = 1:n
         pr = pairs{k};
         out_file = [tempname '.txt'];
         t0 = tic;
-        f = parfeval(pool, @run_vnncomp_instance, 2, cat, pr.onnx, pr.vnnlib, out_file);
-        was_cold = pool_is_cold;   % for accurate timeout reporting below
-        ok = wait(f, 'finished', timeout_s + cold_grace_s*pool_is_cold);
-        pool_is_cold = false;
-        if ok
-            if isempty(f.Error)
-                try
-                    [status, ~] = fetchOutputs(f);
+        witness_status = '';                 % '', 'valid', 'spurious_downgraded', 'cant_check'
+        need_restart = false; restart_reason = '';
+        try
+            f = parfeval(pool, @run_vnncomp_instance, 2, cat, pr.onnx, pr.vnnlib, out_file);
+            was_cold = pool_is_cold;          % for accurate timeout reporting below
+            ok = wait(f, 'finished', timeout_s + cold_grace_s*pool_is_cold);
+            pool_is_cold = false;
+            if ok
+                if isempty(f.Error)
+                    [status, ~] = fetchOutputs(f);   % may throw -> outer catch (pool/queue corruption)
                     status_str = status_to_str(status);
                     err = '';
-                catch ME
-                    status = -1; status_str = 'error'; err = ME.message;
+                else
+                    % a WORKER error (NNV threw on a net) does NOT corrupt the pool -- record it and
+                    % keep going on the SAME pool (restarting on every benign error would add ~15 s to
+                    % each instance in an all-error category).
+                    status = -1; status_str = 'error'; err = f.Error.message;
                 end
             else
-                status = -1; status_str = 'error'; err = f.Error.message;
+                cancel(f);
+                status = -1; status_str = 'timeout';
+                err = sprintf('exceeded %d s', timeout_s + cold_grace_s*was_cold);
+                % cancel() CANNOT interrupt a BUSY worker (it only de-schedules queued futures): the
+                % zombie keeps grinding the timed-out reach while the next parfeval queues BEHIND it --
+                % cascading false timeouts + unbounded CPU/memory growth (this killed the malbeware
+                % runners). Restarting the pool is the only reliable way to kill a busy MATLAB worker;
+                % the ~15 s restart cost applies only on timeouts.
+                need_restart = true; restart_reason = 'timeout';
             end
-        else
-            cancel(f);
-            status = -1; status_str = 'timeout';
-            err = sprintf('exceeded %d s', timeout_s + cold_grace_s*was_cold);
-            % cancel() CANNOT interrupt a BUSY worker (it only de-schedules queued
-            % futures): the zombie keeps grinding the timed-out reach while the next
-            % parfeval queues BEHIND it -- cascading false timeouts plus unbounded
-            % CPU/memory growth. This is what killed the malbeware sweep runners
-            % (~50 scaled_16 instances need ~370 s each vs the 120 s cap; both sweep
-            % runs died with NO logs and NO rows = runner-level death). Restarting
-            % the pool is the only reliable way to kill a busy MATLAB worker; the
-            % ~15 s restart cost applies only on timeouts.
+        catch ME_run
+            % parfeval / wait / fetchOutputs THREW, or the pool is dead -> POOL/QUEUE CORRUPTION (the
+            % FevalQueue error that silently killed grp7 -> metaroom, 0 rows, on 2026-06-24). Record a
+            % SOUND `unknown` (NNV could not decide) and restart the pool so the group keeps running.
+            status = 2; status_str = 'unknown'; err = ['pool/exec error: ' ME_run.message];
+            need_restart = true; restart_reason = 'exec/pool exception';
+        end
+
+        % --- Witness capture + authoritative re-check (sat only): save the witness, then re-validate
+        %     it against the authoritative vnnlib parser + real-onnx ort forward; a spurious witness is
+        %     sound-downgraded sat->unknown (a would-be -150 -> 0). See authoritative_witness_gate.m. ---
+        if status == 0 && exist(out_file, 'file')
+            wdir = fullfile(witness_root, sub);
+            if ~isfolder(wdir), mkdir(wdir); end
+            wname = matlab.lang.makeValidName([pr.onnx_rel '__' pr.vnnlib_rel]);
+            try, copyfile(out_file, fullfile(wdir, [wname '.txt'])); catch, end
+            if witness_gate_on
+                verdict = authoritative_witness_gate(pr.onnx, pr.vnnlib, out_file);
+                switch verdict
+                    case 'valid',    witness_status = 'valid';
+                    case 'spurious'
+                        status = 2; status_str = 'unknown'; witness_status = 'spurious_downgraded';
+                        if isempty(err), err = 'authoritative gate: witness spurious -> unknown'; end
+                        fprintf('  WITNESS GATE: %s/%s  sat -> SPURIOUS -> downgraded to unknown (would-be -150)\n', sub, pr.onnx_rel);
+                    otherwise,       witness_status = 'cant_check';   % fail open: keep sat
+                end
+            end
+        end
+
+        time_s = toc(t0);
+        fprintf('  [%d/%d] %s -> %s (%.1f s)%s%s\n', k, numel(pairs), pr.onnx_rel, status_str, time_s, ...
+            ternary(~isempty(err), [': ' err(1:min(120,end))], ''), ...
+            ternary(~isempty(witness_status), [' {' witness_status '}'], ''));
+        row = {sub, cat, pr.onnx_rel, pr.vnnlib_rel, status, status_str, time_s, err, witness_status};
+        results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
+        if exist(out_file, 'file'), delete(out_file); end   % avoid leaving 1000s of temp .txt
+
+        % --- Pool restart (timeout / corruption) with a GLOBAL circuit breaker ---
+        if need_restart
             try
                 delete(pool);
             catch ME_pool
-                % restarting the pool is the zombie-kill mechanism; if delete
-                % fails we still attempt the restart, but say so loudly
                 fprintf('WARN: pool delete failed (%s); attempting restart anyway\n', ME_pool.message);
             end
-            pool = parpool('Processes', 1);
-            pool_is_cold = true;   % next instance gets the one-time cold-start grace
+            pool_restarts = pool_restarts + 1;
+            if pool_restarts > max_pool_restarts
+                fprintf(2, ['FATAL: pool restarts (%d) exceeded cap (%d) [last: %s] -> aborting this ' ...
+                    'group to avoid an OOM restart loop (partial results kept)\n'], pool_restarts, max_pool_restarts, restart_reason);
+                pool = []; aborted = true; break;
+            end
+            try
+                pool = parpool('Processes', 1);
+                pool_is_cold = true;          % next instance gets the one-time cold-start grace
+                fprintf('  pool restarted (#%d/%d, reason: %s)\n', pool_restarts, max_pool_restarts, restart_reason);
+            catch ME_new
+                fprintf(2, 'FATAL: could not restart pool (%s) -> aborting this group (partial results kept)\n', ME_new.message);
+                pool = []; aborted = true; break;
+            end
         end
-        time_s = toc(t0);
-        fprintf('  [%d/%d] %s -> %s (%.1f s)%s\n', k, numel(pairs), pr.onnx_rel, status_str, time_s, ...
-            ternary(~isempty(err), [': ' err(1:min(120,end))], ''));
-        row = {sub, cat, pr.onnx_rel, pr.vnnlib_rel, status, status_str, time_s, err};
-        results(end+1,:) = row; write_row(fid, row); %#ok<AGROW>
-        if exist(out_file, 'file'), delete(out_file); end   % avoid leaving 1000s of temp .txt
     end
+    if aborted, break; end   % circuit breaker tripped -> stop this group (partial CSV kept)
 end
 
 fclose(fid);
-delete(pool);
+if ~isempty(pool), delete(pool); end
 fprintf('\nCSV written: %s\n', csv_path);
 
 % --- Generate summary markdown ---
@@ -338,12 +407,14 @@ end
 function r = ternary(c, a, b), if c, r = a; else, r = b; end, end
 
 function write_row(fid, row)
-% row = {sub, cat, onnx_rel, vnnlib_rel, status, status_str, time_s, err}
+% row = {sub, cat, onnx_rel, vnnlib_rel, status, status_str, time_s, err, witness_status}
 err_csv = strrep(row{8}, ',', ';');
 err_csv = strrep(err_csv, sprintf('\n'), ' | ');
 err_csv = strrep(err_csv, '"', '''');
-fprintf(fid, '%s,%s,%s,%s,%d,%s,%.2f,"%s"\n', ...
-    row{1}, row{2}, row{3}, row{4}, row{5}, row{6}, row{7}, err_csv);
+ws = '';
+if numel(row) >= 9 && ~isempty(row{9}), ws = row{9}; end
+fprintf(fid, '%s,%s,%s,%s,%d,%s,%.2f,"%s",%s\n', ...
+    row{1}, row{2}, row{3}, row{4}, row{5}, row{6}, row{7}, err_csv, ws);
 end
 
 function write_summary_md(path, results, bench_root, timeout_s)

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -254,6 +254,22 @@ end
 % flagged property.unsupported above and never reaches here.
 if isfield(property, 'multinet')
     [status, counterEx] = verify_multinet(nnvnet, property);
+    % SOUNDNESS GATE (benchmark issue #7 -- iso/monotonic_acasxu two-network specs).
+    % verify_multinet's falsifier evaluates the sub-nets on the FLAT vnnlib input vector
+    % WITHOUT the input reshape the real ONNX needs (vnnlib X[5] vs onnx [1,1,1,5]), so a
+    % "counterexample" can be a mis-indexing artifact -> a SPURIOUS instant (~0.3 s) sat: the
+    % 2026-06-24 sweep produced 50/50 such monotonic_acasxu sats (50 x -150 = -7500 if shipped).
+    % Worse, this branch RETURNS below before the Pillar-2 onnxruntime gate, and the stacked
+    % product-net witness [x_f; x_g] cannot be replayed by the single-network authoritative gate
+    % (validate_witness_authoritative.py opens ONE InferenceSession) -- so NEITHER existing gate
+    % catches it. The unsat verdict (joint-Star reach) is suspect for the same shape reason.
+    % Until the two-network shape handling is implemented AND witness-audited, force a SOUND
+    % `unknown` (0 points, never a -150). Set NNV_TRUST_MULTINET=1 to trust it once fixed.
+    if status ~= 2 && ~strcmp(strtrim(getenv('NNV_TRUST_MULTINET')), '1')
+        fprintf(['vnnlib 2.0 multi-network: verify_multinet status=%d DOWNGRADED to unknown ' ...
+                 '(two-network shape #7 unverified -- sound-or-unknown; NNV_TRUST_MULTINET=1 to trust)\n'], status);
+        status = 2; counterEx = nan;
+    end
     fprintf('vnnlib 2.0 multi-network (equal-to) -> status=%d (0 sat / 1 unsat / 2 unknown)\n', status);
     tTime = toc(t);
     fid = fopen(outputfile, 'w');
@@ -774,13 +790,20 @@ function py = python_exe()
     cands = {};
     e = strtrim(getenv('NNV_ORT_PYTHON'));
     if ~isempty(e), cands{end+1} = e; end
+    % Prefer the project venv (~/taylor_venv) BEFORE MATLAB's pyenv: the witness-replay gate
+    % and the falsifiers (adaptive_cruise) must use the SAME onnxruntime BUILD the witnesses
+    % were validated against. MATLAB pyenv can resolve a python with onnx+ort of a DIFFERENT
+    % ort version that then REJECTS real witnesses (the 2026-06-24 adaptive_cruise all-unknown:
+    % 50/50, incl. the validated instance_2). NNV_ORT_PYTHON still wins for an explicit
+    % eval-box override; on the eval box (no taylor_venv) this falls through to pyenv/system
+    % unchanged, so cctsdb_enumerate.py keeps its onnx+ort interpreter (no 39->0 regression).
+    home = getenv('HOME');
+    if ~isempty(home), cands{end+1} = fullfile(home, 'taylor_venv', 'bin', 'python'); end
     try
         pe = pyenv;
         if ~isempty(pe.Executable) && isfile(pe.Executable), cands{end+1} = char(pe.Executable); end
     catch
     end
-    home = getenv('HOME');
-    if ~isempty(home), cands{end+1} = fullfile(home, 'taylor_venv', 'bin', 'python'); end
     if ispc
         cands = [cands, {'python', 'python3'}];
     else

--- a/code/nnv/tests/vnncomp25/test_authoritative_witness_gate.m
+++ b/code/nnv/tests/vnncomp25/test_authoritative_witness_gate.m
@@ -1,0 +1,125 @@
+function tests = test_authoritative_witness_gate
+%TEST_AUTHORITATIVE_WITNESS_GATE  Tests for authoritative_witness_gate.m -- the run_all_benchmarks
+%   (dev-sweep) twin of execute.py's authoritative SAT-witness gate. The helper re-validates an
+%   emitted `sat` result file against the AUTHORITATIVE vnnlib parser + a real-onnx onnxruntime
+%   forward (validate_witness_authoritative.py) and returns 'valid' / 'spurious' / 'cant'. Wiring it
+%   into run_all_benchmarks is what makes a sweep scorecard PER-WITNESS trustworthy (vs only the
+%   consensus-level check the 2026-06-24 sweep had).
+%
+%   Two groups:
+%     * SOUNDNESS / fail-open contract (ALWAYS runs, no deps): every degenerate input -- missing
+%       result file, non-sat verdict, unparseable onnx/vnnlib -- maps to 'cant'. The gate NEVER
+%       returns 'valid'/'spurious' when it cannot actually check, and the verdict is always one of
+%       the three known strings. This is the property that keeps the gate sound-or-keep.
+%     * replay correctness (runs only if a python imports onnx+onnxruntime+vnnlib AND the acasxu
+%       benchmark asset is present): a made-up witness on a real spec -> 'spurious'; a STACKED
+%       two-network witness -> 'cant' (the KEYSTONE -- the gate provably CANNOT catch the iso/mono
+%       case, which is exactly why run_vnncomp_instance sound-downgrades the multinet branch at the
+%       source; without that downgrade those 50 spurious monotonic_acasxu sats would be -7500).
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(tc)
+    % authoritative_witness_gate lives in examples/Submission/VNN_COMP2026. CI shards tests across
+    % matrix jobs and does not guarantee that dir is on the path, so add it here to be self-sufficient.
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2026');
+    tc.TestData.addedPath = '';
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub); tc.TestData.addedPath = sub;
+    end
+end
+
+function teardownOnce(tc)
+    if isfield(tc.TestData, 'addedPath') && ~isempty(tc.TestData.addedPath)
+        rmpath(tc.TestData.addedPath);
+    end
+end
+
+% ---------- soundness / fail-open contract (environment-independent) ----------
+
+function test_missing_result_file_is_cant(tc)
+    v = authoritative_witness_gate('no.onnx', 'no.vnnlib', fullfile(tempdir, 'nope_xyz_123.txt'));
+    verifyEqual(tc, v, 'cant', 'a missing result file must fail-open (keep the verdict)');
+end
+
+function test_nonsat_file_is_cant(tc)
+    f = [tempname '.txt']; fid = fopen(f, 'w'); fprintf(fid, 'unsat\n'); fclose(fid);
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate('no.onnx', 'no.vnnlib', f);
+    verifyEqual(tc, v, 'cant', 'a non-sat result must never be judged spurious/valid');
+end
+
+function test_bad_paths_with_sat_file_is_cant(tc)
+    % A syntactically real sat witness but bogus onnx/vnnlib -> the script cannot parse/forward ->
+    % the gate must fail-open, NEVER return spurious/valid on an uncheckable input.
+    f = [tempname '.txt']; fid = fopen(f, 'w'); fprintf(fid, 'sat\n(X_0 0.5)\n(X_1 0.5)\n'); fclose(fid);
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate(fullfile(tempdir, 'no_model_xyz.onnx'), ...
+                                   fullfile(tempdir, 'no_spec_xyz.vnnlib'), f);
+    verifyEqual(tc, v, 'cant', 'unparseable onnx/vnnlib must fail-open');
+end
+
+function test_verdict_is_always_known_string(tc)
+    f = [tempname '.txt']; fid = fopen(f, 'w'); fprintf(fid, 'sat\n(X_0 0.5)\n'); fclose(fid);
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate('x.onnx', 'y.vnnlib', f);
+    verifyTrue(tc, ismember(v, {'valid', 'spurious', 'cant'}), 'verdict must be one of the three');
+end
+
+% ---------- replay correctness (needs python+onnx+onnxruntime+vnnlib AND the acasxu asset) ----------
+
+function test_madeup_witness_spurious(tc)
+    [onnx, vnnlib] = assumeAcasxuAsset(tc);
+    f = writeSat([0.5 0.5 0.5 0.5 0.5]);   % a made-up 5-vector that does not satisfy the real spec
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate(onnx, vnnlib, f);
+    verifyEqual(tc, v, 'spurious', 'a made-up witness must be caught -> sound sat->unknown downgrade');
+end
+
+function test_stacked_multinet_witness_is_cant(tc)
+    % KEYSTONE: a STACKED two-network witness (10 values for a 5-input acasxu net) cannot be replayed
+    % by the single-InferenceSession authoritative gate -> 'cant'. This proves the gate will NOT catch
+    % the iso/mono (monotonic_acasxu) spurious sats, which is precisely why run_vnncomp_instance's
+    % multinet branch sound-downgrades to unknown at the SOURCE (preventing the would-be -7500).
+    [onnx, vnnlib] = assumeAcasxuAsset(tc);
+    f = writeSat([0.1 0.1 0.1 0.1 0.1 0.2 0.2 0.2 0.2 0.2]);   % 10 values vs a 5-input net
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate(onnx, vnnlib, f);
+    verifyEqual(tc, v, 'cant', 'a stacked multinet witness is un-replayable -> gate fail-opens');
+end
+
+% ---------- helpers ----------
+
+function [onnx, vnnlib] = assumeAcasxuAsset(tc)
+    % Skip (not fail) when the witness-gate python or the acasxu benchmark asset is unavailable, so a
+    % CI box without onnx/ort/vnnlib OR without the benchmarks repo stays green.
+    assumeFalse(tc, isempty(resolve_gate_python()), 'no python imports onnx+onnxruntime+vnnlib -- skip');
+    here = fileparts(mfilename('fullpath'));
+    base = fullfile(here, '..', '..', '..', '..', '..', 'vnncomp2026_benchmarks', 'benchmarks', 'acasxu_2023');
+    onnx = '';
+    for v = {'2.0', '1.0'}
+        cand = fullfile(base, v{1}, 'onnx', 'ACASXU_run2a_1_1_batch_2000.onnx');
+        if isfile(cand) || isfile([cand '.gz']), onnx = cand; vdir = fullfile(base, v{1}, 'vnnlib'); break; end
+    end
+    assumeFalse(tc, isempty(onnx), 'acasxu benchmark asset not present -- skip replay test');
+    vnnlib = fullfile(vdir, 'prop_3.vnnlib');
+    assumeTrue(tc, isfile(vnnlib) || isfile([vnnlib '.gz']), 'acasxu prop_3.vnnlib not present -- skip');
+end
+
+function py = resolve_gate_python()
+    cands = {strtrim(getenv('NNV_ORT_PYTHON')), fullfile(getenv('HOME'), 'taylor_venv', 'bin', 'python'), 'python3', 'python'};
+    py = '';
+    for i = 1:numel(cands)
+        c = cands{i}; if isempty(c), continue; end
+        [st, ~] = system(sprintf('"%s" -c "import onnx, onnxruntime, vnnlib"', c));
+        if st == 0, py = c; return; end
+    end
+end
+
+function p = writeSat(xs)
+    p = [tempname '.txt'];
+    fid = fopen(p, 'w'); fprintf(fid, 'sat\n');
+    for i = 1:numel(xs), fprintf(fid, '(X_%d %g)\n', i - 1, xs(i)); end
+    fclose(fid);
+end


### PR DESCRIPTION
Hardens the VNN-COMP 2026 eval harness against the gaps surfaced by the 2026-06-24 overnight sweep. **Sound-or-unknown preserved throughout — every change can only ever turn `sat`→`unknown`, never produce a wrong verdict.**

## Soundness (the −7500 closer)
- **iso/mono multinet downgrade** (`run_vnncomp_instance.m`): the two-network (`isomorphic`/`monotonic_acasxu`) branch *returned before* the Pillar-2 gate and emitted a **stacked** `[x_f; x_g]` witness the single-`InferenceSession` authoritative gate cannot replay — so **neither** existing gate caught its spurious instant (~0.3 s) sats (50/50 monotonic on 06-24 = a would-be **−7500**). Now forced to a sound `unknown` until the two-network shape (bench issue #7) is implemented + witness-audited (`NNV_TRUST_MULTINET=1` to trust once fixed). **Verified on this box: `monotonic_acasxu` → unknown** (`verify_multinet` still returns the spurious sat; the downgrade catches it).

## Witness capture + save + eval (the sweep path)
- `run_all_benchmarks.m` now **saves every sat witness** and **re-validates** it via the authoritative gate (new `authoritative_witness_gate.m` → `validate_witness_authoritative.py`), sound-downgrading a spurious sat to `unknown` and recording a new `witness_status` CSV column. This makes a sweep scorecard **per-witness trustworthy** — the 06-24 0-wrong was only *consensus-level* because the sweep bypasses `execute.py`'s gate. Default ON; `NNV_SWEEP_WITNESS_GATE=0` to skip.

## Robustness
- **parpool**: restart on **any** pool/queue exception (the `FevalQueue` error that silently killed group 7 → lost metaroom on 06-24), not just on timeout; record a sound `unknown` + continue; a **global circuit breaker** caps restarts so a persistently dead pool (OOM) aborts the group cleanly instead of looping restarts.
- **`python_exe()`**: prefer `~/taylor_venv` before MATLAB `pyenv` so the witness replay + falsifiers use the onnxruntime **build** the witnesses were validated against (the `adaptive_cruise` all-unknown class). The eval box (no `taylor_venv`) is unchanged → `cctsdb` keeps its onnx+ort interpreter (no 39→0 regression).
- **folder ordering**: `run_all_benchmarks` processes folders in **caller order** (not alphabetical) so a launcher can place cheap categories first; alphabetical order starved metaroom/nn4sys on 06-24.

## Env / requirements hardening
- `install_tool.sh` preflight now verifies **`vnnlib`** imports (it backs the authoritative gate; it was in `requirements.txt` but unchecked → a partial install would silently fail-open the gate). `requirements.txt` confirmed complete for every actual import.
- new **`doctor.sh`** preflight: verifies the witness-gate/importer python + all deps, MATLAB, `matlab.engine`, harness files, and benchmark assets; warns on onnx/ort version divergence from the requirements pins.
- `.gitignore`: `VNN_COMP2026/results_*.csv/.md` + `sweep_witnesses_*/`.

## Tests
- new `tests/vnncomp25/test_authoritative_witness_gate.m` (6): always-run **fail-open / soundness contract** (missing / non-sat / bad-path → `cant`, never `spurious`/`valid`) + replay correctness including the **keystone** that a stacked multinet witness is un-replayable (`cant`), documenting why the source downgrade is required. Existing `test_run_all_benchmarks_helpers` (5/5) + `test_validate_witness_onnx` still green — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)