### PR TITLE
nn4sys lindex: sound batched-IBP early route -> recover ~24 instances (was all-timeout)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Sound batched-IBP decider for nn4sys lindex / lindex_deep (VNN-COMP 2026 early route).
+
+The lindex spec is one big OR over MANY ultra-thin X-boxes (width ~8e-8), each disjunct
+  (and (>= X[0,0] lo) (<= X[0,0] hi) (<= Y[0,0] a))   OR   (... (>= Y[0,0] b))
+i.e. for X in [lo,hi] the UNSAFE region is Y<=a or Y>=b (safe band = (a,b)). The whole instance is
+SAT iff ANY box has an X whose Y is unsafe; UNSAT iff EVERY box keeps Y strictly inside its band.
+
+The net is a tiny FC+ReLU stack (1->128->128->128->1; deep = 5 layers). Over a box this thin, sound
+Interval-Bound-Propagation is essentially tight. NNV's general star/LP reach instead walks the 200-4000
+OR clauses one at a time and TIMES OUT (lindex_200 ran 444s). This does batched IBP (a sound
+over-approximation) in milliseconds, plus a concrete onnxruntime witness search for any non-safe box.
+
+SOUND-OR-UNKNOWN: prints exactly one of
+  unsat   -- EVERY box's IBP output interval is provably inside its safe band  (sound proof)
+  sat     -- a concrete onnxruntime witness lands in an unsafe region          (real counterexample)
+  unknown -- some box's IBP interval touches unsafe but no witness found (IBP too loose) / parse fail
+Never emits unsat/sat without the proof/witness above. A self-check asserts IBP contains the true ORT
+forward at sampled points (a wrong-direction interval would abort to unknown).
+"""
+import sys, re, os, gzip, tempfile
+import numpy as np
+
+# CRASH-SAFE exit codes: NEVER reuse 1 (an uncaught Python exception exits 1) for a verdict, so an
+# unexpected crash maps to fail-open unknown in the MATLAB caller, never a wrong unsat (-150).
+EXIT_SAT, EXIT_UNSAT, EXIT_UNKNOWN = 10, 11, 12
+
+
+def _gunzip(p):
+    if os.path.exists(p):
+        return p
+    if os.path.exists(p + ".gz"):
+        with gzip.open(p + ".gz", "rb") as f:
+            data = f.read()
+        t = tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(p)[1])
+        t.write(data); t.close(); return t.name
+    return p
+
+
+def cant(msg):
+    print("unknown")
+    print("CANT " + msg, file=sys.stderr)
+    sys.exit(EXIT_UNKNOWN)
+
+
+def load_fc_layers(onnx_path):
+    """Return an ordered list of ('gemm', W[out,in], b[out]) / ('relu',) for a pure Gemm/Relu net."""
+    import onnx
+    from onnx import numpy_helper
+    m = onnx.load(onnx_path)
+    init = {i.name: numpy_helper.to_array(i) for i in m.graph.initializer}
+    layers = []
+    for n in m.graph.node:
+        if n.op_type == "Gemm":
+            A = init[n.input[1]].astype(np.float64)
+            b = (init[n.input[2]].astype(np.float64) if len(n.input) > 2
+                 else np.zeros(A.shape[0]))
+            attr = {a.name: a for a in n.attribute}
+            transB = bool(attr["transB"].i) if "transB" in attr else False
+            # NNV/torch export uses y = x @ W^T + b (transB=1), so W=[out,in] is A as-is; else transpose.
+            W = A if transB else A.T
+            alpha = attr["alpha"].f if "alpha" in attr else 1.0
+            beta = attr["beta"].f if "beta" in attr else 1.0
+            layers.append(("gemm", alpha * W, beta * b))
+        elif n.op_type == "Relu":
+            layers.append(("relu",))
+        elif n.op_type in ("Flatten", "Identity", "Reshape"):
+            continue  # shape-only on a [N,1] feature vector -- no-op for IBP
+        else:
+            cant("unsupported op for IBP: " + n.op_type)
+    if not any(L[0] == "gemm" for L in layers):
+        cant("no Gemm layers found")
+    return layers
+
+
+def ibp(layers, lb, ub):
+    """Sound interval propagation. lb,ub: [N,d_in]; returns [N,d_out] interval bounds."""
+    for L in layers:
+        if L[0] == "gemm":
+            W, b = L[1], L[2]                 # y = x @ W^T + b, W=[out,in]
+            Wp = np.maximum(W, 0.0); Wn = np.minimum(W, 0.0)
+            nlb = lb @ Wp.T + ub @ Wn.T + b
+            nub = ub @ Wp.T + lb @ Wn.T + b
+            lb, ub = nlb, nub
+        else:                                  # relu (monotone -> interval is [relu(lb),relu(ub)])
+            lb, ub = np.maximum(lb, 0.0), np.maximum(ub, 0.0)
+    return lb, ub
+
+
+def parse_boxes(vnn_path):
+    """Return boxes [(lo,hi)], a[N], b[N] (unsafe = Y<=a or Y>=b; defaults open)."""
+    txt = open(vnn_path).read()
+    pat = (r"\(and\s*\(>=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*\(<=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*"
+           r"\((<=|>=)\s*Y\[0,0\]\s*([-\d.eE]+)\)")
+    from collections import OrderedDict
+    g = OrderedDict()
+    for lo, hi, sense, bnd in re.findall(pat, txt):
+        k = (float(lo), float(hi))
+        g.setdefault(k, {})
+        g[k]["a" if sense == "<=" else "b"] = float(bnd)
+    if not g:
+        cant("no lindex sub-queries parsed")
+    boxes = list(g.keys())
+    a = np.array([g[k].get("a", -np.inf) for k in boxes])
+    b = np.array([g[k].get("b", np.inf) for k in boxes])
+    return boxes, a, b
+
+
+def main():
+    if len(sys.argv) < 3:
+        cant("usage: nn4sys_lindex_decide.py <onnx> <vnnlib>")
+    onnx_p = _gunzip(sys.argv[1]); vnn_p = _gunzip(sys.argv[2])
+    try:
+        layers = load_fc_layers(onnx_p)
+        boxes, a, b = parse_boxes(vnn_p)
+    except SystemExit:
+        raise
+    except Exception as e:
+        cant("setup failed: " + str(e))
+
+    los = np.array([lo for lo, _ in boxes], dtype=np.float64)
+    his = np.array([hi for _, hi in boxes], dtype=np.float64)
+
+    def subdiv_bounds(idx, K):
+        """Sound output interval per box (worst case over K equal sub-boxes). IBP is exact at a point,
+        so subdividing the thin box shrinks IBP's correlation-looseness ~linearly -> tight + sound."""
+        lo = los[idx]; hi = his[idx]; n = len(idx)
+        Ylb = np.full(n, np.inf); Yub = np.full(n, -np.inf)
+        e = np.linspace(0.0, 1.0, K + 1)
+        for j in range(K):
+            sl = (lo + (hi - lo) * e[j]).reshape(-1, 1)
+            su = (lo + (hi - lo) * e[j + 1]).reshape(-1, 1)
+            ylb, yub = ibp(layers, sl, su)
+            Ylb = np.minimum(Ylb, ylb.ravel()); Yub = np.maximum(Yub, yub.ravel())
+        return Ylb, Yub
+
+    # ADAPTIVE REFINEMENT: certify all boxes at the smallest K; re-subdivide ONLY the still-unsafe boxes
+    # at higher K (keeps memory bounded -- only the few band-boundary boxes need depth). All sound.
+    pending = np.arange(len(boxes))
+    YlbAll = np.full(len(boxes), np.nan); YubAll = np.full(len(boxes), np.nan)
+    for K in (1, 16, 64, 256, 1024, 4096):
+        if pending.size == 0:
+            break
+        ylb, yub = subdiv_bounds(pending, K)
+        YlbAll[pending] = ylb; YubAll[pending] = yub
+        safe = (ylb > a[pending]) & (yub < b[pending])
+        pending = pending[~safe]
+
+    # SOUNDNESS SELF-CHECK: the sound interval MUST contain the true onnxruntime forward at sampled points.
+    try:
+        import onnxruntime as ort
+        s = ort.InferenceSession(onnx_p)
+        iname = s.get_inputs()[0].name; ish = s.get_inputs()[0].shape
+        shp = tuple(1 if (d is None or isinstance(d, str)) else d for d in ish)
+
+        def fwd(x):
+            xv = np.array([[x]], dtype=np.float32).reshape(shp)
+            return float(np.array(s.run(None, {iname: xv})[0]).ravel()[0])
+        chk = np.random.default_rng(0).choice(len(boxes), size=min(50, len(boxes)), replace=False)
+        for i in chk:
+            for x in (boxes[i][0], boxes[i][1], 0.5 * (boxes[i][0] + boxes[i][1])):
+                y = fwd(x)
+                if y < YlbAll[i] - 1e-4 or y > YubAll[i] + 1e-4:
+                    cant("soundness self-check FAILED (interval does not contain forward) -> refuse verdict")
+    except SystemExit:
+        raise
+    except Exception as e:
+        cant("onnxruntime self-check unavailable: " + str(e))
+
+    if pending.size == 0:
+        print("unsat"); sys.exit(EXIT_UNSAT)
+
+    # boxes still un-certified at K_max -> hunt a concrete witness (densely) before claiming anything
+    for i in pending:
+        lo, hi = boxes[i]
+        for x in np.linspace(lo, hi, 64):
+            y = fwd(float(x))
+            if y <= a[i] or y >= b[i]:
+                print("sat"); print("(X_0 %.17g)" % float(x)); print("(Y_0 %.17g)" % y); sys.exit(EXIT_SAT)
+    print("unknown"); sys.exit(EXIT_UNKNOWN)
+
+
+if __name__ == "__main__":
+    main()

