### PR TITLE
anti-drift (GAP 4): single-source vnncomp2026_env.sh for the global competition flags

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_instance.sh
@@ -22,26 +22,11 @@ if [ ! -f "$EXECUTE" ]; then
     echo "ERROR: execute.py not found at $EXECUTE"; exit 1
 fi
 
-# Conv GPU-BaB -- GPU PATHWAY (validated 2026-06-19), exported into MATLAB via execute.py.
-# TRUST_FP32: emit the unsat verdict FROM the GPU-single batched-BaB screen (the raw CROWN bound run on
-#   the GPU -- ~95% util, ~5x faster than the FP64-CPU reconfirm it replaces), PGD-backstopped. PGD runs
-#   FALSIFY-FIRST, so a screen-robust that is PGD-clean is the SAME two-mechanism soundness the GPU-winning
-#   tools rely on (alpha-beta-CROWN runs stock FP32 + a PGD attack; NeuralSAT likewise). Validated
-#   0 false-robust vs the alpha-beta-CROWN gold set (23 cifar100/tinyimagenet instances incl gold-SAT).
-#   SOUNDNESS POLICY: trusts FP32 rounding (~1e-6, negligible vs real robustness margins) with PGD as the
-#   backstop -- the deliberate, field-standard GPU verification model. Forces the GPU screen ON.
-# NO_STAR: a non-certifying conv precheck emits a fast sound 'unknown' (Star never certifies these
-#   resnets). FRONTIER 512: more BaB nodes per GPU kernel. All vars affect ONLY the conv precheck path.
-export NNV_CONV_TRUST_FP32=1
-export NNV_CONV_NO_STAR=1
-export NNV_CONV_FRONTIER=512
-# QUARANTINE_CPSTAR: strip the PROBABILISTIC (conformal) cp-star reach method so a cp-star 'unsat' can
-# never be emitted as a sound verdict. cp-star is NOT an FP64 proof -- under the absolute 0-wrong rule a
-# probabilistic unsat is a latent -150 (correct only with some confidence -> over the field some would be
-# wrong). STRICTLY SOUND: only ever converts a cp-star unsat -> unknown (never adds a verdict); the sound
-# FP64 / GPU-BaB / exact paths still decide what they can. Competition-scoped (set here, not the code
-# default) so tests / other callers are unaffected.
-export NNV_QUARANTINE_CPSTAR=1
+# GLOBAL competition soundness-policy flags (NNV_CONV_TRUST_FP32 / NNV_CONV_NO_STAR / NNV_CONV_FRONTIER /
+# NNV_QUARANTINE_CPSTAR) live in ONE place -- vnncomp2026_env.sh -- so every harness sources the SAME values
+# and cannot drift (the 2026-06-24 cifar regression was sweep_lambda.sh dropping these). Full rationale +
+# soundness notes are in that file.
+source "$(dirname "${BASH_SOURCE[0]}")/vnncomp2026_env.sh"
 
 # FALSIFY_MAXTIME: cap the falsify-first PGD budget so the SOUND reach proof keeps its window within the
 # OFFICIAL timeout. safenlp's ftab PGD budget (30s) EXCEEDS its 20s timeout, so on a ROBUST instance PGD

--- a/code/nnv/examples/Submission/VNN_COMP2026/vnncomp2026_env.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/vnncomp2026_env.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# VNN-COMP 2026 GLOBAL competition env -- THE SINGLE SOURCE for the always-on, category-INDEPENDENT
+# soundness-policy verification flags. SOURCE this from every harness (run_instance.sh + every sweep
+# orchestrator) instead of re-declaring the flags, so they can never drift apart. This file exists because
+# of the 2026-06-24 cifar regression: sweep_lambda.sh had silently dropped these flags that run_instance.sh
+# and robust_runner.m set, costing cifar100 its 20 unsats (23->2 decided).
+#
+#   usage:  source "<path>/vnncomp2026_env.sh"
+#
+# These four are deliberate COMPETITION OPT-INS (NOT code defaults), so the test suite / other callers of
+# run_vnncomp_instance.m are unaffected unless they source this. Category-CONDITIONAL flags
+# (safenlp NNV_FALSIFY_MAXTIME, cifar100 NNV_BAB_BETA_ITERS/NNV_CONV_BETA_FRONTIER/NNV_AMORT_ALPHA) are
+# DELIBERATELY NOT here -- they are set per-category inside run_vnncomp_instance.m (PR #424), so they are
+# harness-independent by construction and can't drift either. Per-instance budgets (NNV_REACH_BUDGET,
+# NNV_ACAS_BAB_TIMECAP) are derived from the timeout by the caller, also not here.
+# Source of truth for the full per-benchmark map: status-repo BENCHMARK_RUN_MATRIX.md.
+
+# NNV_CONV_TRUST_FP32: emit the unsat verdict FROM the GPU-single batched-BaB screen (raw CROWN bound on the
+#   GPU, ~5x faster than the FP64-CPU reconfirm), PGD falsify-first as the backstop -- the same two-mechanism
+#   model alpha-beta-CROWN / NeuralSAT use. Validated 0 false-robust vs the alpha-beta-CROWN gold set
+#   (23 cifar100/tinyimagenet incl gold-SAT). Forces the GPU screen ON. WITHOUT it -> 0 conv unsats.
+export NNV_CONV_TRUST_FP32=1
+# NNV_CONV_NO_STAR: a non-certifying conv precheck emits a FAST sound 'unknown' (Star never certifies these
+#   resnets, it just burns the whole timeout). WITHOUT it -> every conv instance times out.
+export NNV_CONV_NO_STAR=1
+# NNV_CONV_FRONTIER: BaB nodes per GPU kernel.
+export NNV_CONV_FRONTIER=512
+# NNV_QUARANTINE_CPSTAR: strip the PROBABILISTIC (conformal) cp-star reach so a cp-star 'unsat' can never be
+#   emitted as a sound verdict (cp-star is not an FP64 proof -> a latent -150 under the 0-wrong rule).
+#   STRICTLY SOUND: only ever converts a cp-star unsat -> unknown; the FP64 / GPU-BaB / exact paths still
+#   decide what they can.
+export NNV_QUARANTINE_CPSTAR=1


### PR DESCRIPTION
Closes GAP 4 from `BENCHMARK_RUN_MATRIX.md`. The 4 always-on soundness-policy flags (`NNV_CONV_TRUST_FP32` / `NNV_CONV_NO_STAR` / `NNV_CONV_FRONTIER` / `NNV_QUARANTINE_CPSTAR`) were duplicated as literals in `run_instance.sh` **and** in every dev sweep harness — so a harness that forgot them silently regressed conv. That is exactly the **2026-06-24 cifar regression** (`sweep_lambda.sh` dropped them → cifar 23→2 decided).

## Change
- **NEW `vnncomp2026_env.sh`** — the single source for those 4 global flags, with the full soundness rationale. Sourced by `run_instance.sh` (here) and by the status-repo orchestrators (companion commit).
- `run_instance.sh` sources it instead of inlining the 4 exports — **behaviour identical** (verified the source yields all four; syntax clean). The `cifar100`/`safenlp` conditional blocks are unchanged.

Category-conditional flags (`safenlp` falsify cap, `cifar100` β-trio) are deliberately **not** in the env file — PR #424 already made those harness-independent inside `run_vnncomp_instance.m`. So after #424 + this, neither the global nor the conditional competition flags can drift across harnesses.

Low-risk: pure refactor of `run_instance.sh`'s export block into a sourced file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)