### PR TITLE
run_vnncomp_instance faithfulness: adaptive_cruise sat status + category-conditional competition env (anti-drift)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -5,6 +5,21 @@ function [status, tTime] = run_vnncomp_instance(category, onnx, vnnlib, outputfi
 t = tic;
 status = 2; % unknown (to start with)
 
+% CATEGORY-CONDITIONAL competition env (ANTI-DRIFT). These per-category tuning flags used to live ONLY in
+% run_instance.sh, so dev harnesses that re-declare config (robust_runner.m, sweep_lambda.sh) silently
+% drifted -- the 2026-06-24 cifar/safenlp class. Setting them HERE, keyed off the category, makes EVERY
+% harness faithful automatically. Guarded with isempty so an explicitly-set env still wins, and the official
+% run_instance.sh (which sets them first) is a no-op here. NOT the conv SOUNDNESS-policy opt-ins
+% (NNV_CONV_TRUST_FP32 etc.) -- those stay deliberately harness-set. See BENCHMARK_RUN_MATRIX.md.
+if contains(category, 'safenlp') && isempty(getenv('NNV_FALSIFY_MAXTIME'))
+    setenv('NNV_FALSIFY_MAXTIME', '8');     % safenlp 20s timeout: default 30s PGD over-runs -> unsats lost
+end
+if contains(category, 'cifar100')
+    if isempty(getenv('NNV_BAB_BETA_ITERS')),     setenv('NNV_BAB_BETA_ITERS', '3');     end
+    if isempty(getenv('NNV_CONV_BETA_FRONTIER')), setenv('NNV_CONV_BETA_FRONTIER', '64'); end
+    if isempty(getenv('NNV_AMORT_ALPHA')),        setenv('NNV_AMORT_ALPHA', '20');        end
+end
+
 % SOUNDNESS HARDENING (persistent/shared-session safety): the per-instance reach budget lives in GLOBALS
 % (NNV_REACH_T0/_BUD) that ANOTHER verifier entry point (NN.verify_vnnlib / NN.verify_robustness) reads via
 % verify_specification, where under exactReach a result==2 is promoted to 0 (sat). A budget left ARMED after
@@ -78,6 +93,10 @@ end
 if contains(category, "adaptive_cruise")
     [acStatus, acCounterEx] = verify_adaptive_cruise_falsify(onnx, vnnlib);
     if acStatus == 0   % SAT, authoritatively confirmed
+        status = 0;    % FIX: set the RETURN status (was left at the default 2). The result FILE was
+                       % written "sat" below, so the OFFICIAL path (execute.py reads the file) was fine,
+                       % but the DEV SWEEP (robust_runner.m / run_all_benchmarks read the RETURN value)
+                       % recorded `unknown` -> adaptive_cruise sats were silently undercounted.
         tTime = toc(t);
         disp("Verification result: 0");
         disp("Total Time: " + string(tTime));


### PR DESCRIPTION
Two small fixes that make the runner self-consistent and **harness-independent**, hardening against the config-drift class that caused the 2026-06-24 cifar regression. **Please review — do not auto-merge.**

## 1. adaptive_cruise returned `status=2` on a real sat (off-by-one-line)
The `contains(category,"adaptive_cruise")` early route (L80) writes the result **file** as `sat` + the authoritatively-validated witness and returns — but never sets the `status` **output**, which stays at its default `2`. So:
- **Official path** (`execute.py` reads the *file*) → `sat`, correct → **no competition impact**.
- **Dev sweep** (`robust_runner.m` / `run_all_benchmarks` read the *return value*) → `unknown` → adaptive_cruise sats silently undercounted.

Fix: `status = 0;` in that block. Safe — the sat is already `vnnlib`-parse + onnxruntime + robust-margin validated by `adaptive_cruise_falsify.py`. (Validation sweep on this branch in progress; expect the findable instances, e.g. instance_2, to now record `sat`.)

## 2. Category-conditional competition env moved into the runner (anti-drift)
These per-category tuning flags previously lived **only** in `run_instance.sh`, so any harness that re-declares config (`robust_runner.m`, `sweep_lambda.sh`) silently drifted — the same failure mode as the cifar conv-flag drop. Now set in `run_vnncomp_instance.m`, keyed off `category`, guarded by `isempty` (so an explicit env or the official path still wins):
- `safenlp` → `NNV_FALSIFY_MAXTIME=8` (else the 30s PGD over-runs the 20s timeout and loses unsats)
- `cifar100` → `NNV_BAB_BETA_ITERS=3` / `NNV_CONV_BETA_FRONTIER=64` / `NNV_AMORT_ALPHA=20`

The conv **soundness-policy** opt-ins (`NNV_CONV_TRUST_FP32` etc.) deliberately stay harness-set (explicit opt-in). Full per-benchmark map: `status-repo/research/sweep_2026-06-24/BENCHMARK_RUN_MATRIX.md`.

## Context
Part of the 2026-06-24 anti-regression work after cifar (S9 23→2 decided) was traced to `sweep_lambda.sh` dropping the conv flags. Static analysis clean (no new issues). Today's verified recoveries on master: cifar 24 decided (vs S8 23), monotonic_acasxu 50/50 sat, lsnc_relu 9 sat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)