--- a/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
@@ -18,12 +18,25 @@ SOUND-OR-UNKNOWN: prints exactly one of
 Never emits unsat/sat without the proof/witness above. A self-check asserts IBP contains the true ORT
 forward at sampled points (a wrong-direction interval would abort to unknown).
 """
-import sys, re, os, gzip, tempfile
+import sys, re, os, gzip, tempfile, atexit
 import numpy as np
 
 # CRASH-SAFE exit codes: NEVER reuse 1 (an uncaught Python exception exits 1) for a verdict, so an
 # unexpected crash maps to fail-open unknown in the MATLAB caller, never a wrong unsat (-150).
 EXIT_SAT, EXIT_UNSAT, EXIT_UNKNOWN = 10, 11, 12
+
+# .gz inputs are extracted to temp files; remove them on exit so an eval box running many instances
+# does not leak /tmp.
+_TMPFILES = []
+
+
+@atexit.register
+def _cleanup_tmpfiles():
+    for p in _TMPFILES:
+        try:
+            os.unlink(p)
+        except OSError:
+            pass
 
 
 def _gunzip(p):
@@ -33,7 +46,9 @@ def _gunzip(p):
         with gzip.open(p + ".gz", "rb") as f:
             data = f.read()
         t = tempfile.NamedTemporaryFile(delete=False, suffix=os.path.splitext(p)[1])
-        t.write(data); t.close(); return t.name
+        t.write(data); t.close()
+        _TMPFILES.append(t.name)
+        return t.name
     return p
 
 
@@ -89,7 +104,8 @@ def ibp(layers, lb, ub):
 
 def parse_boxes(vnn_path):
     """Return boxes [(lo,hi)], a[N], b[N] (unsafe = Y<=a or Y>=b; defaults open)."""
-    txt = open(vnn_path).read()
+    with open(vnn_path, encoding="utf-8") as f:
+        txt = f.read()
     pat = (r"\(and\s*\(>=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*\(<=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*"
            r"\((<=|>=)\s*Y\[0,0\]\s*([-\d.eE]+)\)")
     from collections import OrderedDict
@@ -149,7 +165,10 @@ def main():
     # SOUNDNESS SELF-CHECK: the sound interval MUST contain the true onnxruntime forward at sampled points.
     try:
         import onnxruntime as ort
-        s = ort.InferenceSession(onnx_p)
+        # pin CPU (like the other VNN_COMP2026 ORT scripts): the session backs the soundness self-check +
+        # witness validation, so behaviour must not depend on the local ORT GPU build, and it must not
+        # contend for the GPU during a sweep.
+        s = ort.InferenceSession(onnx_p, providers=["CPUExecutionProvider"])
         iname = s.get_inputs()[0].name; ish = s.get_inputs()[0].shape
         shp = tuple(1 if (d is None or isinstance(d, str)) else d for d in ish)
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -2199,7 +2199,13 @@ function [status, counterEx] = verify_nn4sys_lindex(onnx, vnnlib)
     script = fullfile(here, 'nn4sys_lindex_decide.py');
     if ~isfile(script), fprintf('nn4sys_lindex_decide.py not found -> unknown\n'); return; end
     py = python_exe();   % needs onnx+numpy+onnxruntime (it parses the vnnlib itself; no vnnlib pkg)
-    if isempty(py), fprintf('no onnx+onnxruntime python for the lindex decider -> unknown\n'); return; end
+    % python_exe() falls back to a PLAIN interpreter when the stack is absent, so isempty alone never
+    % trips. Probe the imports explicitly -> fail fast to a sound `unknown` instead of spawning a doomed
+    % subprocess. (A bad stack would still fail-open via the crash-safe exit map, but this is cleaner.)
+    [probe_rc, ~] = system(sprintf('%s -c "import onnx, onnxruntime, numpy"', py));
+    if isempty(py) || probe_rc ~= 0
+        fprintf('no onnx+onnxruntime+numpy python for the lindex decider -> unknown\n'); return;
+    end
     if ispc
         cmd = sprintf('%s "%s" "%s" "%s"', py, script, char(onnx), char(vnnlib));
     else

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -79,6 +79,29 @@ if contains(category, "cctsdb_yolo")
     return;
 end
 
+%% 0a) nn4sys lindex / lindex_deep: huge OR over ULTRA-THIN X-boxes -> sound batched-IBP decider.
+% A 1-in/1-out learned-index FC+ReLU net whose spec is a disjunction over 200-60000 ultra-thin X-boxes
+% (~8e-8 wide), each requiring Y in a safe band. NNV's general star/LP reach walks the clauses one at a
+% time and TIMES OUT (lindex_200 ran 444s). Route to nn4sys_lindex_decide.py: sound IBP + ADAPTIVE box
+% subdivision (IBP is exact at a point, so subdividing the thin box is sound AND tightens it ~linearly)
+% -> decides every lindex instance in <6s. SOUND-OR-UNKNOWN: unsat only when every box's sound interval
+% is provably inside its band; sat only with an onnxruntime witness; else unknown. (Validated standalone:
+% 24/24 lindex instances -> unsat, IBP-contains-forward self-check green.)
+if contains(category, "nn4sys") && contains(onnx, "lindex")
+    [status, counterEx] = verify_nn4sys_lindex(onnx, vnnlib);
+    tTime = toc(t);
+    disp("Verification result: " + string(status));
+    fid = fopen(outputfile, 'w');
+    if status == 0
+        fprintf(fid, 'sat \n'); fclose(fid); write_counterexample(outputfile, counterEx);
+    elseif status == 1
+        fprintf(fid, 'unsat \n'); fclose(fid);
+    else
+        fprintf(fid, 'unknown \n'); fclose(fid);
+    end
+    return;
+end
+
 %% 0b) adaptive_cruise: NONLINEAR-property falsification path (bypasses NNV's gated load_vnnlib)
 %
 % adaptive_cruise_control_non_linear_2026 has NONLINEAR vnnlib (X*Y, X*X) which NNV deliberately
@@ -2167,6 +2190,35 @@ end
 % onnxruntime. Exit protocol: 10 = SAT (witness CSV written + "SAT p q y" on
 % stdout), 11 = UNSAT, anything else = unknown. ANY parse/replay irregularity
 % on the MATLAB side also degrades to unknown -- never an unsound verdict.
+function [status, counterEx] = verify_nn4sys_lindex(onnx, vnnlib)
+    % Sound batched-IBP + adaptive box-subdivision decider for nn4sys lindex (nn4sys_lindex_decide.py).
+    % Crash-safe exit-code map: 10=sat, 11=unsat, ANYTHING ELSE -> unknown (fail-open). A Python crash
+    % (uncaught exception -> exit 1) therefore degrades to a sound `unknown`, never a wrong unsat (-150).
+    status = 2; counterEx = nan;
+    here = fileparts(mfilename('fullpath'));
+    script = fullfile(here, 'nn4sys_lindex_decide.py');
+    if ~isfile(script), fprintf('nn4sys_lindex_decide.py not found -> unknown\n'); return; end
+    py = python_exe();   % needs onnx+numpy+onnxruntime (it parses the vnnlib itself; no vnnlib pkg)
+    if isempty(py), fprintf('no onnx+onnxruntime python for the lindex decider -> unknown\n'); return; end
+    if ispc
+        cmd = sprintf('%s "%s" "%s" "%s"', py, script, char(onnx), char(vnnlib));
+    else
+        cmd = sprintf('timeout 60 %s "%s" "%s" "%s"', py, script, char(onnx), char(vnnlib));
+    end
+    [rc, out] = system(cmd);
+    disp(strtrim(out));
+    switch rc
+        case 11, status = 1;   % unsat: every box's sound interval is provably inside its band
+        case 10                % sat: a concrete onnxruntime witness
+            xv = regexp(out, '\(X_0\s+([-+0-9.eE]+)\)', 'tokens', 'once');
+            yv = regexp(out, '\(Y_0\s+([-+0-9.eE]+)\)', 'tokens', 'once');
+            if ~isempty(xv) && ~isempty(yv)
+                status = 0; counterEx = {str2double(xv{1}); str2double(yv{1})};
+            end                % else: claimed sat but unparseable witness -> stay unknown
+        otherwise, status = 2; % 12 (cant/unknown) / 124 (timeout) / 1 (crash) / anything -> fail-open
+    end
+end
+
 function [status, counterEx] = verify_cctsdb_enumeration(onnx, vnnlib)
     status = 2; counterEx = nan;
     here = fileparts(mfilename('fullpath'));

--- a/code/nnv/tests/vnncomp25/test_nn4sys_lindex.m
+++ b/code/nnv/tests/vnncomp25/test_nn4sys_lindex.m
@@ -1,0 +1,77 @@
+function tests = test_nn4sys_lindex
+%TEST_NN4SYS_LINDEX  Tests for the nn4sys lindex early route (sound batched-IBP + adaptive box
+%   subdivision decider, nn4sys_lindex_decide.py, dispatched from run_vnncomp_instance.m). The lindex
+%   spec is a huge OR over ultra-thin X-boxes; NNV's general star/LP reach times out (lindex_200 = 444s),
+%   so the early route decides it via sound IBP (exact at a point -> subdividing the thin box is sound
+%   AND tight). The decider is SOUND-OR-UNKNOWN with CRASH-SAFE exit codes (10=sat/11=unsat/else=unknown,
+%   so a Python crash degrades to unknown, never a wrong unsat).
+%
+%   Groups:
+%     * always-run: the decider script ships next to the runner.
+%     * decide correctness (needs onnx+onnxruntime python AND the nn4sys benchmark asset): lindex_200 and
+%       a lindex_deep instance -> unsat via the early route, in well under the 30s budget.
+    tests = functiontests(localfunctions);
+end
+
+function setupOnce(tc)
+    here = fileparts(mfilename('fullpath'));
+    sub = fullfile(here, '..', '..', 'examples', 'Submission', 'VNN_COMP2026');
+    tc.TestData.addedPath = '';
+    if isfolder(sub) && ~contains(path, sub)
+        addpath(sub); tc.TestData.addedPath = sub;
+    end
+    tc.TestData.sub = sub;
+end
+
+function teardownOnce(tc)
+    if isfield(tc.TestData, 'addedPath') && ~isempty(tc.TestData.addedPath)
+        rmpath(tc.TestData.addedPath);
+    end
+end
+
+% ---------- always-run ----------
+
+function test_decider_script_present(tc)
+    verifyTrue(tc, isfile(fullfile(tc.TestData.sub, 'nn4sys_lindex_decide.py')), ...
+        'nn4sys_lindex_decide.py must ship next to run_vnncomp_instance.m');
+end
+
+% ---------- decide correctness (needs python + benchmark asset) ----------
+
+function test_lindex_unsat(tc)
+    [onnx, vnn] = assumeLindexAsset(tc, 'lindex.onnx', 'lindex_200.vnnlib');
+    of = [tempname '.txt']; c = onCleanup(@() delete(of)); %#ok<NASGU>
+    st = run_vnncomp_instance('nn4sys', onnx, vnn, of);
+    verifyEqual(tc, st, 1, 'lindex_200 must be soundly UNSAT via the early route');
+    verifyTrue(tc, contains(fileread(of), 'unsat'), 'result file must say unsat');
+end
+
+function test_lindex_deep_unsat(tc)
+    [onnx, vnn] = assumeLindexAsset(tc, 'lindex_deep.onnx', 'lindex_400.vnnlib');
+    of = [tempname '.txt']; c = onCleanup(@() delete(of)); %#ok<NASGU>
+    st = run_vnncomp_instance('nn4sys', onnx, vnn, of);
+    verifyEqual(tc, st, 1, 'lindex_deep/lindex_400 must be soundly UNSAT (deeper net, IBP looser -> more subdivision)');
+end
+
+% ---------- helpers ----------
+
+function [onnx, vnn] = assumeLindexAsset(tc, onnxName, vnnName)
+    assumeFalse(tc, isempty(resolve_ort_python()), 'no python imports onnx+onnxruntime -- skip');
+    here = fileparts(mfilename('fullpath'));
+    base = fullfile(here, '..', '..', '..', '..', '..', 'vnncomp2026_benchmarks', 'benchmarks', 'nn4sys', '2.0');
+    onnx = fullfile(base, 'onnx', onnxName);
+    vnn  = fullfile(base, 'vnnlib', vnnName);
+    if ~isfile(onnx) && isfile([onnx '.gz']), gunzip([onnx '.gz']); end
+    if ~isfile(vnn)  && isfile([vnn '.gz']),  gunzip([vnn '.gz']);  end
+    assumeTrue(tc, isfile(onnx) && isfile(vnn), 'nn4sys lindex benchmark asset not present -- skip');
+end
+
+function py = resolve_ort_python()
+    cands = {strtrim(getenv('NNV_ORT_PYTHON')), fullfile(getenv('HOME'), 'taylor_venv', 'bin', 'python'), 'python3', 'python'};
+    py = '';
+    for i = 1:numel(cands)
+        c = cands{i}; if isempty(c), continue; end
+        [st, ~] = system(sprintf('"%s" -c "import onnx, onnxruntime, numpy"', c));
+        if st == 0, py = c; return; end
+    end
+end


### PR DESCRIPTION
Recovers the **nn4sys lindex / lindex_deep** sub-benchmark (24 instances, was scoring **0%** — all timeout). Identified by the 0%-category scoping (`status-repo/.../ZERO_PCT_CATEGORIES_PLAN.md`) as the highest-confidence bounded win.

## Problem
lindex is a 1-in/1-out learned-index FC+ReLU net whose spec is a huge **OR over 200–60000 ultra-thin X-boxes** (~8e-8 wide), each requiring `Y ∈ (a,b)`. NNV's general star/LP reach walks the clauses one at a time and **times out** (lindex_200 ran 444s).

## Fix — sound batched-IBP + adaptive box subdivision (new early route)
`nn4sys_lindex_decide.py`, dispatched from `run_vnncomp_instance.m` (`contains(category,"nn4sys") && contains(onnx,"lindex")`), decides every instance in **<6s**:
- IBP is **exact at a point**, so subdividing the thin box is sound and tightens the bound ~linearly. (Plain IBP is too loose — it drops inter-neuron correlation through the 128-wide Gemms; K=16 sub-boxes already certifies lindex_200.)
- Per-box **adaptive refinement** (1→16→…→4096) keeps memory bounded — only the few band-boundary boxes need depth.

## Soundness (0-wrong)
- `unsat` **only** when every box's sound interval is provably inside its band; `sat` **only** with a concrete onnxruntime witness; else `unknown`.
- A per-run **self-check** asserts the IBP interval contains the true onnxruntime forward at sampled points (a wrong-direction interval aborts to `unknown`).
- **Crash-safe exit codes** (10=sat / 11=unsat / else=unknown): a Python crash (uncaught exception → exit 1) maps to fail-open `unknown` in the MATLAB caller, never a wrong unsat.

## Validation
- Standalone: **24/24** lindex instances (both nets, lindex_1…lindex_60000) → `unsat`, self-check green, 0.3–5.4s.
- `run_vnncomp_instance` smoke: 3/3 `unsat` (0.37–2.52s).
- New `tests/vnncomp25/test_nn4sys_lindex.m`: **3/3** green.

Please review — not auto-merging. (pensieve_simple is the next nn4sys lever per the plan; separate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)