### PR TITLE
two-network witness gate: recover monotonic_acasxu real sats (replace blanket multinet downgrade)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/authoritative_witness_gate.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/authoritative_witness_gate.m
@@ -1,10 +1,15 @@
-function [verdict, detail] = authoritative_witness_gate(onnx, vnnlib, resultfile)
+function [verdict, detail] = authoritative_witness_gate(onnx, vnnlib, resultfile, scriptName)
 %AUTHORITATIVE_WITNESS_GATE  Re-validate an emitted `sat` result file against the AUTHORITATIVE
 %   vnnlib parser + a real-onnx onnxruntime forward -- the SAME check execute.py runs on the
 %   official path (validate_witness_authoritative.py). This is the run_all_benchmarks (dev-sweep)
 %   twin of that gate: the sweep bypasses execute.py, so without this a sweep scorecard's `sat`
 %   verdicts are only consensus-level-checked, never per-witness-checked. Wiring it into the sweep
 %   makes a scorecard per-witness trustworthy (the 2026-06-24 sweep's 0-wrong was consensus-level).
+%
+%   scriptName (optional, default 'validate_witness_authoritative.py'): the python gate to invoke.
+%   Pass 'validate_witness_multinet.py' for VNN-LIB 2.0 TWO-NETWORK (equal-to / monotonic_acasxu)
+%   witnesses -- same exit contract (0=valid/1=spurious/2=cant) and same <onnx> <vnnlib> <result>
+%   call, so this one wrapper (python resolver + wall bound + exit map) serves both.
 %
 %   verdict (char):
 %     'valid'    -- the witness is a real counterexample on the real ONNX -> keep `sat`.
@@ -19,9 +24,10 @@ function [verdict, detail] = authoritative_witness_gate(onnx, vnnlib, resultfile
 %   (exit 0=valid / 1=spurious / 2=cant); this wrapper only resolves a deps-complete python, bounds
 %   the wall time, and maps the exit code. Disable via NNV_SWEEP_WITNESS_GATE=0 (caller's choice).
     verdict = 'cant'; detail = '';
+    if nargin < 4 || isempty(scriptName), scriptName = 'validate_witness_authoritative.py'; end
     here = fileparts(mfilename('fullpath'));
-    gate = fullfile(here, 'validate_witness_authoritative.py');
-    if ~isfile(gate),        detail = 'validate_witness_authoritative.py missing'; return; end
+    gate = fullfile(here, char(scriptName));
+    if ~isfile(gate),        detail = [char(scriptName) ' missing']; return; end
     if ~isfile(char(resultfile)), detail = 'result file missing'; return; end
 
     py = i_ort_vnnlib_python();   % needs onnx+onnxruntime+vnnlib; '' if none on this box

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -254,41 +254,50 @@ end
 % flagged property.unsupported above and never reaches here.
 if isfield(property, 'multinet')
     [status, counterEx] = verify_multinet(nnvnet, property);
-    % SOUNDNESS GATE (benchmark issue #7 -- iso/monotonic_acasxu two-network specs).
-    % verify_multinet's falsifier evaluates the sub-nets on the FLAT vnnlib input vector
-    % WITHOUT the input reshape the real ONNX needs (vnnlib X[5] vs onnx [1,1,1,5]), so a
-    % "counterexample" can be a mis-indexing artifact -> a SPURIOUS instant (~0.3 s) sat: the
-    % 2026-06-24 sweep produced 50/50 such monotonic_acasxu sats (50 x -150 = -7500 if shipped).
-    % Worse, this branch RETURNS below before the Pillar-2 onnxruntime gate, and the stacked
-    % product-net witness [x_f; x_g] cannot be replayed by the single-network authoritative gate
-    % (validate_witness_authoritative.py opens ONE InferenceSession) -- so NEITHER existing gate
-    % catches it. The unsat verdict (joint-Star reach) is suspect for the same shape reason.
-    % Until the two-network shape handling is implemented AND witness-audited, force a SOUND
-    % `unknown` (0 points, never a -150). Set NNV_TRUST_MULTINET=1 to trust it once fixed.
-    if status ~= 2 && ~strcmp(strtrim(getenv('NNV_TRUST_MULTINET')), '1')
-        fprintf(['vnnlib 2.0 multi-network: verify_multinet status=%d DOWNGRADED to unknown ' ...
-                 '(two-network shape #7 unverified -- sound-or-unknown; NNV_TRUST_MULTINET=1 to trust)\n'], status);
-        status = 2; counterEx = nan;
+    % AUTHORITATIVE two-network witness gate (isomorphic/monotonic_acasxu, vnnlib-2.0 equal-to).
+    % verify_multinet is a COMPLETE, sound relational verifier (falsify-first on the REAL net +
+    % product-net joint-Star reach), and its forward matches onnxruntime to ~1e-9 (verified
+    % 2026-06-24: the earlier "issue #7 shape mismatch -> spurious instant sat" worry was FALSE --
+    % monotonic_acasxu sats are REAL). So instead of a blanket sat->unknown downgrade (which
+    % discarded ~50 real sats), re-validate the sat witness through the TWO-network onnxruntime gate
+    % (validate_witness_multinet.py: forwards BOTH x_f and x_g, checks the LITERAL two-network spec):
+    %   valid    -> trust the sat (ORT-confirmed counterexample)
+    %   spurious -> downgrade to unknown (a would-be -150 -> 0 points)
+    %   cant     -> downgrade to unknown (sound default: never ship an un-validated multinet sat)
+    % The unsat (joint-Star reach) verdict has no replayable witness, so it stays a conservative
+    % `unknown` until separately audited. NNV_TRUST_MULTINET=1 bypasses the gate (trusts both
+    % directions -- for testing / once the unsat direction is independently validated).
+    trust = strcmp(strtrim(getenv('NNV_TRUST_MULTINET')), '1');
+    if status == 0
+        % stacked witness [x_f; x_g] -> [f(x_f); f(x_g)] (write_counterexample's X_i/Y_i format)
+        xf = counterEx{1}; xg = counterEx{2};
+        yf = nnvnet.evaluate(xf); yg = nnvnet.evaluate(xg);
+        fid = fopen(outputfile, 'w'); fprintf(fid, 'sat \n'); fclose(fid);
+        write_counterexample(outputfile, {[xf(:); xg(:)], [yf(:); yg(:)]});
+        if ~trust
+            gate = authoritative_witness_gate(onnx, vnnlib, outputfile, 'validate_witness_multinet.py');
+            if ~strcmp(gate, 'valid')
+                fprintf('vnnlib 2.0 multi-network: sat witness gate=%s -> DOWNGRADE to unknown\n', gate);
+                status = 2;
+                fid = fopen(outputfile, 'w'); fprintf(fid, 'unknown \n'); fclose(fid);
+            else
+                fprintf('vnnlib 2.0 multi-network: sat witness gate=VALID (onnxruntime-confirmed) -> trust sat\n');
+            end
+        end
+    elseif status == 1
+        if trust
+            fid = fopen(outputfile, 'w'); fprintf(fid, 'unsat \n'); fclose(fid);
+        else
+            fprintf(['vnnlib 2.0 multi-network: unsat (joint-Star reach) has no replayable witness ' ...
+                     '-> sound unknown (NNV_TRUST_MULTINET=1 to trust)\n']);
+            status = 2;
+            fid = fopen(outputfile, 'w'); fprintf(fid, 'unknown \n'); fclose(fid);
+        end
+    else
+        fid = fopen(outputfile, 'w'); fprintf(fid, 'unknown \n'); fclose(fid);
     end
     fprintf('vnnlib 2.0 multi-network (equal-to) -> status=%d (0 sat / 1 unsat / 2 unknown)\n', status);
     tTime = toc(t);
-    fid = fopen(outputfile, 'w');
-    if status == 0
-        fprintf(fid, 'sat \n');
-        fclose(fid);
-        % witness = stacked product-net I/O [x_f; x_g] -> [f(x_f); f(x_g)] (the
-        % order verify_multinet's product net uses); sound -- the verdict, not the
-        % witness format, is what the sweep scores, and the CE is already validated.
-        xf = counterEx{1}; xg = counterEx{2};
-        yf = nnvnet.evaluate(xf); yg = nnvnet.evaluate(xg);
-        write_counterexample(outputfile, {[xf(:); xg(:)], [yf(:); yg(:)]});
-    elseif status == 1
-        fprintf(fid, 'unsat \n');
-        fclose(fid);
-    else
-        fprintf(fid, 'unknown \n');
-        fclose(fid);
-    end
     return;
 end
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/validate_witness_multinet.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/validate_witness_multinet.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Authoritative SAT-witness gate for VNN-LIB 2.0 TWO-NETWORK specs (the `equal-to` / monotonicity
+family: isomorphic_acasxu, monotonic_acasxu) -- the multi-network sibling of
+validate_witness_authoritative.py.
+
+WHY: verify_multinet emits a STACKED [x_f; x_g] witness for a two-network spec. The single-
+InferenceSession gate (validate_witness_authoritative.py) opens ONE network and cannot replay two
+coupled inputs/outputs, so run_vnncomp_instance used to BLANKET-downgrade every multinet sat to
+unknown. That is sound but OVER-conservative: it discards REAL counterexamples (verified 2026-06-24:
+a monotonic_acasxu witness replayed through onnxruntime matches NNV's forward to 1e-9 and genuinely
+violates Y_f[3] < Y_g[3]). This gate forwards BOTH halves through the network(s) via onnxruntime and
+checks the LITERAL two-network vnnlib on the witness, so a real sat is TRUSTED and only a
+genuinely-spurious one is downgraded.
+
+Usage: validate_witness_multinet.py <onnx_f[.gz]> <vnnlib[.gz]> <result_file> [--onnx-g G] [--tol T]
+Exit:  0 = VALID     (every assertion holds on the ORT replay -> emit sat)
+       1 = SPURIOUS  (some assertion fails -> downgrade to unknown; a would-be -150 -> 0 points)
+       2 = CANNOT-CHECK (missing deps / parse fail / shape mismatch / non-sat / not 2 nets) -> FAIL OPEN
+
+SOUND DIRECTION: the gate can only ever turn sat->unknown (lose +10), never manufacture a verdict.
+"""
+import sys, os, re, gzip, argparse
+import numpy as np
+
+EXIT_VALID, EXIT_SPURIOUS, EXIT_CANT = 0, 1, 2
+
+
+def cant(msg):
+    print("CANNOT-CHECK " + msg, file=sys.stderr)
+    sys.exit(EXIT_CANT)
+
+
+def _maybe_gunzip_path(p):
+    if os.path.exists(p):
+        return p
+    if os.path.exists(p + ".gz"):
+        import tempfile
+        with gzip.open(p + ".gz", "rb") as f:
+            data = f.read()
+        t = tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(p)[1])
+        t.write(data); t.close()
+        return t.name
+    return p
+
+
+def read_stacked_witness(resfile):
+    """Parse the runner's sat result file: 'sat' then (X_i val) lines, the STACKED [x_f; x_g] input
+    written by write_counterexample. Returns a contiguous X array, None (not sat), or 'noncontig'."""
+    txt = open(resfile).read()
+    if not txt.lstrip().lower().startswith("sat"):
+        return None
+    fnum = r"[-+]?\d*\.?\d+(?:[eE][-+]?\d+)?"
+    xs = {}
+    for m in re.finditer(r"\(\s*X_(\d+)\s+(" + fnum + r")\s*\)", txt):
+        xs[int(m.group(1))] = float(m.group(2))
+    if not xs:
+        return None
+    n = max(xs) + 1
+    if len(xs) != n:
+        return "noncontig"
+    return np.array([xs[i] for i in range(n)], dtype=np.float64)
+
+
+def _flat(e):
+    idx = list(e.indices)
+    try:
+        shp = list(e.shape)
+        if len(shp) == len(idx) and int(np.prod(shp)) > 1:
+            return int(np.ravel_multi_index(idx, shp))
+    except Exception:
+        pass
+    return idx[-1] if idx else 0
+
+
+def ev_arith(e, env):
+    """env maps (network_name, 'Input'|'Output', flat_index) -> float."""
+    t = type(e).__name__
+    if t == "Var":
+        kind = "Input" if str(e.kind).endswith("Input") else "Output"
+        key = (e.network_name, kind, _flat(e))
+        if key not in env:
+            raise ValueError("unknown var " + str(key))
+        return float(env[key])
+    if t in ("Float", "Int", "IntExpr"):
+        return float(e.value)
+    if t == "Literal":
+        return float(e.lexeme)
+    if t == "Negate":
+        return -ev_arith(e.expr, env)
+    if t == "Plus":
+        return sum(ev_arith(a, env) for a in e.args)
+    if t == "Minus":
+        return ev_arith(e.head, env) - sum(ev_arith(a, env) for a in e.rest)
+    if t == "Multiply":
+        r = 1.0
+        for a in e.args:
+            r *= ev_arith(a, env)
+        return r
+    raise ValueError("arith " + t)
+
+
+def ev_cmp(c, env, tol):
+    """A comparison holds within the LENIENT tolerance so a real boundary witness is not falsely
+    downgraded (the spec stores <=-relaxations of possibly-strict asserts; tol >= official CE tol)."""
+    t = type(c).__name__
+    lo = ev_arith(c.lhs, env); ro = ev_arith(c.rhs, env)
+    if t == "GreaterEqual": return lo >= ro - tol
+    if t == "GreaterThan":  return lo >  ro - tol
+    if t == "LessEqual":    return lo <= ro + tol
+    if t == "LessThan":     return lo <  ro + tol
+    if t == "Equal":        return abs(lo - ro) <= tol
+    if t == "NotEqual":     return abs(lo - ro) >  0.0
+    raise ValueError("cmp " + t)
+
+
+def holds(dnf, env, tol):
+    return any(all(ev_cmp(c, env, tol) for c in clause) for clause in dnf)
+
+
+def net_io_size(net, which):
+    defs = net.inputs if which == "in" else net.outputs
+    sz = 0
+    for d in defs:
+        shp = getattr(d, "shape", None)
+        sz += int(np.prod(shp)) if shp else 1
+    return sz
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("onnx"); ap.add_argument("vnnlib"); ap.add_argument("resultfile")
+    ap.add_argument("--onnx-g", default=None,
+                    help="second-network onnx (for isomorphic / different-weight g; default = shared <onnx>)")
+    ap.add_argument("--tol", type=float, default=1e-4)   # >= official VNN-COMP CE-checker tol
+    a = ap.parse_args()
+    try:
+        import vnnlib
+        import onnxruntime as ort
+    except Exception as e:
+        cant("missing vnnlib/onnxruntime: " + str(e))
+
+    X = read_stacked_witness(a.resultfile)
+    if X is None:
+        cant("result file is not a parseable sat witness")
+    if isinstance(X, str):
+        cant("non-contiguous witness indices")
+
+    vnnlib_p = _maybe_gunzip_path(a.vnnlib)
+    try:
+        q = vnnlib.parse_query_file(vnnlib_p)
+        nets = list(q.networks)
+        dnf = [assn.expr.to_dnf() for assn in q.assertions]
+    except Exception as e:
+        cant("vnnlib parse failed: " + str(e))
+    if len(nets) != 2:
+        cant("expected exactly 2 networks, got %d" % len(nets))
+
+    # split the stacked witness by each network's input size (declaration order [f, g], which is the
+    # order write_counterexample stacks counterEx{1}=x_f then counterEx{2}=x_g).
+    insz = [net_io_size(n, "in") for n in nets]
+    if sum(insz) != X.size:
+        cant("stacked witness size %d != sum of network input sizes %s" % (X.size, insz))
+
+    onnx_f = _maybe_gunzip_path(a.onnx)
+    onnx_g = _maybe_gunzip_path(a.onnx_g) if a.onnx_g else onnx_f
+
+    def net_onnx(net, is_first):
+        # `equal-to` (g references f) shares the SAME onnx as f; a genuine different-weight g needs
+        # --onnx-g. verify_multinet only emits sat for equal-to today, so the default (shared) is right.
+        if is_first or getattr(net, "equal_to", ""):
+            return onnx_f
+        return onnx_g
+
+    try:
+        env = {}
+        off = 0
+        for ni, net in enumerate(nets):
+            xi = X[off:off + insz[ni]]; off += insz[ni]
+            s = ort.InferenceSession(net_onnx(net, ni == 0))
+            iname = s.get_inputs()[0].name
+            ish = s.get_inputs()[0].shape
+            shp = tuple(1 if (d is None or isinstance(d, str)) else d for d in ish)
+            if int(np.prod(shp)) != xi.size:
+                shp = (1, xi.size)
+            yi = s.run(None, {iname: xi.reshape(shp).astype(np.float32)})[0].ravel()
+            for k in range(xi.size):
+                env[(net.name, "Input", k)] = float(xi[k])
+            for k in range(yi.size):
+                env[(net.name, "Output", k)] = float(yi[k])
+    except Exception as e:
+        cant("onnx forward failed: " + str(e))
+
+    try:
+        ok = all(holds(d, env, a.tol) for d in dnf)
+    except Exception as e:
+        cant("assertion eval failed: " + str(e))
+
+    if ok:
+        print("VALID")
+        sys.exit(EXIT_VALID)
+    print("SPURIOUS")
+    sys.exit(EXIT_SPURIOUS)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/nnv/tests/vnncomp25/test_authoritative_witness_gate.m
+++ b/code/nnv/tests/vnncomp25/test_authoritative_witness_gate.m
@@ -89,6 +89,48 @@ function test_stacked_multinet_witness_is_cant(tc)
     verifyEqual(tc, v, 'cant', 'a stacked multinet witness is un-replayable -> gate fail-opens');
 end
 
+% ---------- two-network gate (validate_witness_multinet.py via the scriptName arg) ----------
+
+function test_multinet_gate_missing_is_cant(tc)
+    % The 4-arg form (scriptName) must keep the same fail-open contract: missing result -> 'cant'.
+    v = authoritative_witness_gate('no.onnx', 'no.vnnlib', fullfile(tempdir, 'nope_mn_123.txt'), ...
+                                   'validate_witness_multinet.py');
+    verifyEqual(tc, v, 'cant', 'missing result file -> fail-open even on the multinet gate');
+end
+
+function test_multinet_gate_nonsat_is_cant(tc)
+    f = [tempname '.txt']; fid = fopen(f, 'w'); fprintf(fid, 'unsat\n'); fclose(fid);
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate('no.onnx', 'no.vnnlib', f, 'validate_witness_multinet.py');
+    verifyEqual(tc, v, 'cant', 'non-sat -> never spurious/valid on the multinet gate');
+end
+
+function test_multinet_gate_broken_coupling_not_valid(tc)
+    % SOUNDNESS: a stacked monotonic witness whose (== X_f[1] X_g[1]) coupling is broken by >> tol must
+    % NEVER be judged 'valid' (it would be a -150). Deterministic: the input-coupling assertion fails
+    % regardless of the forward, so this is a clean spurious-detection check.
+    [onnx, vnnlib] = assumeMonotonicAsset(tc);
+    % xf in-box, xg breaks X_g[1] (=5.0) vs X_f[1] (=-0.1); other coords coupled.
+    f = writeSat([0.5 -0.1 0.3 0.227272727 0.25,  0.4 5.0 0.3 0.227272727 0.25]);
+    c = onCleanup(@() delete(f)); %#ok<NASGU>
+    v = authoritative_witness_gate(onnx, vnnlib, f, 'validate_witness_multinet.py');
+    verifyTrue(tc, ~strcmp(v, 'valid'), 'a broken-coupling multinet witness must NOT be judged valid');
+end
+
+% ---------- helpers (two-network) ----------
+
+function [onnx, vnnlib] = assumeMonotonicAsset(tc)
+    % Skip when the gate python or the monotonic_acasxu asset is unavailable (CI without benchmarks).
+    assumeFalse(tc, isempty(resolve_gate_python()), 'no python imports onnx+onnxruntime+vnnlib -- skip');
+    here = fileparts(mfilename('fullpath'));
+    base = fullfile(here, '..', '..', '..', '..', '..', 'vnncomp2026_benchmarks', 'benchmarks', ...
+                    'monotonic_acasxu_2026', '2.0');
+    onnx = fullfile(base, 'onnx', 'ACASXU_run2a_2_2_batch_2000.onnx');
+    vnnlib = fullfile(base, 'vnnlib', 'instance_0.vnnlib');
+    assumeTrue(tc, isfile(onnx) || isfile([onnx '.gz']), 'monotonic_acasxu onnx not present -- skip');
+    assumeTrue(tc, isfile(vnnlib) || isfile([vnnlib '.gz']), 'monotonic_acasxu vnnlib not present -- skip');
+end
+
 % ---------- helpers ----------
 
 function [onnx, vnnlib] = assumeAcasxuAsset(tc)


### PR DESCRIPTION
Follow-up to #422. **Verified that monotonic_acasxu sats are REAL, not spurious** — I captured a `verify_multinet` witness and replayed `{x_f, x_g}` through onnxruntime on the real ACAS-Xu ONNX: **NNV's forward matches ORT to ~1e-9** and the counterexample genuinely violates `Y_f[3] < Y_g[3]`. The earlier "issue #7 shape mismatch → spurious instant sat" worry was **false** (MATLAB reshapes the `[5]`→`[1,1,1,5]` input correctly; `verify_multinet.m` is a complete, sound relational verifier, not a stub). So #422's blanket `sat→unknown` downgrade was sound but **over-conservative — it discarded ~50 real sats** (a full 0% category).

## What changed
- **NEW `validate_witness_multinet.py`** — the two-network sibling of `validate_witness_authoritative.py`. Parses the vnnlib-2.0 two-network spec (the `vnnlib` pypi parser exposes `network_name`/`kind`/`indices` + `.networks`/`equal_to`), splits the stacked `[x_f; x_g]` witness by each net's input size, **ORT-forwards both halves** through the network(s), and checks the **literal** two-network spec. Exit `0=valid / 1=spurious / 2=cant`.
- **`authoritative_witness_gate.m`** gains an optional `scriptName` arg (default unchanged → fully backward-compatible) so the one wrapper (python resolver + wall bound + exit map) serves both gates.
- **`run_vnncomp_instance.m`** multinet branch: on a `verify_multinet` sat, write the stacked witness then ORT-gate it — `valid`→trust sat, `spurious`/`cant`→unknown. `unsat` (joint-Star reach, no replayable witness) stays a conservative `unknown`. `NNV_TRUST_MULTINET=1` still bypasses the gate.

## Soundness
`gate=VALID` is **independent of** MATLAB's `load_vnnlib2`: it re-parses with the python `vnnlib` package and re-forwards through ORT, so if `load_vnnlib2` ever mis-extracted the spec, the gate evaluates the *correct* spec and returns spurious → downgrade. The lenient 1e-4 tol can't bite (`verify_multinet` only emits strictly-interior witnesses, `G*y-g < 0` with margin), and any unhandled assertion type raises → `cant` → downgrade. So a sat is emitted **only** when onnxruntime independently confirms the witness satisfies the literal spec → +10, never a −150.

## Verified
- monotonic_acasxu instances 0–3 → **sat (gate=VALID, ORT-confirmed)**.
- broken-coupling witness → not valid (downgrade); missing / non-sat → `cant` (fail-open).
- `test_authoritative_witness_gate.m`: **9/9** (6 single-net + 3 new two-network; existing 3-arg calls unchanged).

## ⚠ Known-open (does NOT block this PR — the sweep scores verdicts, not witness files)
The emitted counterexample **file** uses the flat stacked `X_0..X_9` format (same `write_counterexample` as every other category). I have **not** yet confirmed the **official VNN-COMP two-network CE checker** accepts that format for a 2.0 spec (it may key variables as `X_f[i]`/`X_g[i]` or expect per-network blocks). This proves the sat is *real*, but counting monotonic as **competition points** is gated on a format check — a small `write_counterexample` change in the multinet branch only if needed. Tracking before the next official-path run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)