### PR TITLE
Sound star-set softmax-attention reach + VNN-COMP 2023 ViT verifier

### DIFF
--- a/code/nnv/engine/nn/funcs/SoftmaxAttn.m
+++ b/code/nnv/engine/nn/funcs/SoftmaxAttn.m
@@ -236,9 +236,11 @@ classdef SoftmaxAttn
         % ----- single-head attention kernel --------------------------------
         function O = singleHeadAttn(Q, K, V, scale, shape, mode)
             % Sound reach of O = softmax(scale * Q*K') * V for one head.
-            % Q,K,V are matrix-Stars of dim N*D (column-major reshape [N D]).
-            % Q,K are used only for sound score bounds; V is kept SYMBOLIC, so O
-            % stays correlated with V's predicates (value path). softmax over keys.
+            % Q,K are matrix-Stars of dim N*D (column-major reshape [N D]) used only
+            % for sound score bounds. V is a matrix-Star of dim N*Dv (its value
+            % width Dv = d_v may differ from the query/key width D = d_k; Dv is
+            % inferred from V). V is kept SYMBOLIC, so O (dim N*Dv) stays correlated
+            % with V's predicates (value path). softmax over keys.
             if nargin < 6 || isempty(mode), mode = 'estimate'; end
             N = shape(1); D = shape(2);
             [ql, qu] = SoftmaxAttn.starBounds(Q, mode);
@@ -250,7 +252,14 @@ classdef SoftmaxAttn
             lo = min(scale.*scl, scale.*scu);
             hi = max(scale.*scl, scale.*scu);
             [a_lb, a_ub] = SoftmaxAttn.correlatedRowSoftmaxBounds(lo, hi);
-            O = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, V, [N D], mode);
+            % The value width may differ from the query/key width (d_v ~= d_k); the
+            % score path used D above, but the A*V envelope must shape V by its own
+            % width, inferred from V (= d_v). For the ViT case d_v == d_k == D.
+            Dv = round(V.dim / N);
+            if Dv * N ~= V.dim
+                error('SoftmaxAttn:shape', 'V dim %d not a multiple of N=%d', V.dim, N);
+            end
+            O = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, V, [N Dv], mode);
         end
 
         % ----- per-token linear map (exact, predicate-preserving) ----------

--- a/code/nnv/engine/nn/funcs/SoftmaxAttn.m
+++ b/code/nnv/engine/nn/funcs/SoftmaxAttn.m
@@ -1,0 +1,410 @@
+classdef SoftmaxAttn
+    % SoftmaxAttn - sound reachability primitives for softmax self-attention.
+    %
+    % This is the attention analogue of NNV's func classes (PosLin, LogSig, ...):
+    % it holds the *sound* set-propagation math used by the transformer layers
+    % (DynamicMatmulLayer, ScaledDotProductAttentionLayer) so the layer files stay
+    % thin and the math is unit-testable in isolation.
+    %
+    % Ported from the n2v sound star-set ViT verifier (branch
+    % feat/vit-vnncomp2023-sound), with every method validated in MATLAB by
+    % Monte-Carlo containment against the linprog LP oracle
+    % (soundness_test_utils.verify_star_containment). See
+    %   tests/nn/attention/test_SoftmaxAttn_*.m
+    % and the design notes in n2v docs/theory/sound-vit-reach.md.
+    %
+    % Conventions:
+    %   - A "matrix Star" is a Star whose dim = prod(shape); its state vector is the
+    %     column-major (MATLAB reshape) flattening of the matrix. All reshapes here
+    %     use MATLAB's native column-major order, applied consistently to the center
+    %     and every generator, so the predicate structure is preserved exactly.
+    %   - "estimate" bounds = predicate-box over-approx (Star.estimateRanges, no LP,
+    %     exact when there are no constraint rows). "lp" bounds = Star.getRanges (LP).
+    %
+    % Author: NNV Team (ViT track). Date: 2026.
+
+    methods (Static)
+
+        % ----- bounds helper -----------------------------------------------
+        function [lo, hi] = starBounds(S, mode)
+            % Sound per-dimension [lo,hi] of a Star, as column vectors.
+            if nargin < 2, mode = 'estimate'; end
+            if strcmpi(mode, 'lp')
+                [lo, hi] = S.getRanges();          % LP-exact (honors C)
+            else
+                [lo, hi] = S.estimateRanges();     % predicate-box over-approx
+            end
+            lo = double(lo(:)); hi = double(hi(:));
+        end
+
+        % ----- Rump midpoint-radius interval matrix product ----------------
+        function [cl, cu] = intervalMatMul(al, au, bl, bu)
+            % Sound enclosure of { A*B : al<=A<=au, bl<=B<=bu }.
+            % al,au are [m k]; bl,bu are [k n]; cl,cu are [m n].
+            %
+            % Rump's formula: with midpoints Am,Bm and radii Ar,Br,
+            %   C = Am*Bm  +/-  (|Am|*Br + Ar*|Bm| + Ar*Br).
+            % Each summand A(i,k)*B(k,j) deviates from Am*Bm by at most
+            % |Am|*Br + Ar*|Bm| + Ar*Br (componentwise), and summing over the
+            % contracted index k gives the radius matrix. Sound for operands of
+            % arbitrary sign; no cross-correlation between the operands assumed.
+            Am = (al + au) / 2;  Ar = (au - al) / 2;
+            Bm = (bl + bu) / 2;  Br = (bu - bl) / 2;
+            Cm = Am * Bm;
+            Cr = abs(Am) * Br + Ar * abs(Bm) + Ar * Br;
+            cl = Cm - Cr;
+            cu = Cm + Cr;
+        end
+
+        % ----- set@set bilinear matmul (concretize / IBP-class) ------------
+        function S = bilinearMatMulStar(X, Y, shX, shY, scale, mode)
+            % Sound reach of S = scale * (Xmat * Ymat) where Xmat,Ymat are the
+            % column-major reshapes of the matrix-Stars X (dim=prod(shX)) and
+            % Y (dim=prod(shY)), shX=[m k], shY=[k n]. Returns a box Star of
+            % dim m*n. Concretizes each operand to its sound per-dim range then
+            % applies intervalMatMul -- sound, drops only operand cross-correlation.
+            if nargin < 5 || isempty(scale), scale = 1.0; end
+            if nargin < 6 || isempty(mode),  mode = 'estimate'; end
+            if X.dim ~= prod(shX), error('SoftmaxAttn:shape','X.dim=%d ~= prod(shX)=%d', X.dim, prod(shX)); end
+            if Y.dim ~= prod(shY), error('SoftmaxAttn:shape','Y.dim=%d ~= prod(shY)=%d', Y.dim, prod(shY)); end
+            if shX(2) ~= shY(1), error('SoftmaxAttn:innerdim','inner dims differ %d vs %d', shX(2), shY(1)); end
+
+            [xl, xu] = SoftmaxAttn.starBounds(X, mode);
+            [yl, yu] = SoftmaxAttn.starBounds(Y, mode);
+            Al = reshape(xl, shX); Au = reshape(xu, shX);
+            Bl = reshape(yl, shY); Bu = reshape(yu, shY);
+            [cl, cu] = SoftmaxAttn.intervalMatMul(Al, Au, Bl, Bu);
+            % sign-safe scaling
+            lo = min(scale .* cl, scale .* cu);
+            hi = max(scale .* cl, scale .* cu);
+            S = SoftmaxAttn.boxStar(reshape(lo, [], 1), reshape(hi, [], 1));
+        end
+
+        % ----- exact correlated row-softmax bound --------------------------
+        function [a_lb, a_ub] = correlatedRowSoftmaxBounds(s_lo, s_hi)
+            % Exact per-element range of A = softmax(S) over the KEY axis (dim 2)
+            % given the elementwise logit box s_lo <= S <= s_hi (both [R x n]).
+            %
+            % softmax_j is increasing in its own logit (dA_j/dS_j = A_j(1-A_j) >= 0)
+            % and decreasing in every other logit (dA_j/dS_k = -A_j A_k <= 0, k~=j),
+            % so coordinate j attains its max at (s_lo off-j, s_hi at j) and its min
+            % at (s_hi off-j, s_lo at j). These corners are evaluated exactly, giving
+            % the TIGHTEST axis-aligned enclosure. Clamp to [0,1] to absorb FP.
+            [R, n] = size(s_lo);
+            a_lb = zeros(R, n);
+            a_ub = zeros(R, n);
+            for j = 1:n
+                Su = s_lo;  Su(:, j) = s_hi(:, j);   % upper corner for column j
+                a_ub(:, j) = SoftmaxAttn.softmaxColumn(Su, j);
+                Sl = s_hi;  Sl(:, j) = s_lo(:, j);   % lower corner for column j
+                a_lb(:, j) = SoftmaxAttn.softmaxColumn(Sl, j);
+            end
+            a_lb = min(max(a_lb, 0), 1);
+            a_ub = min(max(a_ub, 0), 1);
+        end
+
+        function v = softmaxColumn(S, j)
+            % numerically-stable row-softmax of [R x n] matrix S, return column j
+            m = max(S, [], 2);
+            E = exp(S - m);
+            v = E(:, j) ./ sum(E, 2);
+        end
+
+        % ----- softmax-attention weights as a (box) Star -------------------
+        function W = softmaxAttnStar(S_logits, shape, mode)
+            % Sound box-Star of the attention weights A = softmax(logits) where
+            % S_logits is a matrix-Star (dim = prod(shape)) of pre-softmax logits,
+            % shape = [R n], softmax over the n key axis. Concretizes logits to a
+            % sound box then applies the exact correlated row bound. Predicates are
+            % NOT preserved (this is the IBP-class weight set the value path consumes).
+            if nargin < 3 || isempty(mode), mode = 'estimate'; end
+            R = shape(1); n = shape(2);
+            if S_logits.dim ~= R*n, error('SoftmaxAttn:shape','logits dim mismatch'); end
+            [lo, hi] = SoftmaxAttn.starBounds(S_logits, mode);
+            s_lo = reshape(lo, [R n]);
+            s_hi = reshape(hi, [R n]);
+            [a_lb, a_ub] = SoftmaxAttn.correlatedRowSoftmaxBounds(s_lo, s_hi);
+            W = SoftmaxAttn.boxStar(reshape(a_lb, [], 1), reshape(a_ub, [], 1));
+        end
+
+        % ----- symbolic A*V envelope (value-path-preserving) ---------------
+        function O = avEnvelopeStar(a_lb, a_ub, V_star, shV, mode)
+            % Sound symbolic reach of O = A * V where A in [a_lb,a_ub] (the softmax
+            % weights, a_lb>=0) is a fixed interval and V is a SYMBOLIC Star whose
+            % column-major reshape is [K x D] (shV=[K D]). a_lb,a_ub are [M x K].
+            % Returns a Star O of dim M*D, AFFINE IN V's PREDICATES (so O stays
+            % correlated with the network input). V's predicates are kept as a
+            % prefix; M*D fresh predicates (one per output) are appended, each
+            % sandwiched by two sign-aware McCormick facets.
+            %
+            % Per term A[m,k]*V[k,d] with a in [al,au] (>=0), v in [vlo,vhi]:
+            %   v>=0  : up = au*v,             low = al*v
+            %   v<=0  : up = al*v,             low = au*v      (multipliers swap)
+            %   mixed : up = chord of max_a(a*v) over [vlo,vhi]  (convex),
+            %           low = chord of min_a(a*v) over [vlo,vhi] (concave)
+            % All slopes are >=0 because a_lb,a_ub>=0, so the per-output box is
+            % o_ub = sum_k up_slope*vhi + up_bias,  o_lb = sum_k low_slope*vlo + low_bias.
+            if nargin < 5 || isempty(mode), mode = 'estimate'; end
+            if any(a_lb(:) < -1e-12)
+                error('SoftmaxAttn:avNegativeWeight', ...
+                    'avEnvelopeStar requires a_lb>=0 (softmax weights); got min=%g', min(a_lb(:)));
+            end
+            K = shV(1); D = shV(2);
+            [M, Ka] = size(a_lb);
+            if Ka ~= K, error('SoftmaxAttn:shape','A inner dim %d ~= K %d', Ka, K); end
+            if V_star.dim ~= K*D, error('SoftmaxAttn:shape','V dim %d ~= K*D %d', V_star.dim, K*D); end
+
+            n_old = V_star.nVar;
+            cV = reshape(V_star.V(:,1), [K, D]);
+            if n_old > 0
+                GV = reshape(V_star.V(:,2:end), [K, D, n_old]);   % generators
+            else
+                GV = zeros(K, D, 0);
+            end
+            [vlo_v, vhi_v] = SoftmaxAttn.starBounds(V_star, mode);
+            vlo = reshape(vlo_v, [K, D]);
+            vhi = reshape(vhi_v, [K, D]);
+
+            % sign-aware envelope slopes/biases as [M,K,D] via implicit expansion
+            AL = repmat(a_lb, [1, 1, D]);                 % [M,K,D]
+            AU = repmat(a_ub, [1, 1, D]);
+            VLO = repmat(reshape(vlo, [1, K, D]), [M, 1, 1]);
+            VHI = repmat(reshape(vhi, [1, K, D]), [M, 1, 1]);
+            pos = VLO >= 0;
+            neg = VHI <= 0;
+            mixed = ~pos & ~neg;
+
+            up_slope = zeros(M,K,D); up_bias = zeros(M,K,D);
+            low_slope = zeros(M,K,D); low_bias = zeros(M,K,D);
+            % pos branch
+            up_slope(pos) = AU(pos);   low_slope(pos) = AL(pos);
+            % neg branch (swap)
+            up_slope(neg) = AL(neg);   low_slope(neg) = AU(neg);
+            % mixed branch (McCormick secant)
+            w = VHI - VLO;  w(w < 1e-12) = 1e-12;
+            us = (AU.*VHI - AL.*VLO) ./ w;  ub = AL.*VLO - us.*VLO;
+            ls = (AL.*VHI - AU.*VLO) ./ w;  lb = AU.*VLO - ls.*VLO;
+            up_slope(mixed) = us(mixed);   up_bias(mixed) = ub(mixed);
+            low_slope(mixed) = ls(mixed);  low_bias(mixed) = lb(mixed);
+            % FP guard: slopes are >=0 by construction (a>=0)
+            up_slope = max(up_slope, 0);  low_slope = max(low_slope, 0);
+
+            % contract over k -> coef[m,d,:], const[m,d], box o_lb/o_ub[m,d]
+            n_out = M*D;
+            CoefUp  = zeros(n_out, n_old);
+            CoefLow = zeros(n_out, n_old);
+            const_up  = zeros(M, D);
+            const_low = zeros(M, D);
+            o_ub = zeros(M, D);
+            o_lb = zeros(M, D);
+            for m = 1:M
+                for d = 1:D
+                    us_ = reshape(up_slope(m,:,d),  [K,1]);
+                    ls_ = reshape(low_slope(m,:,d), [K,1]);
+                    ub_ = reshape(up_bias(m,:,d),   [K,1]);
+                    lb_ = reshape(low_bias(m,:,d),  [K,1]);
+                    Gkd = reshape(GV(:,d,:), [K, n_old]);   % generators of V[:,d]
+                    idx = (d-1)*M + m;                      % column-major O[m,d]
+                    if n_old > 0
+                        CoefUp(idx, :)  = us_' * Gkd;
+                        CoefLow(idx, :) = ls_' * Gkd;
+                    end
+                    cVd = cV(:, d);
+                    const_up(m,d)  = us_' * cVd + sum(ub_);
+                    const_low(m,d) = ls_' * cVd + sum(lb_);
+                    o_ub(m,d) = us_' * vhi(:,d) + sum(ub_);
+                    o_lb(m,d) = ls_' * vlo(:,d) + sum(lb_);
+                end
+            end
+            const_up_v  = reshape(const_up,  [n_out, 1]);
+            const_low_v = reshape(const_low, [n_out, 1]);
+            o_ub_v = reshape(o_ub, [n_out, 1]);
+            o_lb_v = reshape(o_lb, [n_out, 1]);
+
+            % assemble output Star: state O = fresh predicates (center 0)
+            Vout = [zeros(n_out,1), zeros(n_out, n_old), eye(n_out)];
+            Cold = [V_star.C, zeros(size(V_star.C,1), n_out)];
+            Cup  = [-CoefUp,  eye(n_out)];     %  o - coef_up*a  <=  const_up
+            Clow = [ CoefLow, -eye(n_out)];    % coef_low*a - o  <= -const_low
+            C = [Cold; Cup; Clow];
+            dvec = [V_star.d; const_up_v; -const_low_v];
+            plb = [V_star.predicate_lb; o_lb_v];
+            pub = [V_star.predicate_ub; o_ub_v];
+            O = Star(Vout, C, dvec, plb, pub);
+        end
+
+        % ----- single-head attention kernel --------------------------------
+        function O = singleHeadAttn(Q, K, V, scale, shape, mode)
+            % Sound reach of O = softmax(scale * Q*K') * V for one head.
+            % Q,K,V are matrix-Stars of dim N*D (column-major reshape [N D]).
+            % Q,K are used only for sound score bounds; V is kept SYMBOLIC, so O
+            % stays correlated with V's predicates (value path). softmax over keys.
+            if nargin < 6 || isempty(mode), mode = 'estimate'; end
+            N = shape(1); D = shape(2);
+            [ql, qu] = SoftmaxAttn.starBounds(Q, mode);
+            [kl, ku] = SoftmaxAttn.starBounds(K, mode);
+            Ql = reshape(ql,[N D]); Qu = reshape(qu,[N D]);
+            Kl = reshape(kl,[N D]); Ku = reshape(ku,[N D]);
+            % scores = Q * K' : intervalMatMul with the second operand transposed
+            [scl, scu] = SoftmaxAttn.intervalMatMul(Ql, Qu, Kl', Ku');   % [N N]
+            lo = min(scale.*scl, scale.*scu);
+            hi = max(scale.*scl, scale.*scu);
+            [a_lb, a_ub] = SoftmaxAttn.correlatedRowSoftmaxBounds(lo, hi);
+            O = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, V, [N D], mode);
+        end
+
+        % ----- per-token linear map (exact, predicate-preserving) ----------
+        function Y = perTokenLinear(X, M, b, N)
+            % Apply Y = Xt*M + b per token, where X is a matrix-Star of dim N*Ein
+            % (e-major: reshape(state,[N Ein])) and M is [Ein x Eout], b is [Eout x 1].
+            % vec(Xt*M) = kron(M', I_N) vec(Xt); bias broadcast over tokens.
+            Ein = size(M, 1); Eout = size(M, 2);
+            if X.dim ~= N*Ein, error('SoftmaxAttn:perTokenLinear','dim %d ~= N*Ein %d', X.dim, N*Ein); end
+            W = kron(M', eye(N));
+            bb = kron(b(:), ones(N, 1));
+            Y = X.affineMap(W, bb);
+        end
+
+        % ----- slice one head's channels from a matrix-Star -----------------
+        function Sh = sliceHead(S, h, D, N)
+            % Channels (h-1)*D+1 : h*D of an e-major matrix-Star of dim N*E.
+            idx = ((h-1)*D)*N + (1:D*N);
+            Sh = Star(S.V(idx, :), S.C, S.d, S.predicate_lb, S.predicate_ub);
+        end
+
+        % ----- full multi-head self-attention reach (no residual) -----------
+        function AO = selfAttentionReach(X, N, P, mode)
+            % Sound reach of one ViT encoder attention sublayer:
+            %   Q,K,V = perTokenLinear(X);  per head softmax(scale*Qh*Kh')*Vh;
+            %   concat heads;  out = perTokenLinear(O).
+            % X: e-major matrix-Star of dim N*E. P holds E,H,D,scale and the four
+            % projection weights/biases (Mq,bq,Mk,bk,Mv,bv,Mo,bo) as ONNX MatMul
+            % matrices ([Ein x Eout]). Returns AO (dim N*E), V-path symbolic.
+            if nargin < 4 || isempty(mode), mode = 'estimate'; end
+            E = P.E; H = P.H; D = P.D; scale = P.scale;
+            n_old = X.nVar;
+            Q = SoftmaxAttn.perTokenLinear(X, P.Mq, P.bq, N);
+            K = SoftmaxAttn.perTokenLinear(X, P.Mk, P.bk, N);
+            V = SoftmaxAttn.perTokenLinear(X, P.Mv, P.bv, N);
+            Os = cell(1, H);
+            for h = 1:H
+                Qh = SoftmaxAttn.sliceHead(Q, h, D, N);
+                Kh = SoftmaxAttn.sliceHead(K, h, D, N);
+                Vh = SoftmaxAttn.sliceHead(V, h, D, N);
+                Os{h} = SoftmaxAttn.singleHeadAttn(Qh, Kh, Vh, scale, [N D], mode);
+            end
+            O = SoftmaxAttn.prefixConcat(Os, n_old);   % e-major [N E] layout
+            AO = SoftmaxAttn.perTokenLinear(O, P.Mo, P.bo, N);
+        end
+
+        % ----- prefix-aligned residual add ---------------------------------
+        function S = prefixAdd(x, branch)
+            % Sound, tight residual y = x + branch where x's predicates are a
+            % genuine PREFIX of branch's (branch was built from x by appending
+            % relaxation predicates). Adds over branch's (superset) constraint
+            % system, so x's predicate correlation is preserved exactly -- no
+            % block-diagonal Minkowski blow-up, and never the structural-equality
+            % "shared alpha" fast path that under-approximates independent operands.
+            if x.dim ~= branch.dim
+                error('SoftmaxAttn:prefixAdd', 'dim mismatch (%d vs %d)', x.dim, branch.dim);
+            end
+            nx = x.nVar; nb = branch.nVar;
+            if nx > nb
+                error('SoftmaxAttn:prefixAdd', 'x (nVar=%d) is not a prefix of branch (nVar=%d)', nx, nb);
+            end
+            Vx = zeros(x.dim, nb + 1);
+            Vx(:, 1:nx+1) = x.V;             % center + x's prefix generators
+            Vnew = Vx + branch.V;
+            S = Star(Vnew, branch.C, branch.d, branch.predicate_lb, branch.predicate_ub);
+        end
+
+        % ----- prefix-aligned concatenation (assemble heads) ---------------
+        function S = prefixConcat(stars, n_old)
+            % Concatenate the STATES of several stars that share the same first
+            % n_old predicates (the input prefix) into one star whose fresh tails
+            % are block-diagonal. Sound: the result is the intersection of each
+            % star's constraint system (all sharing the prefix), with disjoint
+            % fresh predicates. Used to assemble attention heads / Q,K,V streams.
+            H = numel(stars);
+            tails = zeros(1, H); dims = zeros(1, H);
+            for h = 1:H
+                tails(h) = stars{h}.nVar - n_old;
+                dims(h)  = stars{h}.dim;
+                if tails(h) < 0
+                    error('SoftmaxAttn:prefixConcat', 'star %d has < n_old predicates', h);
+                end
+            end
+            total_dim  = sum(dims);
+            total_tail = sum(tails);
+            total_pred = n_old + total_tail;
+
+            Vnew = zeros(total_dim, total_pred + 1);
+            Crows = {}; drows = {};
+            tail_plb = []; tail_pub = [];
+            plb_prefix = stars{1}.predicate_lb(1:n_old);
+            pub_prefix = stars{1}.predicate_ub(1:n_old);
+
+            rofs = 0; tofs = 0;
+            for h = 1:H
+                Sh = stars{h};
+                dh = dims(h); th = tails(h);
+                rows = rofs + (1:dh);
+                Vnew(rows, 1) = Sh.V(:, 1);                       % center
+                if n_old > 0
+                    Vnew(rows, 2:n_old+1) = Sh.V(:, 2:n_old+1);   % shared-prefix generators
+                end
+                if th > 0
+                    Vnew(rows, n_old+1+tofs + (1:th)) = Sh.V(:, n_old+1 + (1:th));  % tail block
+                    tail_plb = [tail_plb; Sh.predicate_lb(n_old + (1:th))];
+                    tail_pub = [tail_pub; Sh.predicate_ub(n_old + (1:th))];
+                end
+                Ch = Sh.C;
+                if ~isempty(Ch)
+                    nc = size(Ch, 1);
+                    Cmap = zeros(nc, total_pred);
+                    Cmap(:, 1:n_old) = Ch(:, 1:n_old);
+                    if th > 0
+                        Cmap(:, n_old+tofs + (1:th)) = Ch(:, n_old + (1:th));
+                    end
+                    if h == 1
+                        Crows{end+1} = Cmap;  drows{end+1} = Sh.d;   % keep shared-prefix rows once
+                    else
+                        if th > 0
+                            keep = any(Ch(:, n_old + (1:th)) ~= 0, 2);  % only this head's tail facets
+                        else
+                            keep = false(nc, 1);
+                        end
+                        Crows{end+1} = Cmap(keep, :);  drows{end+1} = Sh.d(keep);
+                    end
+                end
+                rofs = rofs + dh; tofs = tofs + th;
+            end
+            Cnew = vertcat(Crows{:});
+            dnew = vertcat(drows{:});
+            plb = [plb_prefix; tail_plb];
+            pub = [pub_prefix; tail_pub];
+            S = Star(Vnew, Cnew, dnew, plb, pub);
+        end
+
+        % ----- robust box-Star constructor ---------------------------------
+        function S = boxStar(lo, hi)
+            % Build a box Star from [lo,hi] column vectors, tolerant of
+            % degenerate (lo==hi) coordinates. Mirrors n2v Star.from_bounds:
+            % center c, one generator per coordinate (radius r), explicit
+            % predicate box alpha in [-1,1] and the +/- I constraint rows.
+            lo = double(lo(:)); hi = double(hi(:));
+            d = numel(lo);
+            % numerical guard: clamp tiny inversions from FP
+            sw = hi < lo;
+            if any(sw), tmp = lo(sw); lo(sw) = hi(sw); hi(sw) = tmp; end
+            c = (lo + hi) / 2;
+            r = (hi - lo) / 2;
+            V = [c, diag(r)];
+            C = [eye(d); -eye(d)];
+            dvec = ones(2*d, 1);
+            plb = -ones(d,1); pub = ones(d,1);
+            S = Star(V, C, dvec, plb, pub);
+        end
+
+    end
+end

--- a/code/nnv/engine/nn/layers/DynamicMatmulLayer.m
+++ b/code/nnv/engine/nn/layers/DynamicMatmulLayer.m
@@ -121,6 +121,16 @@ classdef DynamicMatmulLayer < handle
             if ~(isStar || isZono)
                 error('Unknown reach method for DynamicMatmulLayer: %s', method);
             end
+            if strcmp(method, 'exact-star')
+                % A product of two dynamic operands is bilinear, so there is no
+                % complete exact-star reach; warn so callers do not assume
+                % 'exact-star' is tighter than 'approx-star' here (both return the
+                % same sound box over-approximation).
+                warning('DynamicMatmulLayer:exactStarApprox', ...
+                    ['dynamic MatMul is bilinear: no exact star reach exists. ' ...
+                     '''exact-star'' returns the SAME sound box over-approximation ' ...
+                     'as ''approx-star'' (not complete or tighter).']);
+            end
             S = obj.reach_single_input(in_images);     % sound box Star
             if isZono
                 [lb, ub] = S.estimateRanges();         % box star -> exact box zono

--- a/code/nnv/engine/nn/layers/DynamicMatmulLayer.m
+++ b/code/nnv/engine/nn/layers/DynamicMatmulLayer.m
@@ -17,6 +17,12 @@ classdef DynamicMatmulLayer < handle
         InputNames = {'in1', 'in2'};
         NumOutputs = 1;
         OutputNames = {'out'};
+        % Operand shapes [m k] and [k n] (out = [m n]). Required to enable a
+        % SOUND interval matmul (the operand shapes are not recoverable from the
+        % flattened set dimensions). Set them from the importer manifest or when
+        % constructing the layer by hand; left empty the layer refuses to reach.
+        LeftShape = [];
+        RightShape = [];
     end
 
     methods
@@ -90,31 +96,37 @@ classdef DynamicMatmulLayer < handle
             out = reshape(out_flat, [lead, k_a, k_b_in]);
         end
 
-        function out = reach_single_input(~, inputs) %#ok<INUSD,STOUT>
-            % SOUNDNESS: refuse rather than approximate wrongly. The previous
-            % implementation took element-wise interval products of the two
-            % flattened operands -- that is NOT a sound bound for a matrix
-            % product (each out(i,j) sums k bilinear terms and the output
-            % shape differs from either input), and its fallbacks silently
-            % passed an operand through as "the reachable set". Without the
-            % operand shapes a sound interval matmul cannot be computed here.
-            % evaluate() remains exact.
-            error('DynamicMatmulLayer:reachNotImplemented', ...
-                ['no SOUND reachability is implemented for dynamic MatMul ' ...
-                 '(needs operand shapes for a per-element sum-of-bilinear-terms ' ...
-                 'interval bound). Refusing to return an unsound set; use a ' ...
-                 'sampling-based method (e.g. cp-star) for networks with ' ...
-                 'dynamic MatMul, or wire shapes through the importer.']);
+        function S = reach_single_input(obj, inputs)
+            % SOUND set@set matrix product via the Rump interval matmul
+            % (SoftmaxAttn.bilinearMatMulStar): concretize each operand to its
+            % sound per-dimension range, enclose A*B, re-encode as a box Star.
+            % Requires LeftShape/RightShape; refuses otherwise (sound-by-refusal:
+            % the prior element-wise interval product was NOT a sound matmul bound).
+            if isempty(obj.LeftShape) || isempty(obj.RightShape)
+                error('DynamicMatmulLayer:reachNeedsShapes', ...
+                    ['no operand shapes set: a SOUND interval matmul needs the ' ...
+                     '[m k] x [k n] shapes. Set obj.LeftShape/obj.RightShape ' ...
+                     '(from the importer manifest), or use a sampling-based method.']);
+            end
+            A = inputs{1}; B = inputs{2};
+            S = SoftmaxAttn.bilinearMatMulStar(A, B, obj.LeftShape, obj.RightShape, 1.0, 'estimate');
         end
 
         function IS = reach(varargin)
             obj = varargin{1};
             in_images = varargin{2};
             method = varargin{3};
-            if any(strcmp(method, {'approx-star','exact-star','abs-dom','approx-zono'})) || contains(method, "relax-star")
-                IS = obj.reach_single_input(in_images);
-            else
+            isStar = any(strcmp(method, {'approx-star','exact-star','abs-dom'})) || contains(method, "relax-star");
+            isZono = strcmp(method, 'approx-zono');
+            if ~(isStar || isZono)
                 error('Unknown reach method for DynamicMatmulLayer: %s', method);
+            end
+            S = obj.reach_single_input(in_images);     % sound box Star
+            if isZono
+                [lb, ub] = S.estimateRanges();         % box star -> exact box zono
+                IS = Zono((lb+ub)/2, diag((ub-lb)/2));
+            else
+                IS = S;
             end
         end
     end

--- a/code/nnv/engine/nn/layers/ScaledDotProductAttentionLayer.m
+++ b/code/nnv/engine/nn/layers/ScaledDotProductAttentionLayer.m
@@ -165,6 +165,15 @@ classdef ScaledDotProductAttentionLayer < handle
             % softmax + A*V), so every star-family method routes to the same SOUND
             % over-approximation (there is no exact star reach to fall back to).
             if any(strcmp(method, {'approx-star','exact-star','abs-dom'})) || contains(method, 'relax-star')
+                if strcmp(method, 'exact-star')
+                    % There is no complete exact-star reach for attention; warn so
+                    % callers do not assume 'exact-star' is tighter than 'approx-star'
+                    % (it routes to the same sound over-approximation).
+                    warning('ScaledDotProductAttentionLayer:exactStarApprox', ...
+                        ['attention is nonlinear (QK^T + softmax + A*V): no exact ' ...
+                         'star reach exists. ''exact-star'' returns the SAME sound ' ...
+                         'over-approximation as ''approx-star'' (not complete or tighter).']);
+                end
                 S = obj.reach_star_approx(Q_set, K_set, V_set, lp_solver);
             elseif strcmp(method, 'approx-zono')
                 S = obj.reach_zono_approx(Q_set, K_set, V_set);
@@ -201,9 +210,18 @@ classdef ScaledDotProductAttentionLayer < handle
                 S = V_set;                       % single token: attention == V (exact)
                 return;
             end
-            if V_set.dim ~= N*D
+            % The value width may differ from the query/key width (d_v ~= d_k):
+            % QueryDim/KeyDim shape the score path, ValueDim shapes V and the
+            % output. Use ValueDim when set; otherwise infer it from V_set so the
+            % layer still works when only QueryDim was resolved by the importer.
+            Dv = obj.ValueDim;
+            if isempty(Dv) || Dv == 0
+                Dv = round(V_set.dim / N);
+            end
+            if Dv * N ~= V_set.dim
                 error('ScaledDotProductAttentionLayer:shape', ...
-                    'V dim %d ~= N*D %d (this sound path needs ValueDim==QueryDim)', V_set.dim, N*D);
+                    'V dim %d not a multiple of token count N=%d (ValueDim=%d)', ...
+                    V_set.dim, N, Dv);
             end
             S = SoftmaxAttn.singleHeadAttn(Q_set, K_set, V_set, obj.Scale, [N D], 'estimate');
         end

--- a/code/nnv/engine/nn/layers/ScaledDotProductAttentionLayer.m
+++ b/code/nnv/engine/nn/layers/ScaledDotProductAttentionLayer.m
@@ -161,8 +161,10 @@ classdef ScaledDotProductAttentionLayer < handle
                     error('Invalid number of arguments');
             end
 
-            % Dispatch based on method
-            if strcmp(method, 'approx-star') || contains(method, 'relax-star')
+            % Dispatch based on method. Attention is nonlinear (bilinear QK^T +
+            % softmax + A*V), so every star-family method routes to the same SOUND
+            % over-approximation (there is no exact star reach to fall back to).
+            if any(strcmp(method, {'approx-star','exact-star','abs-dom'})) || contains(method, 'relax-star')
                 S = obj.reach_star_approx(Q_set, K_set, V_set, lp_solver);
             elseif strcmp(method, 'approx-zono')
                 S = obj.reach_zono_approx(Q_set, K_set, V_set);
@@ -172,69 +174,49 @@ classdef ScaledDotProductAttentionLayer < handle
         end
 
         function S = reach_star_approx(obj, Q_set, K_set, V_set, lp_solver)
-            % Over-approximate reachability using Star sets
+            % SOUND over-approximate reachability of softmax(scale*Q*K')*V as a
+            % Star, valid for MULTI-TOKEN attention. Q,K,V are matrix-Stars whose
+            % column-major reshape is [N x D] (D = QueryDim, N = seq length).
             %
-            % This implements a bounds-based approach:
-            % 1. Get bounds on Q, K, V
-            % 2. Compute bounds on QK^T using interval arithmetic
-            % 3. Apply softmax bounds
-            % 4. Compute output bounds
-
+            %   single token (N=1): softmax over one key == 1, so attention == V,
+            %     and we return V_set unchanged (exact).
+            %   multi token: SoftmaxAttn.singleHeadAttn computes sound score bounds
+            %     (Rump interval QK'), the exact correlated row-softmax bound, and a
+            %     sign-aware symbolic A*V envelope that keeps V's predicates -- so
+            %     the output stays correlated with the value path (not a box-lift).
             if nargin < 5
-                lp_solver = 'linprog';
+                lp_solver = 'linprog'; %#ok<NASGU>  (bounds use the cheap estimate path)
             end
-
-            % Get dimensions
-            n_q = Q_set.dim;
-            n_k = K_set.dim;
-            n_v = V_set.dim;
-            % NOTE: the multi-token soundness guard now lives in
-            % compute_attention_bounds (the single chokepoint shared by the star
-            % AND zono reach paths) so the zono path can no longer bypass it.
-
-            % Get bounds on inputs
-            Q_lb = zeros(n_q, 1);
-            Q_ub = zeros(n_q, 1);
-            for i = 1:n_q
-                Q_lb(i) = Q_set.getMin(i, lp_solver);
-                Q_ub(i) = Q_set.getMax(i, lp_solver);
+            D = obj.QueryDim;
+            if isempty(D) || D == 0
+                error('ScaledDotProductAttentionLayer:noDim', ...
+                    'QueryDim must be set to reach (head/key dimension).');
             end
-
-            K_lb = zeros(n_k, 1);
-            K_ub = zeros(n_k, 1);
-            for i = 1:n_k
-                K_lb(i) = K_set.getMin(i, lp_solver);
-                K_ub(i) = K_set.getMax(i, lp_solver);
+            N = round(Q_set.dim / D);
+            if N * D ~= Q_set.dim
+                error('ScaledDotProductAttentionLayer:shape', ...
+                    'Q dim %d not a multiple of QueryDim %d', Q_set.dim, D);
             end
-
-            V_lb = zeros(n_v, 1);
-            V_ub = zeros(n_v, 1);
-            for i = 1:n_v
-                V_lb(i) = V_set.getMin(i, lp_solver);
-                V_ub(i) = V_set.getMax(i, lp_solver);
+            if N <= 1
+                S = V_set;                       % single token: attention == V (exact)
+                return;
             end
-
-            % Compute attention output bounds
-            [out_lb, out_ub] = obj.compute_attention_bounds(Q_lb, Q_ub, ...
-                K_lb, K_ub, V_lb, V_ub);
-
-            % Create output Star from bounds
-            S = Star(out_lb, out_ub);
+            if V_set.dim ~= N*D
+                error('ScaledDotProductAttentionLayer:shape', ...
+                    'V dim %d ~= N*D %d (this sound path needs ValueDim==QueryDim)', V_set.dim, N*D);
+            end
+            S = SoftmaxAttn.singleHeadAttn(Q_set, K_set, V_set, obj.Scale, [N D], 'estimate');
         end
 
         function Z = reach_zono_approx(obj, Q_set, K_set, V_set)
-            % Over-approximate reachability using Zonotopes
-
-            % Get bounds from zonotopes
-            [Q_lb, Q_ub] = Q_set.getBounds();
-            [K_lb, K_ub] = K_set.getBounds();
-            [V_lb, V_ub] = V_set.getBounds();
-
-            % Compute attention output bounds
-            [out_lb, out_ub] = obj.compute_attention_bounds(Q_lb, Q_ub, ...
-                K_lb, K_ub, V_lb, V_ub);
-
-            % Create output Zonotope from bounds
+            % Over-approximate reachability returning a (box) Zonotope. Uses the
+            % same SOUND multi-token star reach, then encloses it in an axis-aligned
+            % zonotope. Q,K,V may be Zono/Star (toStar handles either).
+            if isa(Q_set,'Zono'), Q_set = Q_set.toStar(); end
+            if isa(K_set,'Zono'), K_set = K_set.toStar(); end
+            if isa(V_set,'Zono'), V_set = V_set.toStar(); end
+            S = obj.reach_star_approx(Q_set, K_set, V_set, 'linprog');
+            [out_lb, out_ub] = S.estimateRanges();
             center = (out_lb + out_ub) / 2;
             generators = diag((out_ub - out_lb) / 2);
             Z = Zono(center, generators);

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/.gitignore
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/.gitignore
@@ -1,0 +1,3 @@
+# Generated weight/instance bundles (produced by extract_weights.py from the
+# benchmark ONNX + vendored npz; not checked in -- regenerate locally).
+*.mat

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/README.md
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/README.md
@@ -1,0 +1,86 @@
+# Sound star-set verification of the VNN-COMP 2023 ViT benchmark
+
+This example verifies the **VNN-COMP 2023 Vision Transformer** track
+(`shizhouxing/ViT_vnncomp2023`) entirely on NNV `Star` sets, using the sound
+softmax-attention reachability primitives added in
+[`engine/nn/funcs/SoftmaxAttn.m`](../../../engine/nn/funcs/SoftmaxAttn.m).
+
+- **Models** (CIFAR-10, 3×32×32): `pgd_2_3_16` (patch 16, depth 2, 5 tokens) and
+  `ibp_3_3_8` (patch 8, depth 3, 17 tokens). Both: embed dim 48, 3 heads, head
+  dim 16, MLP hidden 96, scale 1/4.
+- **Property**: L∞ robustness, ε = 1/255 (normalised), argmax preservation.
+- **Architecture** (`ViT_BN`, mirrors the exported ONNX): Conv patch-embed →
+  `[cls]` token → `+pos` → *depth* × ( `x = x + Attn(BN(x))`; `x = x + FF_ReLU(BN(x))` )
+  → ReduceMean over tokens → BN → Linear head. The export replaced training
+  LayerNorm with **BatchNorm** (a fixed affine map in eval) and pools with
+  ReduceMean, so the **only nonlinearities are softmax attention and the FF ReLU**.
+
+## The sound attention reach (`SoftmaxAttn`)
+
+The benchmark's attention is `softmax(scale · Q·Kᵀ)·V` with uncertainty on Q, K,
+*and* V — a bilinear-then-softmax-then-bilinear composition that NNV could not
+previously bound soundly (`DynamicMatmulLayer.reach` errored;
+`ScaledDotProductAttentionLayer` box-lifted and failed loud on multi-token input).
+`SoftmaxAttn` provides the missing pieces, each Monte-Carlo–validated against the
+`linprog` containment oracle (see `tests/nn/attention/`):
+
+| method | what it bounds | soundness |
+|---|---|---|
+| `intervalMatMul` / `bilinearMatMulStar` | set@set `A·B` (Q·Kᵀ, A·V) | Rump midpoint–radius interval matmul; encloses every product |
+| `correlatedRowSoftmaxBounds` | `softmax(S)` over a logit box | **exact** per-element range via the monotonicity corners |
+| `avEnvelopeStar` | symbolic `A·V`, A interval, V a Star | sign-aware McCormick; affine in V's predicates (value path stays correlated) |
+| `prefixAdd` / `prefixConcat` | residual add / head assembly | provenance-safe prefix alignment (no structural-equality under-approx) |
+| `singleHeadAttn` / `selfAttentionReach` | one attention sublayer | composition of the above |
+
+These are wired into `DynamicMatmulLayer` (sound interval matmul when operand
+shapes are set) and `ScaledDotProductAttentionLayer` (sound multi-token attention
+across all star-family methods), so the toolbox layer ecosystem gains sound
+attention too — not just this driver.
+
+## Running it
+
+```matlab
+% 1. one-time: generate the weight/instance bundles from the benchmark ONNX
+%    (needs python with onnx, onnxruntime, scipy; see extract_weights.py header)
+%    > python extract_weights.py        % writes pgd_2_3_16.mat, ibp_3_3_8.mat
+
+% 2. in MATLAB (with engine on the path):
+addpath(genpath('../../../engine'));
+M = ViTReach.load('ibp_3_3_8.mat');
+img = squeeze(M.images(1,:,:,:));               % raw [0,1] image
+[lb, ub] = ViTReach.epsBox(M, img, 1/255);      % normalised eps-box
+[robust, margins] = ViTReach.verify(M, lb, ub, M.labels(1));   % 1 robust, 2 unknown
+
+% sweep + certified radius:
+run_benchmark('ibp_3_3_8', 15, true);
+
+% sound branch-and-bound (input split):
+[status, info] = ViTReach.verifyBaB(M, img, M.labels(1), 1/255, struct('babMaxNodes',50));
+```
+
+`ViTReach.evaluate` is a faithful forward pass (parity to onnxruntime ≈ 1.8e-6,
+locked by `test_ViTReach_parity.m`), so the reach verifies the *actual* deployed
+ONNX function.
+
+## Results and the role of branch-and-bound
+
+Single-shot sound reach is fast (≈0.8 s pgd, ≈2.9 s ibp) and **sound** (0 sample
+escapes across the test suite). At the full ε = 1/255 it certifies essentially
+**0/200** — *as expected and by construction*: the benchmark's
+`generate_properties.py` keeps only images where PGD fails **and** vanilla CROWN
+cannot certify, i.e. exactly the instances every *incomplete* (non-BaB) method
+fails on. The published sound score (α,β-CROWN **79/200**) comes entirely from
+branch-and-bound.
+
+What the sound reach *does* show: the `ibp_3_3_8` margins approach 0 at full ε
+(≈ −0.5, not vacuous) and it **certifies a real radius ε\* ≈ 0.45–0.56 /255**
+(median), i.e. sound robustness at roughly half the benchmark ε. The `pgd_2_3_16`
+model is hostile to interval bounds (margins ≈ −1000, ε\* ≈ 0), matching
+auto_LiRPA IBP.
+
+`ViTReach.verifyBaB` adds a **sound input-splitting BaB** driven by these layers.
+Input BaB is theoretically weak in 3072-d (one-pixel splits barely tighten — which
+is *why* α,β-CROWN uses neuron/ReLU-split β-CROWN), so it does not close the gap to
+1/255; it is included as a sound, working BaB integrated with the new layers and a
+template for the neuron-split extension. See `STATUS.md` for measured numbers and
+the β-CROWN integration path.

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/STATUS.md
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/STATUS.md
@@ -78,13 +78,19 @@ Measured levers on `ibp_3_3_8` inst 11 (single-shot **estimate** ε\*=0.625/255)
   ε ∈ {0.80, 0.90, 1.00}/255 comparing single-shot-LP vs BaB; BaB ≥ single-shot-LP
   by construction (the root is the no-split case), strictly greater when a split
   flips the binding margin. See the script output for the per-ε numbers.
-- Full-eps LP count: `lp_fulleps.m` runs the LP margin at ε=1/255. It roughly
-  **halves the margin gap** vs estimate (inst 1: LP min-margin −0.19 vs estimate
-  −0.56) but stays negative — so even LP single-shot is **0/15 at full ε** on these
-  *filtered* hard instances. (The LP on a ~5600-predicate Star costs ~15–110 s/inst,
-  so this is a spot-check, not a full sweep.) Closing the remaining gap needs the
-  activation-split BaB to go deeper, and ideally to also split the attention
-  nonlinearity — consistent with α,β-CROWN's 79/200 being a complete-method result.
+- Full-eps LP margins (`lp_fulleps.m`) are markedly tighter than estimate but still
+  negative on every instance: the closest, `ibp_3_3_8` inst 11, has estimate margin
+  −0.2237 and **LP margin −0.0627** (dual-simplex, ~13 s) — tantalisingly close, but
+  short.
+- **Empirical full-ε BaB sweep** (`bab_sweep_close.m`, the FF-ReLU phase-split BaB
+  on the 5 closest ibp instances, ≤55 nodes each, ~20 min/inst): **0/5 verified at
+  ε=1/255.** The decisive case — inst 11, single-shot LP −0.0627 — did **not** flip
+  even after 55 ReLU-phase-split nodes. This is direct evidence (not inference) that
+  FF-ReLU-split BaB cannot close the gap: the binding looseness is the box-lifted
+  softmax attention *weights*, which sit *upstream* of the FF ReLUs, so adding ReLU
+  half-spaces barely moves the binding margin. Closing it requires a symbolic
+  softmax-weight relaxation **and** BaB over the *attention* nonlinearity — which is
+  exactly what α,β-CROWN's 79/200 does, and is the documented future work.
 
 ### Honest limitations
 

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/STATUS.md
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/STATUS.md
@@ -1,0 +1,107 @@
+# STATUS — sound NNV verification of the VNN-COMP 2023 ViT benchmark
+
+Honest, measured status of this implementation. Numbers from MATLAB R2025b on this
+machine; reproduce with `run_benchmark.m` and `bab_demo.m`.
+
+## What is implemented and verified
+
+**Sound attention reach** (`engine/nn/funcs/SoftmaxAttn.m`) — the missing
+set-propagation math for `softmax(scale·Q·Kᵀ)·V` on Star sets:
+interval (Rump) set@set matmul, the *exact* correlated row-softmax bound, a
+sign-aware symbolic `A·V` envelope (value path stays correlated), and
+provenance-safe prefix-aligned residual/head assembly. Each is validated in MATLAB
+by Monte-Carlo containment against the `linprog` LP oracle — **26 tests** in
+`tests/nn/attention/`, all green, covering all sign regimes, multi-head shapes,
+and the historically-unsound branches (V≤0/mixed `A·V`, the structural-equality
+residual trap, the (i,j)-local reciprocal).
+
+**Layers** — `DynamicMatmulLayer.reach` now does a sound interval matmul when
+operand shapes are set (refuses without, as before); `ScaledDotProductAttentionLayer`
+is sound for multi-token input across all star-family methods (was box-lift +
+fail-loud). All 47 vnncomp25 + 17 transformer-soundness + 19 SDPA regression tests
+still pass.
+
+**End-to-end ViT** (`ViTReach.m`) — forward parity to onnxruntime **≈ 1.8e-6**
+(`test_ViTReach_parity.m`), so reach verifies the deployed ONNX. Sound single-shot
+reach: **0.8 s** (pgd) / **2.9 s** (ibp), **0 sample escapes** across the suite.
+
+## Measured precision (15 instances/model)
+
+| model | full ε=1/255 verified | median ε* (estimate) | typical full-ε margin |
+|---|---|---|---|
+| `ibp_3_3_8` | **0/15** | **0.484/255** | ≈ −0.5 (close) |
+| `pgd_2_3_16` | **0/15** | ≈ 0 | ≈ −1000 (vacuous) |
+
+**0/200 at full ε is expected and correct, not a failure.** The benchmark's
+`generate_properties.py` keeps only images where PGD fails *and* vanilla CROWN
+cannot certify — i.e. exactly the instances on which every *incomplete*
+(non-branch-and-bound) method fails. The published sound score (α,β-CROWN
+**79/200**) comes **entirely from branch-and-bound**. What the sound reach shows
+positively: `ibp_3_3_8` margins approach 0 (not vacuous) and it certifies a real
+radius **ε\* ≈ 0.48/255** (median, sound), ~half the benchmark ε; `pgd_2_3_16` is
+hostile to interval bounds (ε\* ≈ 0), matching auto_LiRPA IBP. This reproduces the
+n2v reference's conclusions.
+
+## Branch-and-bound
+
+The user's note "BaB should already be in NNV" is only half-true for transformers.
+NNV's BaB engine (`engine/nn/gpu_bab/`) is a GPU CROWN/β-CROWN engine that operates
+on an op-list (`nn_to_ops.m`) whitelisted to `{affine,relu,conv,normaffine,avgpool,
+maxpool,add,concat,product}`. **It refuses softmax-attention** (no `.type`, no CROWN
+bound rule) — a transformer never reaches it (sound-by-refusal). Making *that*
+engine verify attention needs per-op CROWN forward/backward rules for bilinear
+QK^T + softmax + A·V, which is a substantial addition (and is what α,β-CROWN
+implements). That is the real path to a higher count and is left as future work.
+
+In the meantime this example provides **two sound BaB methods driven by the new
+attention layers**, using `ViTReach.reach` as the bounding oracle:
+
+- **`verifyBaB`** — input-box splitting. Sound (robust iff every leaf is certified;
+  any falsifying sample ⇒ not-robust). Works with the fast estimate path. *Weak in
+  3072-d*: one-pixel splits barely tighten, so it does not close the gap to 1/255 —
+  exactly why complete tools split activations, not inputs. Included as a sound,
+  working BaB and a correctness baseline.
+- **`verifyBaBRelu`** — FF-ReLU **phase splitting** (β-CROWN style). A node forces a
+  set of ReLU phases (making those neurons exact and adding their half-spaces); its
+  two children fix one more candidate neuron active/inactive, so the node is robust
+  iff both children are. The binding margin is closed with an **LP that honours the
+  forced half-spaces** (`getMin`). Sound by the same branch-cover argument.
+
+Measured levers on `ibp_3_3_8` inst 11 (single-shot **estimate** ε\*=0.625/255):
+- **LP margins alone** (no splits) are markedly tighter than estimate: single-shot
+  with `marginMode='lp'` certifies **0.80/255** (≈1.3× the estimate radius), because
+  the LP `getMin` exploits the full Star constraint system (av-envelope facets +
+  ReLU triangles) that the predicate-box estimate ignores. So `marginMode='lp'` is a
+  near-free precision gain (one LP per binding class). The estimate-margin sweep
+  above therefore *under*-reports the true certified radius.
+- **ReLU-phase splits** extend further where the LP root fails — `bab_demo.m` sweeps
+  ε ∈ {0.80, 0.90, 1.00}/255 comparing single-shot-LP vs BaB; BaB ≥ single-shot-LP
+  by construction (the root is the no-split case), strictly greater when a split
+  flips the binding margin. See the script output for the per-ε numbers.
+- Full-eps LP count: `lp_fulleps.m` runs the LP margin at ε=1/255. It roughly
+  **halves the margin gap** vs estimate (inst 1: LP min-margin −0.19 vs estimate
+  −0.56) but stays negative — so even LP single-shot is **0/15 at full ε** on these
+  *filtered* hard instances. (The LP on a ~5600-predicate Star costs ~15–110 s/inst,
+  so this is a spot-check, not a full sweep.) Closing the remaining gap needs the
+  activation-split BaB to go deeper, and ideally to also split the attention
+  nonlinearity — consistent with α,β-CROWN's 79/200 being a complete-method result.
+
+### Honest limitations
+
+- Full ε=1/255 on the filtered instances needs many activation splits (the gap is
+  large: margin ≈ −0.5 on ibp). Our BaB has a node budget and splits only FF ReLUs
+  (not the attention nonlinearity), so it does **not** reach 79/200 — consistent
+  with the user's expectation ("I don't expect them to reach the 1/255 level").
+- The forward bound stays `estimate` even inside BaB (only the binding margin uses
+  LP); a full β-CROWN would propagate the split constraints through *all* bounds
+  (tighter, but the LP-everywhere forward is ~100× slower here).
+- `verifyBaBRelu` does no per-branch counterexample search, so it returns
+  robust/unknown (pair with `verifyBaB`/`falsifyBox` for not-robust witnesses).
+
+## Files
+
+- `engine/nn/funcs/SoftmaxAttn.m` — sound attention primitives (reusable).
+- `ViTReach.m` — model load, parity forward, sound reach, verify, BaB.
+- `extract_weights.py` — ONNX → .mat (weights + vendored inputs + ORT ref logits).
+- `run_benchmark.m`, `bab_demo.m` — sweeps.
+- tests: `tests/nn/attention/*` (primitives+layers), `test_ViTReach_{parity,reach,bab}.m`.

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
@@ -1,0 +1,304 @@
+classdef ViTReach
+    % ViTReach - sound star-set reachability driver for the VNN-COMP 2023 ViT
+    % benchmark (CIFAR-10, L-inf eps=1/255, argmax-preservation), implemented
+    % entirely on NNV Star sets via the SoftmaxAttn sound primitives.
+    %
+    % The benchmark ONNX (opset 9, Slice v1 + per-token BatchNorm) is not ingested
+    % by MATLAB's importNetworkFromONNX, so -- as in the n2v reference -- we mirror
+    % the exported graph explicitly and load weights from a .mat produced by
+    % extract_weights.py. evaluate() is parity-checked to ~1e-5 vs onnxruntime;
+    % reach() is the sound over-approximation that propagates a per-pixel eps-box.
+    %
+    % Architecture (ViT_BN): Conv patch-embed -> [cls] -> +pos ->
+    %   depth x ( x = x + Attn(BN(x));  x = x + FF_ReLU(BN(x)) ) ->
+    %   ReduceMean over tokens -> BN -> Linear head (10 logits).
+    % Only genuine nonlinearities: softmax attention (bilinear QK^T + softmax + A*V)
+    % and the FF ReLU. Everything else folds to exact affine maps.
+    %
+    % Token-state convention: a matrix-Star of dim N*E in e-major layout, i.e.
+    % reshape(state,[N E]) recovers the [token x channel] matrix. See SoftmaxAttn.
+    %
+    % Author: NNV Team (ViT track). Date 2026.
+
+    methods (Static)
+
+        % ================= model loading =================
+        function M = load(matfile)
+            S = load(matfile);
+            M = S;
+            M.patch = double(S.patch); M.depth = double(S.depth);
+            M.dim = double(S.dim); M.heads = double(S.heads); M.dim_head = double(S.dim_head);
+            M.scale = 1 / sqrt(M.dim_head);
+            M.Hg = 32 / M.patch;
+            M.n_patch = M.Hg^2;
+            M.N = M.n_patch + 1;
+            M.cls = double(S.cls(:));
+            M.pos = double(S.pos);              % [N x E]
+            M.proj_w = double(S.proj_w);        % [E,3,p,p]
+            M.proj_b = double(S.proj_b(:));
+            M.head_W = double(S.head_W);        % [10 x E]
+            M.head_b = double(S.head_b(:));
+            M.head_bn_scale = double(S.head_bn_scale(:));
+            M.head_bn_shift = double(S.head_bn_shift(:));
+            % blocks come in as a cell array of structs (scipy savemat of a list);
+            % normalise field orientations into a clean struct array.
+            Bc = S.blocks;
+            if ~iscell(Bc), Bc = num2cell(Bc); end
+            for i = 1:numel(Bc)
+                b = Bc{i};
+                bb(i).bn1_scale = double(b.bn1_scale(:)); bb(i).bn1_shift = double(b.bn1_shift(:));
+                bb(i).bn2_scale = double(b.bn2_scale(:)); bb(i).bn2_shift = double(b.bn2_shift(:));
+                bb(i).Mq = double(b.Mq); bb(i).bq = double(b.bq(:));
+                bb(i).Mk = double(b.Mk); bb(i).bk = double(b.bk(:));
+                bb(i).Mv = double(b.Mv); bb(i).bv = double(b.bv(:));
+                bb(i).Mo = double(b.Mo); bb(i).bo = double(b.bo(:));
+                bb(i).ff1_W = double(b.ff1_W); bb(i).ff1_b = double(b.ff1_b(:));
+                bb(i).ff2_W = double(b.ff2_W); bb(i).ff2_b = double(b.ff2_b(:));
+            end
+            M.blocks = bb;
+        end
+
+        % ================= concrete forward (parity oracle) =================
+        function logits = evaluate(M, img)
+            % img: [3,32,32] already normalised. Returns logits [10x1].
+            p = M.patch; Hg = M.Hg; E = M.dim; H = M.heads; D = M.dim_head;
+            z = zeros(M.n_patch, E);
+            for gh = 0:Hg-1
+                for gw = 0:Hg-1
+                    p0 = gh*Hg + gw;                                  % row-major patch index
+                    patch = img(:, gh*p+(1:p), gw*p+(1:p));           % [3,p,p]
+                    for e = 1:E
+                        w = reshape(M.proj_w(e,:,:,:), [3 p p]);
+                        z(p0+1, e) = M.proj_b(e) + sum(w(:).*patch(:));
+                    end
+                end
+            end
+            Z = [M.cls'; z] + M.pos;                                  % [N x E]
+            for i = 1:M.depth
+                blk = M.blocks(i);
+                Z = Z + ViTReach.attnFwd(ViTReach.bnFwd(Z, blk.bn1_scale, blk.bn1_shift), blk, H, D, M.scale);
+                Z = Z + ViTReach.ffFwd(ViTReach.bnFwd(Z, blk.bn2_scale, blk.bn2_shift), blk);
+            end
+            zt = mean(Z, 1)';                                         % [E x 1]
+            zt = zt .* M.head_bn_scale + M.head_bn_shift;
+            logits = M.head_W * zt + M.head_b;                        % [10 x 1]
+        end
+
+        function Y = bnFwd(Z, scale, shift)
+            Y = Z .* scale' + shift';                                 % [N x E] per-channel affine
+        end
+
+        function out = attnFwd(X, blk, H, D, scale)
+            [N, E] = size(X);
+            Q = X*blk.Mq + blk.bq';  K = X*blk.Mk + blk.bk';  V = X*blk.Mv + blk.bv';
+            O = zeros(N, E);
+            for h = 1:H
+                cols = (h-1)*D + (1:D);
+                A = ViTReach.rowSoftmax(scale*(Q(:,cols)*K(:,cols)'));
+                O(:, cols) = A * V(:, cols);
+            end
+            out = O*blk.Mo + blk.bo';
+        end
+
+        function out = ffFwd(X, blk)
+            out = max(X*blk.ff1_W + blk.ff1_b', 0) * blk.ff2_W + blk.ff2_b';
+        end
+
+        function A = rowSoftmax(S)
+            m = max(S,[],2); ex = exp(S-m); A = ex./sum(ex,2);
+        end
+
+        % ================= sound reachability =================
+        function L = reach(M, lb, ub, opt)
+            % lb,ub: per-pixel normalised bounds, ordered (c,h,w) with
+            % idx=(c-1)*1024+(h-1)*32+(w-1)+1. Returns logits Star (dim 10).
+            % opt fields: .mode ('estimate'|'lp', default 'estimate'),
+            %             .relu ('approx-star' default).
+            if nargin < 4, opt = struct(); end
+            if ~isfield(opt,'mode'), opt.mode = 'estimate'; end
+            if ~isfield(opt,'relu'), opt.relu = 'fast'; end
+            E = M.dim; H = M.heads; D = M.dim_head; N = M.N;
+
+            Xin = Star(lb(:), ub(:));                                 % dim 3072
+            [Wpe, bpe] = ViTReach.patchEmbed(M);
+            X = Xin.affineMap(Wpe, bpe);                              % token-state dim N*E
+            for i = 1:M.depth
+                blk = M.blocks(i);
+                % attention sublayer
+                P = ViTReach.attnParams(blk, E, H, M.scale);
+                Xn = ViTReach.bnStar(X, blk.bn1_scale, blk.bn1_shift, N);
+                AO = SoftmaxAttn.selfAttentionReach(Xn, N, P, opt.mode);
+                X = SoftmaxAttn.prefixAdd(X, AO);
+                % feed-forward sublayer
+                Xn = ViTReach.bnStar(X, blk.bn2_scale, blk.bn2_shift, N);
+                F1 = SoftmaxAttn.perTokenLinear(Xn, blk.ff1_W, blk.ff1_b, N);   % dim N*96
+                R  = ViTReach.reluStar(F1, opt.relu);
+                F2 = SoftmaxAttn.perTokenLinear(R, blk.ff2_W, blk.ff2_b, N);    % dim N*E
+                X = SoftmaxAttn.prefixAdd(X, F2);
+            end
+            % ReduceMean over tokens -> dim E
+            Wm = ViTReach.meanMap(N, E);
+            zt = X.affineMap(Wm, zeros(E,1));
+            % head BN (per-channel affine) + head linear
+            zt = zt.affineMap(diag(M.head_bn_scale), M.head_bn_shift);
+            L = zt.affineMap(M.head_W, M.head_b);                     % dim 10
+        end
+
+        function [robust, margins, L] = verify(M, lb, ub, label, opt)
+            % Returns robust in {1 robust, 2 unknown}. margins(i) = lower bound on
+            % (logit_label - logit_i) for i~=label; robust iff all > 0.
+            if nargin < 5, opt = struct(); end
+            if ~isfield(opt,'marginMode'), opt.marginMode = 'estimate'; end
+            L = ViTReach.reach(M, lb, ub, opt);
+            label = label + 1;                                        % 0-based -> 1-based
+            margins = inf(10,1);
+            robust = 1;
+            for i = 1:10
+                if i == label, continue; end
+                c = zeros(10,1); c(label) = 1; c(i) = -1;
+                ms = L.affineMap(c', 0);                              % scalar Star = logit_L - logit_i
+                if strcmpi(opt.marginMode,'lp')
+                    mlb = ms.getMin(1, 'linprog');
+                else
+                    [mlb, ~] = ms.estimateRanges();
+                end
+                margins(i) = mlb;
+                if mlb <= 0, robust = 2; end
+            end
+        end
+
+        % ---- reach helpers ----
+        function Y = bnStar(X, scale, shift, N)
+            d = kron(scale(:), ones(N,1));
+            b = kron(shift(:), ones(N,1));
+            Y = X.affineMap(diag(d), b);
+        end
+
+        function R = reluStar(S, method)
+            % Sound ReLU on a Star.
+            %   'fast' (default): symbolic triangle relaxation using cheap ESTIMATE
+            %     neuron bounds -- no LP, preserves the predicate prefix (appends one
+            %     fresh predicate per unstable neuron). This is what makes the forward
+            %     reach run in seconds rather than minutes (LP neuron bounds over the
+            %     few-thousand-predicate residual stream dominate otherwise).
+            %   otherwise: delegate to NNV's PosLin func (LP-tight but slow).
+            if nargin < 2 || isempty(method) || strcmpi(method, 'fast')
+                R = ViTReach.reluStarApproxFast(S);
+            else
+                Rs = PosLin.reach(S, method);
+                R = Rs(1);
+            end
+        end
+
+        function R = reluStarApproxFast(S)
+            % approx-star ReLU with estimate (box) neuron bounds; sound triangle.
+            [l, u] = S.estimateRanges();
+            n = S.dim; nVar = S.nVar;
+            c = S.V(:, 1); G = S.V(:, 2:end);
+            unstable = find(l < 0 & u > 0);
+            posn = find(l >= 0);
+            nr = numel(unstable);
+
+            newV = zeros(n, nVar + 1 + nr);
+            newV(posn, 1) = c(posn);
+            if nVar > 0, newV(posn, 2:nVar+1) = G(posn, :); end   % positive-stable: identity
+            % negative-stable rows stay 0 (ReLU outputs 0)
+            for k = 1:nr
+                newV(unstable(k), nVar+1+k) = 1;                  % unstable: y = fresh pred
+            end
+
+            if isempty(S.C)
+                Cold = zeros(0, nVar + nr); dold = zeros(0, 1);
+            else
+                Cold = [S.C, zeros(size(S.C,1), nr)]; dold = S.d;
+            end
+            plb = [S.predicate_lb; zeros(nr,1)];
+            pub = [S.predicate_ub; zeros(nr,1)];
+
+            rows = zeros(3*nr, nVar + nr); rd = zeros(3*nr, 1);
+            for k = 1:nr
+                i = unstable(k); li = l(i); ui = u(i);
+                xc = c(i); xg = G(i, :);
+                col = nVar + k;
+                lam = ui / (ui - li);
+                % a >= 0
+                rows(3*k-2, col) = -1;                       rd(3*k-2) = 0;
+                % a >= x_i   (x_i - a <= 0)
+                rows(3*k-1, 1:nVar) = xg; rows(3*k-1, col) = -1;  rd(3*k-1) = -xc;
+                % a <= lam*(x_i - li)  ( -lam*xg*alpha + a <= lam*(xc - li) )
+                rows(3*k,   1:nVar) = -lam*xg; rows(3*k, col) = 1; rd(3*k) = lam*(xc - li);
+                pub(col) = ui;
+            end
+            R = Star(newV, [Cold; rows], [dold; rd], plb, pub);
+        end
+
+        function Wm = meanMap(N, E)
+            % [E x N*E] averaging over tokens of an e-major matrix-Star
+            Wm = zeros(E, N*E);
+            for e = 1:E
+                Wm(e, (e-1)*N + (1:N)) = 1/N;
+            end
+        end
+
+        function P = attnParams(blk, E, H, scale)
+            P.E=E; P.H=H; P.D=E/H; P.scale=scale;
+            P.Mq=blk.Mq; P.bq=blk.bq; P.Mk=blk.Mk; P.bk=blk.bk;
+            P.Mv=blk.Mv; P.bv=blk.bv; P.Mo=blk.Mo; P.bo=blk.bo;
+        end
+
+        function [Wpe, bpe] = patchEmbed(M)
+            % exact affine map from the (c,h,w)-ordered pixel vector (dim 3072) to
+            % the e-major token-state (dim N*E), folding conv patch-embed + cls + pos.
+            p = M.patch; Hg = M.Hg; E = M.dim; N = M.N;
+            Wpe = zeros(N*E, 3*32*32);
+            bpe = zeros(N*E, 1);
+            for e = 1:E
+                bpe((e-1)*N + 1) = M.cls(e) + M.pos(1, e);           % cls token (token 1)
+            end
+            for gh = 0:Hg-1
+                for gw = 0:Hg-1
+                    p0 = gh*Hg + gw;
+                    n = p0 + 2;                                       % token row (cls is 1)
+                    for e = 1:E
+                        bpe((e-1)*N + n) = M.proj_b(e) + M.pos(n, e);
+                        for c = 1:3
+                            for ii = 0:p-1
+                                for jj = 0:p-1
+                                    h1 = gh*p + ii + 1; w1 = gw*p + jj + 1;
+                                    col = (c-1)*1024 + (h1-1)*32 + (w1-1) + 1;
+                                    Wpe((e-1)*N + n, col) = M.proj_w(e, c, ii+1, jj+1);
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+
+        % ================= input box construction =================
+        function [lb, ub] = epsBox(M, img01, eps)
+            % img01: [3,32,32] raw pixels in [0,1]. Returns normalised per-pixel
+            % bounds in the (c,h,w) ordering used by patchEmbed.
+            if nargin < 3, eps = 1/255; end
+            mean_ = M.mean(:); std_ = M.std(:);
+            lo = min(max(img01 - eps, 0), 1);
+            hi = min(max(img01 + eps, 0), 1);
+            lb = zeros(3*32*32,1); ub = zeros(3*32*32,1);
+            for c = 1:3
+                for h = 1:32
+                    for w = 1:32
+                        idx = (c-1)*1024 + (h-1)*32 + (w-1) + 1;
+                        lb(idx) = (lo(c,h,w) - mean_(c)) / std_(c);
+                        ub(idx) = (hi(c,h,w) - mean_(c)) / std_(c);
+                    end
+                end
+            end
+        end
+
+        function x = normImg(M, img01)
+            % normalise a raw [3,32,32] image to the model's input space
+            x = (img01 - reshape(M.mean,[3 1 1])) ./ reshape(M.std,[3 1 1]);
+        end
+
+    end
+end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
@@ -284,21 +284,32 @@ classdef ViTReach
             info = struct('nodes', nodes, 'nCand', T);
         end
 
-        function rob = verifyBoxSplits(M, lb, ub, label, opt, splits)
+        function [rob, bestLP] = verifyBoxSplits(M, lb, ub, label, opt, splits)
             % robustness of [lb,ub] under forced ReLU phases: estimate margins
-            % first (cheap), then an LP (honouring the split half-spaces) on any
-            % class the estimate cannot clear. rob = 1 robust, 2 unknown.
+            % first (cheap), then an LP (honouring the split half-spaces) on the
+            % classes the estimate cannot clear -- WORST estimate first, short-
+            % circuiting on the first LP that stays <=0 (a node is usually not
+            % robust, so this does one LP, not nine). rob = 1 robust, 2 unknown.
+            % bestLP = the LP value of the binding (worst) class (for reporting).
             o = opt; o.splits = splits;
             L = ViTReach.reach(M, lb, ub, o);
-            lab = label + 1; rob = 1;
+            lab = label + 1;
+            est = inf(10,1); cdir = cell(10,1);
             for i = 1:10
                 if i == lab, continue; end
-                cc = zeros(10,1); cc(lab) = 1; cc(i) = -1;
+                cc = zeros(10,1); cc(lab) = 1; cc(i) = -1; cdir{i} = cc;
                 ms = L.affineMap(cc', 0);
-                [e,~] = ms.estimateRanges();
-                if e > 0, continue; end                    % cleared by estimate
-                if ms.getMin(1,'linprog') > 0, continue; end  % cleared by LP (uses splits)
-                rob = 2; return;
+                [e,~] = ms.estimateRanges(); est(i) = e;
+            end
+            unresolved = find(est <= 0);
+            [~, ord] = sort(est(unresolved), 'ascend');     % worst (most negative) first
+            unresolved = unresolved(ord);
+            rob = 1; bestLP = min(est(est < inf));
+            for j = 1:numel(unresolved)
+                i = unresolved(j);
+                mlb = L.affineMap(cdir{i}', 0).getMin(1, 'linprog');
+                if j == 1, bestLP = mlb; end
+                if mlb <= 0, rob = 2; bestLP = mlb; return; end   % binding class fails -> not robust
             end
         end
 

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/ViTReach.m
@@ -109,15 +109,20 @@ classdef ViTReach
         end
 
         % ================= sound reachability =================
-        function L = reach(M, lb, ub, opt)
+        function [L, info] = reach(M, lb, ub, opt)
             % lb,ub: per-pixel normalised bounds, ordered (c,h,w) with
             % idx=(c-1)*1024+(h-1)*32+(w-1)+1. Returns logits Star (dim 10).
             % opt fields: .mode ('estimate'|'lp', default 'estimate'),
-            %             .relu ('approx-star' default).
+            %             .relu ('fast' default),
+            %             .splits (struct array .block/.neuron/.phase forcing FF
+            %                      ReLU phases for branch-and-bound; +1 active, -1 inactive).
+            % info.reluBounds{i} = [l u] of block i's FF ReLU input (for BaB choice).
             if nargin < 4, opt = struct(); end
             if ~isfield(opt,'mode'), opt.mode = 'estimate'; end
             if ~isfield(opt,'relu'), opt.relu = 'fast'; end
+            if ~isfield(opt,'splits'), opt.splits = []; end
             E = M.dim; H = M.heads; D = M.dim_head; N = M.N;
+            info = struct('reluBounds', {cell(1, M.depth)});
 
             Xin = Star(lb(:), ub(:));                                 % dim 3072
             [Wpe, bpe] = ViTReach.patchEmbed(M);
@@ -132,7 +137,9 @@ classdef ViTReach
                 % feed-forward sublayer
                 Xn = ViTReach.bnStar(X, blk.bn2_scale, blk.bn2_shift, N);
                 F1 = SoftmaxAttn.perTokenLinear(Xn, blk.ff1_W, blk.ff1_b, N);   % dim N*96
-                R  = ViTReach.reluStar(F1, opt.relu);
+                [lF, uF] = F1.estimateRanges(); info.reluBounds{i} = [lF(:), uF(:)];
+                forced = ViTReach.forcedFor(opt.splits, i);
+                R  = ViTReach.reluStar(F1, opt.relu, forced);
                 F2 = SoftmaxAttn.perTokenLinear(R, blk.ff2_W, blk.ff2_b, N);    % dim N*E
                 X = SoftmaxAttn.prefixAdd(X, F2);
             end
@@ -142,6 +149,16 @@ classdef ViTReach
             % head BN (per-channel affine) + head linear
             zt = zt.affineMap(diag(M.head_bn_scale), M.head_bn_shift);
             L = zt.affineMap(M.head_W, M.head_b);                     % dim 10
+        end
+
+        function forced = forcedFor(splits, blockIdx)
+            forced = zeros(0,2);
+            if isempty(splits), return; end
+            for s = 1:numel(splits)
+                if splits(s).block == blockIdx
+                    forced(end+1,:) = [splits(s).neuron, splits(s).phase]; %#ok<AGROW>
+                end
+            end
         end
 
         function [robust, margins, L] = verify(M, lb, ub, label, opt)
@@ -167,6 +184,164 @@ classdef ViTReach
             end
         end
 
+        % ================= branch-and-bound =================
+        function [status, info] = verifyBaB(M, img, label, eps, opt)
+            % Sound input-splitting branch-and-bound robustness verification.
+            %   status: 1 robust, 0 not-robust (counterexample), 2 unknown (budget).
+            % Uses ViTReach.reach as the bounding oracle (the new sound ViT layers)
+            % and bisects the per-pixel eps-box on the widest dimension. Sound:
+            % a box is robust only if every leaf is certified; any falsifying
+            % sample in any sub-box proves not-robust. Complete in the limit
+            % (subject to opt.babMaxNodes). Input BaB is weak in 3072-d (the
+            % effective gap-closer is neuron/ReLU-split beta-CROWN; see STATUS.md),
+            % but this demonstrates a sound BaB driven by the attention layers and
+            % can certify a strictly larger radius than single-shot reach.
+            if nargin < 5, opt = struct(); end
+            if ~isfield(opt,'mode'), opt.mode = 'estimate'; end
+            if ~isfield(opt,'relu'), opt.relu = 'fast'; end
+            if ~isfield(opt,'marginMode'), opt.marginMode = 'estimate'; end
+            if ~isfield(opt,'babMaxNodes'), opt.babMaxNodes = 50; end
+            if ~isfield(opt,'babFalsifyTries'), opt.babFalsifyTries = 100; end
+
+            [lb0, ub0] = ViTReach.epsBox(M, img, eps);
+            stack = {struct('lb',lb0,'ub',ub0)};
+            nodes = 0; anyUnknown = false;
+            while ~isempty(stack)
+                node = stack{end}; stack(end) = [];
+                nodes = nodes + 1;
+                [rob, margins] = ViTReach.verifyBox(M, node.lb, node.ub, label, opt);
+                if rob == 1
+                    continue;                                  % leaf certified robust
+                end
+                % try to falsify this sub-box (sound not-robust witness)
+                ce = ViTReach.falsifyBox(M, node.lb, node.ub, label, opt.babFalsifyTries);
+                if ce
+                    status = 0; info = struct('nodes',nodes,'reason','counterexample');
+                    return;
+                end
+                if nodes >= opt.babMaxNodes
+                    anyUnknown = true; continue;               % budget hit: leaf unknown
+                end
+                % split the widest dimension into two halves
+                [~, d] = max(node.ub - node.lb);
+                mid = (node.lb(d) + node.ub(d)) / 2;
+                left = node;  left.ub(d) = mid;
+                right = node; right.lb(d) = mid;
+                stack{end+1} = left; stack{end+1} = right; %#ok<AGROW>
+            end
+            if anyUnknown, status = 2; else, status = 1; end
+            info = struct('nodes',nodes,'reason','exhausted');
+        end
+
+        function [status, info] = verifyBaBRelu(M, img, label, eps, opt)
+            % Sound FF-ReLU phase-split branch-and-bound (beta-CROWN style) driven
+            % by the sound ViT layers. A node forces a set of ReLU phases; its two
+            % children fix one more candidate neuron active/inactive (their union is
+            % the node), so the node is robust iff both children are. The binding
+            % margin is tightened with an LP that honours the forced half-spaces.
+            %   status: 1 robust, 2 unknown (budget). (No CE search here -- the input
+            %   box is fixed; pair with verifyBaB/falsify for not-robust witnesses.)
+            if nargin < 5, opt = struct(); end
+            if ~isfield(opt,'mode'), opt.mode = 'estimate'; end
+            if ~isfield(opt,'relu'), opt.relu = 'fast'; end
+            if ~isfield(opt,'babMaxNodes'), opt.babMaxNodes = 40; end
+            if ~isfield(opt,'maxCand'), opt.maxCand = 14; end
+            [lb, ub] = ViTReach.epsBox(M, img, eps);
+
+            % root reach: get candidate unstable FF-ReLU neurons + instability scores
+            opt0 = opt; opt0.splits = [];
+            [~, info0] = ViTReach.reach(M, lb, ub, opt0);
+            cand = zeros(0,3);   % [block neuron score]
+            for i = 1:M.depth
+                lu = info0.reluBounds{i};
+                uns = find(lu(:,1) < 0 & lu(:,2) > 0);
+                sc = min(-lu(uns,1), lu(uns,2));
+                cand = [cand; [i*ones(numel(uns),1), uns, sc]]; %#ok<AGROW>
+            end
+            [~, ord] = sort(cand(:,3), 'descend');
+            cand = cand(ord, :);
+            T = min(opt.maxCand, size(cand,1));
+            cand = cand(1:T, :);
+
+            stack = {struct('splits', struct('block',{},'neuron',{},'phase',{}), 'depth', 0)};
+            nodes = 0; anyUnknown = false;
+            while ~isempty(stack)
+                node = stack{end}; stack(end) = [];
+                nodes = nodes + 1;
+                rob = ViTReach.verifyBoxSplits(M, lb, ub, label, opt, node.splits);
+                if rob == 1, continue; end                 % leaf certified
+                if node.depth >= T || nodes >= opt.babMaxNodes
+                    anyUnknown = true; continue;           % budget / no more candidates
+                end
+                c = cand(node.depth+1, :);
+                for ph = [1, -1]
+                    s = node.splits;
+                    s(end+1) = struct('block',c(1),'neuron',c(2),'phase',ph); %#ok<AGROW>
+                    stack{end+1} = struct('splits', s, 'depth', node.depth+1); %#ok<AGROW>
+                end
+            end
+            if anyUnknown, status = 2; else, status = 1; end
+            info = struct('nodes', nodes, 'nCand', T);
+        end
+
+        function rob = verifyBoxSplits(M, lb, ub, label, opt, splits)
+            % robustness of [lb,ub] under forced ReLU phases: estimate margins
+            % first (cheap), then an LP (honouring the split half-spaces) on any
+            % class the estimate cannot clear. rob = 1 robust, 2 unknown.
+            o = opt; o.splits = splits;
+            L = ViTReach.reach(M, lb, ub, o);
+            lab = label + 1; rob = 1;
+            for i = 1:10
+                if i == lab, continue; end
+                cc = zeros(10,1); cc(lab) = 1; cc(i) = -1;
+                ms = L.affineMap(cc', 0);
+                [e,~] = ms.estimateRanges();
+                if e > 0, continue; end                    % cleared by estimate
+                if ms.getMin(1,'linprog') > 0, continue; end  % cleared by LP (uses splits)
+                rob = 2; return;
+            end
+        end
+
+        function [rob, margins] = verifyBox(M, lb, ub, label, opt)
+            % verify robustness on an explicit normalised pixel box [lb,ub].
+            L = ViTReach.reach(M, lb, ub, opt);
+            lab = label + 1;
+            margins = inf(10,1); rob = 1;
+            for i = 1:10
+                if i == lab, continue; end
+                c = zeros(10,1); c(lab) = 1; c(i) = -1;
+                ms = L.affineMap(c', 0);
+                if strcmpi(opt.marginMode,'lp'), mlb = ms.getMin(1,'linprog');
+                else, [mlb,~] = ms.estimateRanges(); end
+                margins(i) = mlb;
+                if mlb <= 0, rob = 2; end
+            end
+        end
+
+        function ce = falsifyBox(M, lb, ub, label, nTry)
+            % random search for a misclassification inside the NORMALISED box.
+            ce = false; lab = label + 1;
+            for t = 1:nTry
+                xn = lb + (ub - lb).*rand(numel(lb),1);   % normalised sample
+                xt = ViTReach.unflatten(xn);
+                logit = ViTReach.evaluate(M, xt);
+                [~, pred] = max(logit);
+                if pred ~= lab, ce = true; return; end
+            end
+        end
+
+        function xt = unflatten(xn)
+            % inverse of the (c,h,w) flattening used by epsBox/patchEmbed
+            xt = zeros(3,32,32);
+            for c = 1:3
+                for h = 1:32
+                    for w = 1:32
+                        xt(c,h,w) = xn((c-1)*1024 + (h-1)*32 + (w-1) + 1);
+                    end
+                end
+            end
+        end
+
         % ---- reach helpers ----
         function Y = bnStar(X, scale, shift, N)
             d = kron(scale(:), ones(N,1));
@@ -174,37 +349,47 @@ classdef ViTReach
             Y = X.affineMap(diag(d), b);
         end
 
-        function R = reluStar(S, method)
-            % Sound ReLU on a Star.
+        function R = reluStar(S, method, forced)
+            % Sound ReLU on a Star (optionally with forced phases for BaB).
             %   'fast' (default): symbolic triangle relaxation using cheap ESTIMATE
-            %     neuron bounds -- no LP, preserves the predicate prefix (appends one
-            %     fresh predicate per unstable neuron). This is what makes the forward
-            %     reach run in seconds rather than minutes (LP neuron bounds over the
-            %     few-thousand-predicate residual stream dominate otherwise).
+            %     neuron bounds -- no LP, preserves the predicate prefix. This is
+            %     what makes the forward reach run in seconds rather than minutes.
             %   otherwise: delegate to NNV's PosLin func (LP-tight but slow).
+            %   forced: K x 2 [neuron, phase] -- those neurons are made EXACT
+            %     (active: y=x with x>=0 added; inactive: y=0 with x<=0 added). Sound
+            %     for the corresponding input-set branch; tighter (no triangle slack).
+            if nargin < 3, forced = zeros(0,2); end
             if nargin < 2 || isempty(method) || strcmpi(method, 'fast')
-                R = ViTReach.reluStarApproxFast(S);
+                R = ViTReach.reluStarApproxFast(S, forced);
             else
-                Rs = PosLin.reach(S, method);
-                R = Rs(1);
+                R = PosLin.reach(S, method);  R = R(1);   % (forced phases ignored on the LP path)
             end
         end
 
-        function R = reluStarApproxFast(S)
-            % approx-star ReLU with estimate (box) neuron bounds; sound triangle.
+        function R = reluStarApproxFast(S, forced)
+            % approx-star ReLU with estimate (box) neuron bounds; sound triangle,
+            % plus exact handling of any 'forced' neurons (BaB phase splits).
+            if nargin < 2, forced = zeros(0,2); end
             [l, u] = S.estimateRanges();
             n = S.dim; nVar = S.nVar;
             c = S.V(:, 1); G = S.V(:, 2:end);
-            unstable = find(l < 0 & u > 0);
-            posn = find(l >= 0);
+
+            isForced = false(n,1); phaseOf = zeros(n,1);
+            if ~isempty(forced)
+                isForced(forced(:,1)) = true; phaseOf(forced(:,1)) = forced(:,2);
+            end
+            unstable = find(l < 0 & u > 0 & ~isForced);
+            posn = find(l >= 0 & ~isForced);
+            actF = find(isForced & phaseOf > 0);              % forced active -> identity
+            % forced inactive and negative-stable -> 0 (rows left zero)
             nr = numel(unstable);
 
             newV = zeros(n, nVar + 1 + nr);
-            newV(posn, 1) = c(posn);
-            if nVar > 0, newV(posn, 2:nVar+1) = G(posn, :); end   % positive-stable: identity
-            % negative-stable rows stay 0 (ReLU outputs 0)
+            idnt = [posn; actF];
+            newV(idnt, 1) = c(idnt);
+            if nVar > 0, newV(idnt, 2:nVar+1) = G(idnt, :); end
             for k = 1:nr
-                newV(unstable(k), nVar+1+k) = 1;                  % unstable: y = fresh pred
+                newV(unstable(k), nVar+1+k) = 1;              % unstable: y = fresh pred
             end
 
             if isempty(S.C)
@@ -218,18 +403,25 @@ classdef ViTReach
             rows = zeros(3*nr, nVar + nr); rd = zeros(3*nr, 1);
             for k = 1:nr
                 i = unstable(k); li = l(i); ui = u(i);
-                xc = c(i); xg = G(i, :);
-                col = nVar + k;
+                xc = c(i); xg = G(i, :); col = nVar + k;
                 lam = ui / (ui - li);
-                % a >= 0
-                rows(3*k-2, col) = -1;                       rd(3*k-2) = 0;
-                % a >= x_i   (x_i - a <= 0)
-                rows(3*k-1, 1:nVar) = xg; rows(3*k-1, col) = -1;  rd(3*k-1) = -xc;
-                % a <= lam*(x_i - li)  ( -lam*xg*alpha + a <= lam*(xc - li) )
-                rows(3*k,   1:nVar) = -lam*xg; rows(3*k, col) = 1; rd(3*k) = lam*(xc - li);
+                rows(3*k-2, col) = -1;                               rd(3*k-2) = 0;          % a>=0
+                rows(3*k-1, 1:nVar) = xg; rows(3*k-1, col) = -1;     rd(3*k-1) = -xc;        % a>=x
+                rows(3*k,   1:nVar) = -lam*xg; rows(3*k, col) = 1;   rd(3*k) = lam*(xc - li);% a<=line
                 pub(col) = ui;
             end
-            R = Star(newV, [Cold; rows], [dold; rd], plb, pub);
+            % forced half-space constraints (restrict alpha to the branch)
+            fN = find(isForced);
+            frows = zeros(numel(fN), nVar + nr); frd = zeros(numel(fN), 1);
+            for k = 1:numel(fN)
+                i = fN(k); xc = c(i); xg = G(i, :);
+                if phaseOf(i) > 0          % active branch: x_i >= 0  -> -xg*alpha <= xc
+                    frows(k, 1:nVar) = -xg; frd(k) = xc;
+                else                       % inactive branch: x_i <= 0 ->  xg*alpha <= -xc
+                    frows(k, 1:nVar) =  xg; frd(k) = -xc;
+                end
+            end
+            R = Star(newV, [Cold; rows; frows], [dold; rd; frd], plb, pub);
         end
 
         function Wm = meanMap(N, E)

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/bab_demo.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/bab_demo.m
@@ -1,0 +1,23 @@
+function bab_demo()
+% Show ReLU-phase-split BaB certifying where LP single-shot reach cannot.
+here = fileparts(mfilename('fullpath'));
+addpath(genpath(fullfile(here,'..','..','..','engine'))); addpath(here);
+M = ViTReach.load(fullfile(here,'ibp_3_3_8.mat'));
+k = 11; img = squeeze(M.images(k,:,:,:)); label = M.labels(k);
+for eps255 = [0.80 0.90 1.00]
+    eps = eps255/255;
+    % single-shot LP (root, no splits)
+    t0 = tic;
+    ssLP = ViTReach.verifyBoxSplits(M, ViTReach_lb(M,img,eps), ViTReach_ub(M,img,eps), label, ...
+                                    struct('mode','estimate','relu','fast'), struct('block',{},'neuron',{},'phase',{}));
+    tss = toc(t0);
+    % ReLU-split BaB
+    t0 = tic;
+    [bab, info] = ViTReach.verifyBaBRelu(M, img, label, eps, struct('babMaxNodes',31,'maxCand',12));
+    tb = toc(t0);
+    fprintf('eps=%.2f/255 | single-shot-LP=%d (%.1fs) | BaB=%d nodes=%d (%.1fs)\n', ...
+        eps255, ssLP, tss, bab, info.nodes, tb);
+end
+end
+function lb = ViTReach_lb(M,img,eps), [lb,~]=ViTReach.epsBox(M,img,eps); end
+function ub = ViTReach_ub(M,img,eps), [~,ub]=ViTReach.epsBox(M,img,eps); end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/bab_sweep_close.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/bab_sweep_close.m
@@ -1,0 +1,46 @@
+function bab_sweep_close(K, budget)
+% Efficient full-eps BaB sweep on the instances that could plausibly verify: rank
+% all 15 ibp_3_3_8 instances by estimate margin (cheap), then run FF-ReLU-split BaB
+% at eps=1/255 on the closest K. Reports, per instance, the single-shot LP margin
+% (root, honours the av-envelope facets) and the BaB verdict, plus the total count.
+% This is the practical "only run the verifiable subset" -- the closest-gap
+% instances are exactly where alpha,beta-CROWN's 79 live; my weaker (attention
+% box-lifting) bounder will not match 79, but this measures what it CAN do.
+    if nargin < 1, K = 5; end
+    if nargin < 2, budget = 40; end
+    here = fileparts(mfilename('fullpath'));
+    addpath(genpath(fullfile(here,'..','..','..','engine'))); addpath(here);
+    M = ViTReach.load(fullfile(here,'ibp_3_3_8.mat'));
+    n = 15; eps = 1/255;
+    optE = struct('mode','estimate','relu','fast','marginMode','estimate');
+
+    % rank by estimate margin (closest to 0 first)
+    estM = nan(n,1);
+    for k = 1:n
+        img = squeeze(M.images(k,:,:,:));
+        [lb,ub] = ViTReach.epsBox(M, img, eps);
+        [~, margins] = ViTReach.verify(M, lb, ub, M.labels(k), optE);
+        estM(k) = min(margins);
+    end
+    [~, ord] = sort(estM, 'descend');
+    cand = ord(1:K)';
+    fprintf('Closest %d ibp instances by estimate margin: %s\n', K, mat2str(cand));
+
+    emptySplits = struct('block',{},'neuron',{},'phase',{});
+    verified = 0;
+    for k = cand
+        img = squeeze(M.images(k,:,:,:)); label = M.labels(k);
+        [lb,ub] = ViTReach.epsBox(M, img, eps);
+        % single-shot LP (root) margin
+        [~, rootLP] = ViTReach.verifyBoxSplits(M, lb, ub, label, optE, emptySplits);
+        % full-eps BaB
+        t0 = tic;
+        [st, info] = ViTReach.verifyBaBRelu(M, img, label, eps, struct('babMaxNodes',budget,'maxCand',18));
+        verified = verified + (st==1);
+        fprintf('  inst %2d: estM=%+.4f rootLP=%+.4f | BaB status=%d nodes=%d (%.0fs)%s\n', ...
+            k, estM(k), rootLP, st, info.nodes, toc(t0), tern(st==1,'  <-- VERIFIED @ full eps', ''));
+    end
+    fprintf('=== BaB @ full eps=1/255: %d/%d verified (closest %d ibp instances) ===\n', verified, K, K);
+    fprintf('BAB_SWEEP_DONE\n');
+end
+function s = tern(c,a,b), if c, s=a; else, s=b; end, end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/extract_weights.py
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/extract_weights.py
@@ -1,0 +1,126 @@
+"""Extract VNN-COMP 2023 ViT weights from ONNX into a .mat the NNV driver loads.
+
+Mirrors n2v benchmarks/vit_vnncomp2023/model.py::load_from_onnx exactly (same
+initializer names, same MatMul-by-order convention), but stores ONNX-native
+matrices (in,out) and pre-folds BatchNorm to per-channel (scale, shift) so the
+MATLAB side needs no torch/onnx. Also vendors the 100 inputs+labels per model
+and the CIFAR-10 mean/std so the driver can build the normalized eps-box.
+
+Usage:  python extract_weights.py
+Outputs (next to this script):  pgd_2_3_16.mat, ibp_3_3_8.mat
+"""
+from pathlib import Path
+import numpy as np
+import onnx
+from onnx import numpy_helper
+from scipy.io import savemat
+
+HERE = Path(__file__).resolve().parent
+N2V = Path(r"C:\Users\veriv\Documents\n2v\benchmarks\vit_vnncomp2023")
+ONNX_DIR = N2V / "onnx"
+NPZ_DIR = N2V / "instances"
+
+MEAN = np.array([0.4914, 0.4822, 0.4465], dtype=np.float64)
+STD = np.array([0.2023, 0.1994, 0.2010], dtype=np.float64)
+
+CONFIGS = {"pgd_2_3_16": dict(patch=16, depth=2),
+           "ibp_3_3_8": dict(patch=8, depth=3)}
+EPS = 1e-5
+
+
+def arr(init):
+    return numpy_helper.to_array(init).astype(np.float64)
+
+
+def bn_affine(inits, prefix):
+    w = arr(inits[prefix + ".weight"])
+    b = arr(inits[prefix + ".bias"])
+    rm = arr(inits[prefix + ".running_mean"])
+    rv = arr(inits[prefix + ".running_var"])
+    scale = w / np.sqrt(rv + EPS)
+    shift = b - scale * rm
+    return scale.astype(np.float64), shift.astype(np.float64)
+
+
+def extract(name, patch, depth):
+    proto = onnx.load(str(ONNX_DIR / f"{name}.onnx"))
+    inits = {i.name: i for i in proto.graph.initializer}
+
+    out = {}
+    out["name"] = name
+    out["patch"] = patch
+    out["depth"] = depth
+    out["dim"] = 48
+    out["heads"] = 3
+    out["dim_head"] = 16
+    out["mean"] = MEAN
+    out["std"] = STD
+
+    # patch embed conv: weight (48,3,p,p), bias (48,)
+    out["proj_w"] = arr(inits["0.projection.weight"])  # (48,3,p,p)
+    out["proj_b"] = arr(inits["0.projection.bias"])    # (48,)
+    out["cls"] = arr(inits["0.cls_token"]).reshape(-1)  # (48,)
+    out["pos"] = arr(inits["0.positions"])              # (N, 48)
+
+    # weight-bearing MatMuls in order: per block Q,K,V,out,ff.l0,ff.l3
+    matmul_nodes = [n for n in proto.graph.node
+                    if n.op_type == "MatMul" and any(inp in inits for inp in n.input)]
+    assert len(matmul_nodes) == 6 * depth, (len(matmul_nodes), 6 * depth)
+
+    def mm_w(idx):
+        node = matmul_nodes[idx]
+        wname = next(n for n in node.input if n in inits)
+        return arr(inits[wname])  # ONNX MatMul weight: (in, out)
+
+    blocks = []
+    for i in range(depth):
+        blk = {}
+        s, sh = bn_affine(inits, f"1.{i}.0.fn.0.norm")
+        blk["bn1_scale"], blk["bn1_shift"] = s, sh
+        blk["Mq"], blk["bq"] = mm_w(i*6+0), arr(inits[f"1.{i}.0.fn.1.query.bias"])
+        blk["Mk"], blk["bk"] = mm_w(i*6+1), arr(inits[f"1.{i}.0.fn.1.key.bias"])
+        blk["Mv"], blk["bv"] = mm_w(i*6+2), arr(inits[f"1.{i}.0.fn.1.value.bias"])
+        blk["Mo"], blk["bo"] = mm_w(i*6+3), arr(inits[f"1.{i}.0.fn.1.out.bias"])
+        s2, sh2 = bn_affine(inits, f"1.{i}.1.fn.0.norm")
+        blk["bn2_scale"], blk["bn2_shift"] = s2, sh2
+        blk["ff1_W"], blk["ff1_b"] = mm_w(i*6+4), arr(inits[f"1.{i}.1.fn.1.0.bias"])
+        blk["ff2_W"], blk["ff2_b"] = mm_w(i*6+5), arr(inits[f"1.{i}.1.fn.1.3.bias"])
+        blocks.append(blk)
+    out["blocks"] = blocks
+
+    hs, hsh = bn_affine(inits, "2.1")
+    out["head_bn_scale"], out["head_bn_shift"] = hs, hsh
+    out["head_W"] = arr(inits["2.2.weight"])  # (in=48, ... ) check orientation below
+    out["head_b"] = arr(inits["2.2.bias"])
+
+    # vendored inputs
+    npz = np.load(NPZ_DIR / f"{name}.npz")
+    images = npz["images"].astype(np.float64)  # (100,3,32,32) in [0,1]
+    out["images"] = images
+    out["labels"] = npz["labels"].astype(np.float64)  # (100,)
+
+    # onnxruntime reference logits on the first 5 NORMALISED images (parity oracle)
+    import onnxruntime as ort
+    sess = ort.InferenceSession(str(ONNX_DIR / f"{name}.onnx"),
+                                providers=["CPUExecutionProvider"])
+    iname = sess.get_inputs()[0].name
+    norm = (images - MEAN.reshape(1, 3, 1, 1)) / STD.reshape(1, 3, 1, 1)
+    ref = []
+    for k in range(5):
+        xin = norm[k:k+1].astype(np.float32)
+        y = sess.run(None, {iname: xin})[0].reshape(-1)
+        ref.append(y.astype(np.float64))
+    out["ref_logits"] = np.array(ref)        # (5,10)
+    out["ref_norm_images"] = norm[:5]        # (5,3,32,32) normalised
+
+    savemat(str(HERE / f"{name}.mat"), out, do_compression=True)
+    # report shapes for a sanity log
+    print(f"[{name}] proj_w{out['proj_w'].shape} pos{out['pos'].shape} "
+          f"Mq{blocks[0]['Mq'].shape} ff1_W{blocks[0]['ff1_W'].shape} "
+          f"head_W{out['head_W'].shape} images{out['images'].shape}")
+
+
+if __name__ == "__main__":
+    for nm, cfg in CONFIGS.items():
+        extract(nm, **cfg)
+    print("OK")

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/extract_weights.py
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/extract_weights.py
@@ -6,9 +6,16 @@ matrices (in,out) and pre-folds BatchNorm to per-channel (scale, shift) so the
 MATLAB side needs no torch/onnx. Also vendors the 100 inputs+labels per model
 and the CIFAR-10 mean/std so the driver can build the normalized eps-box.
 
-Usage:  python extract_weights.py
+Usage:  python extract_weights.py [--benchmark-root PATH]
+        The benchmark checkout (the n2v benchmarks/vit_vnncomp2023 directory,
+        containing onnx/ and instances/) is located, in order, from:
+          1) --benchmark-root PATH
+          2) the $N2V_VIT_BENCHMARK environment variable
+          3) ./vit_vnncomp2023 next to this script (vendored/symlinked checkout)
 Outputs (next to this script):  pgd_2_3_16.mat, ibp_3_3_8.mat
 """
+import argparse
+import os
 from pathlib import Path
 import numpy as np
 import onnx
@@ -16,9 +23,23 @@ from onnx import numpy_helper
 from scipy.io import savemat
 
 HERE = Path(__file__).resolve().parent
-N2V = Path(r"C:\Users\veriv\Documents\n2v\benchmarks\vit_vnncomp2023")
-ONNX_DIR = N2V / "onnx"
-NPZ_DIR = N2V / "instances"
+
+
+def resolve_benchmark_root(cli_root=None):
+    """Locate the n2v vit_vnncomp2023 benchmark checkout (see module docstring)."""
+    if cli_root is not None:
+        root = Path(cli_root)
+    elif os.environ.get("N2V_VIT_BENCHMARK"):
+        root = Path(os.environ["N2V_VIT_BENCHMARK"])
+    else:
+        root = HERE / "vit_vnncomp2023"
+    root = root.expanduser().resolve()
+    if not (root / "onnx").is_dir() or not (root / "instances").is_dir():
+        raise SystemExit(
+            f"benchmark root {root} is missing onnx/ or instances/. Pass "
+            f"--benchmark-root PATH or set $N2V_VIT_BENCHMARK to the n2v "
+            f"benchmarks/vit_vnncomp2023 checkout.")
+    return root
 
 MEAN = np.array([0.4914, 0.4822, 0.4465], dtype=np.float64)
 STD = np.array([0.2023, 0.1994, 0.2010], dtype=np.float64)
@@ -42,8 +63,8 @@ def bn_affine(inits, prefix):
     return scale.astype(np.float64), shift.astype(np.float64)
 
 
-def extract(name, patch, depth):
-    proto = onnx.load(str(ONNX_DIR / f"{name}.onnx"))
+def extract(name, patch, depth, onnx_dir, npz_dir):
+    proto = onnx.load(str(onnx_dir / f"{name}.onnx"))
     inits = {i.name: i for i in proto.graph.initializer}
 
     out = {}
@@ -94,14 +115,14 @@ def extract(name, patch, depth):
     out["head_b"] = arr(inits["2.2.bias"])
 
     # vendored inputs
-    npz = np.load(NPZ_DIR / f"{name}.npz")
+    npz = np.load(npz_dir / f"{name}.npz")
     images = npz["images"].astype(np.float64)  # (100,3,32,32) in [0,1]
     out["images"] = images
     out["labels"] = npz["labels"].astype(np.float64)  # (100,)
 
     # onnxruntime reference logits on the first 5 NORMALISED images (parity oracle)
     import onnxruntime as ort
-    sess = ort.InferenceSession(str(ONNX_DIR / f"{name}.onnx"),
+    sess = ort.InferenceSession(str(onnx_dir / f"{name}.onnx"),
                                 providers=["CPUExecutionProvider"])
     iname = sess.get_inputs()[0].name
     norm = (images - MEAN.reshape(1, 3, 1, 1)) / STD.reshape(1, 3, 1, 1)
@@ -121,6 +142,16 @@ def extract(name, patch, depth):
 
 
 if __name__ == "__main__":
+    ap = argparse.ArgumentParser(
+        description="Extract VNN-COMP 2023 ViT weights from ONNX into .mat files.")
+    ap.add_argument("--benchmark-root", default=None,
+                    help="n2v benchmarks/vit_vnncomp2023 checkout (with onnx/ and "
+                         "instances/). Defaults to $N2V_VIT_BENCHMARK or "
+                         "./vit_vnncomp2023 next to this script.")
+    args = ap.parse_args()
+    root = resolve_benchmark_root(args.benchmark_root)
+    onnx_dir = root / "onnx"
+    npz_dir = root / "instances"
     for nm, cfg in CONFIGS.items():
-        extract(nm, **cfg)
+        extract(nm, onnx_dir=onnx_dir, npz_dir=npz_dir, **cfg)
     print("OK")

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/lp_fulleps.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/lp_fulleps.m
@@ -1,0 +1,23 @@
+function lp_fulleps(modelName, nInst)
+% Full-eps (1/255) verification using LP margins (marginMode='lp'), which honour
+% the full Star constraint system (av-envelope facets + ReLU triangles) and are
+% strictly tighter than the estimate margins used in run_benchmark. Reports the
+% LP-verified count at full eps and the LP min-margin per instance.
+    if nargin < 2, nInst = 15; end
+    here = fileparts(mfilename('fullpath'));
+    addpath(genpath(fullfile(here,'..','..','..','engine'))); addpath(here);
+    M = ViTReach.load(fullfile(here, [modelName '.mat']));
+    nInst = min(nInst, size(M.images,1));
+    opt = struct('mode','estimate','relu','fast','marginMode','lp');
+    verified = 0;
+    fprintf('=== %s full-eps LP margins ===\n', modelName);
+    for k = 1:nInst
+        img = squeeze(M.images(k,:,:,:));
+        [lb,ub] = ViTReach.epsBox(M, img, 1/255);
+        t0 = tic;
+        [rob, margins] = ViTReach.verify(M, lb, ub, M.labels(k), opt);
+        verified = verified + (rob==1);
+        fprintf('  inst %2d: LP robust=%d minMargin=%+.4f (%.1fs)\n', k, rob==1, min(margins), toc(t0));
+    end
+    fprintf('--- %s: %d/%d LP-verified @ full eps=1/255 ---\n', modelName, verified, nInst);
+end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/run_benchmark.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/run_benchmark.m
@@ -1,0 +1,92 @@
+function summary = run_benchmark(modelName, nInst, doRadius)
+% RUN_BENCHMARK  Sweep the VNN-COMP 2023 ViT benchmark with the sound NNV
+% star-set verifier (ViTReach). Reports, per model:
+%   - full-eps (1/255) verified count (sound; expected ~0 by construction --
+%     the benchmark filters out everything incomplete methods can certify),
+%   - the certified radius eps* (largest eps verified) by bisection, which shows
+%     the verifier certifies real, non-trivial robustness below the benchmark eps,
+%   - soundness self-check: PGD/random falsification must never contradict a
+%     "robust" verdict (no false robust).
+%
+%   summary = run_benchmark('ibp_3_3_8', 20, true)
+%   summary = run_benchmark('pgd_2_3_16', 20, false)
+%
+% Requires the .mat produced by extract_weights.py next to this file.
+
+    if nargin < 2, nInst = 20; end
+    if nargin < 3, doRadius = true; end
+    here = fileparts(mfilename('fullpath'));
+    nnvroot = fullfile(here, '..', '..', '..');
+    addpath(genpath(fullfile(nnvroot, 'engine')));
+    addpath(here);
+
+    M = ViTReach.load(fullfile(here, [modelName '.mat']));
+    nInst = min(nInst, size(M.images,1));
+    fullEps = 1/255;
+    opt = struct('mode','estimate','relu','fast','marginMode','estimate');
+
+    verified = 0; falsified = 0; epsStars = nan(nInst,1);
+    fprintf('\n=== %s : %d instances ===\n', modelName, nInst);
+    tAll = tic;
+    for k = 1:nInst
+        img = squeeze(M.images(k,:,:,:));
+        label = M.labels(k);
+        % full-eps verification (sound)
+        [lb, ub] = ViTReach.epsBox(M, img, fullEps);
+        t0 = tic;
+        [rob, margins] = ViTReach.verify(M, lb, ub, label, opt);
+        tk = toc(t0);
+        isRobust = (rob == 1);
+        verified = verified + isRobust;
+
+        % soundness self-check: if "robust", a random/PGD search must not break it
+        if isRobust
+            if ViTReach_falsify(M, img, label, fullEps, 200)
+                error('SOUNDNESS VIOLATION: instance %d certified robust but falsified!', k);
+            end
+        end
+
+        % certified radius by bisection on eps in [0, fullEps]
+        es = NaN;
+        if doRadius
+            es = certify_radius(M, img, label, fullEps, opt, 6);
+            epsStars(k) = es;
+        end
+        fprintf('  inst %3d: label=%d full-eps robust=%d minMargin=%+.4f eps*=%.4f/255  (%.1fs)\n', ...
+            k, label, isRobust, min(margins), es*255, tk);
+    end
+    fprintf('--- %s: %d/%d verified @ full eps=1/255; median eps*=%.3f/255; total %.1fs ---\n', ...
+        modelName, verified, nInst, 255*median(epsStars,'omitnan'), toc(tAll));
+
+    summary = struct('model',modelName,'nInst',nInst,'verified',verified, ...
+        'falsified',falsified,'epsStars',epsStars,'medianEpsStar255',255*median(epsStars,'omitnan'));
+end
+
+function es = certify_radius(M, img, label, epsMax, opt, iters)
+    % largest eps in [0, epsMax] for which verify returns robust (bisection)
+    lo = 0; hi = epsMax; es = 0;
+    % quick check at epsMax
+    [lb,ub] = ViTReach.epsBox(M, img, epsMax);
+    if ViTReach.verify(M, lb, ub, label, opt) == 1, es = epsMax; return; end
+    for it = 1:iters
+        mid = (lo+hi)/2;
+        [lb,ub] = ViTReach.epsBox(M, img, mid);
+        if ViTReach.verify(M, lb, ub, label, opt) == 1
+            es = mid; lo = mid;
+        else
+            hi = mid;
+        end
+    end
+end
+
+function broken = ViTReach_falsify(M, img, label, eps, nTry)
+    % random search for a counterexample inside the eps-box (raw->normalised)
+    broken = false; label1 = label + 1;
+    for t = 1:nTry
+        d = (2*rand(size(img))-1) * eps;
+        xp = min(max(img + d, 0), 1);
+        logit = ViTReach.evaluate(M, ViTReach.normImg(M, xp));
+        [~, pred] = max(logit);
+        if pred ~= label1, broken = true; return; end
+    end
+end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_bab.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_bab.m
@@ -1,0 +1,51 @@
+%% test_ViTReach_bab - sound branch-and-bound: soundness + does BaB beat single-shot?
+% (1) input-split BaB is SOUND (never certifies a falsifiable box; certifies small eps);
+% (2) ReLU-phase-split BaB can certify a STRICTLY larger eps than single-shot reach
+%     on an instance near its certified boundary (the mechanism that closes the gap).
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(here);
+rng(20260626);
+
+%% input-split BaB soundness: robust@small-eps sound; never robust on a falsifiable box
+here = pdir();
+M = ViTReach.load(fullfile(here, 'ibp_3_3_8.mat'));
+k = 11; img = squeeze(M.images(k,:,:,:)); label = M.labels(k);
+% small eps: single-shot already robust -> BaB must also be robust (status 1)
+[st_small, ~] = ViTReach.verifyBaB(M, img, label, 0.3/255, struct('babMaxNodes',8));
+fprintf('BaB(input) @0.3/255: status=%d (expect 1 robust)\n', st_small);
+assert(st_small == 1, 'BaB input-split should certify a clearly-robust small box');
+% large eps: model is misclassifiable nearby -> BaB must NOT return robust
+[st_big, info_big] = ViTReach.verifyBaB(M, img, label, 6/255, struct('babMaxNodes',12,'babFalsifyTries',400));
+fprintf('BaB(input) @6/255: status=%d nodes=%d (expect 0 or 2, never 1)\n', st_big, info_big.nodes);
+assert(st_big ~= 1, 'BaB must not certify a falsifiable box (SOUNDNESS)');
+fprintf('PASS input-split BaB soundness\n');
+
+%% ReLU-phase-split BaB certifies beyond single-shot on a borderline instance
+here = pdir();
+M = ViTReach.load(fullfile(here, 'ibp_3_3_8.mat'));
+k = 11; img = squeeze(M.images(k,:,:,:)); label = M.labels(k);
+% single-shot certified radius for this instance is ~0.625/255 (from the sweep);
+% pick an eps just above it where single-shot reach is UNKNOWN:
+epsTest = 0.66/255;
+ss = ViTReach.verify(M, ViTReach_box(M,img,epsTest,1), ViTReach_box(M,img,epsTest,2), label, struct('marginMode','lp'));
+fprintf('single-shot @%.3f/255: robust=%d (expect 2 unknown)\n', epsTest*255, ss);
+t0 = tic;
+[st_bab, info] = ViTReach.verifyBaBRelu(M, img, label, epsTest, struct('babMaxNodes',24,'maxCand',12));
+fprintf('ReLU-split BaB @%.3f/255: status=%d nodes=%d (%.1fs)\n', epsTest*255, st_bab, info.nodes, toc(t0));
+if st_bab == 1 && ss ~= 1
+    fprintf('PASS BaB certifies beyond single-shot (sound BaB win)\n');
+else
+    fprintf('NOTE: BaB status=%d, single-shot=%d at %.3f/255 (mechanism sound; gain bounded by budget)\n', ...
+        st_bab, ss, epsTest*255);
+end
+assert(st_bab ~= 0, 'BaB returned not-robust without a CE search; unexpected');
+
+% ---- helpers ----
+function d = pdir(), d = fileparts(mfilename('fullpath')); end
+function out = ViTReach_box(M, img, eps, which)
+  [lb, ub] = ViTReach.epsBox(M, img, eps);
+  if which==1, out = lb; else, out = ub; end
+end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_parity.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_parity.m
@@ -1,0 +1,40 @@
+%% test_ViTReach_parity - the MATLAB ViT forward must match onnxruntime
+% Validates evaluate() (patch-embed layout, BN folding, multi-head attention,
+% FF ReLU, meanpool, head) against the onnxruntime reference logits stored in the
+% .mat by extract_weights.py. If this passes, reach() verifies the right function.
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(here);
+
+%% pgd_2_3_16 parity vs onnxruntime
+here = pdir();
+M = ViTReach.load(fullfile(here, 'pgd_2_3_16.mat'));
+ref = M.ref_logits;                       % [5 x 10]
+maxerr = 0;
+for k = 1:5
+  img = squeeze(M.ref_norm_images(k,:,:,:));     % [3,32,32] normalised
+  logits = ViTReach.evaluate(M, img);
+  maxerr = max(maxerr, max(abs(logits(:) - ref(k,:)')));
+end
+fprintf('pgd_2_3_16 max parity err = %.3e\n', maxerr);
+assert(maxerr < 1e-4, 'pgd parity FAILED: %.3e', maxerr);
+
+%% ibp_3_3_8 parity vs onnxruntime
+here = pdir();
+M = ViTReach.load(fullfile(here, 'ibp_3_3_8.mat'));
+ref = M.ref_logits;
+maxerr = 0;
+for k = 1:5
+  img = squeeze(M.ref_norm_images(k,:,:,:));
+  logits = ViTReach.evaluate(M, img);
+  maxerr = max(maxerr, max(abs(logits(:) - ref(k,:)')));
+end
+fprintf('ibp_3_3_8 max parity err = %.3e\n', maxerr);
+assert(maxerr < 1e-4, 'ibp parity FAILED: %.3e', maxerr);
+
+% ---- local helpers ----
+function d = pdir()
+  d = fileparts(mfilename('fullpath'));
+end

--- a/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_reach.m
+++ b/code/nnv/examples/Transformer/ViT_VNNCOMP2023/test_ViTReach_reach.m
@@ -1,0 +1,61 @@
+%% test_ViTReach_reach - end-to-end sound reachability soundness + timing
+% Propagates a per-pixel eps-box through the full ViT on Star sets and checks
+% that EVERY sampled concrete logit vector lies inside the reach enclosure
+% (estimate-box containment -- the estimate box outer-bounds the reachable set,
+% so any sample escaping it is a definite soundness violation). Reports timing
+% and verification margins. Each cell is self-contained (re-loads its model).
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(here);
+rng(20260626);
+
+%% pgd_2_3_16 reach is SOUND at full eps=1/255 + margins
+here = pdir();
+M = ViTReach.load(fullfile(here, 'pgd_2_3_16.mat'));
+img = squeeze(M.images(1,:,:,:));
+[lb, ub] = ViTReach.epsBox(M, img, 1/255);
+t0 = tic;
+L = ViTReach.reach(M, lb, ub, struct('mode','estimate','relu','fast'));
+fprintf('pgd reach (full eps) time = %.1fs, nVar=%d\n', toc(t0), L.nVar);
+[Llb, Lub] = L.estimateRanges();
+viol = 0;
+for t = 1:40
+  d = (2*rand(size(img))-1) * (1/255);
+  xp = min(max(img + d, 0), 1);
+  logit = ViTReach.evaluate(M, ViTReach.normImg(M, xp));
+  if any(logit < Llb - 1e-5) || any(logit > Lub + 1e-5), viol = viol + 1; end
+end
+fprintf('pgd soundness violations: %d/40\n', viol);
+assert(viol == 0, 'pgd reach UNSOUND: %d violations', viol);
+center_logit = ViTReach.evaluate(M, ViTReach.normImg(M, img));
+assert(all(center_logit >= Llb - 1e-5) && all(center_logit <= Lub + 1e-5), 'center not in box');
+[robust, margins] = ViTReach.verify(M, lb, ub, M.labels(1), struct('marginMode','estimate'));
+fprintf('pgd full-eps verify: robust=%d, min margin=%.3f\n', robust, min(margins));
+
+%% ibp_3_3_8 reach is SOUND at full eps (the verifiable model; depth 3, 17 tokens)
+here = pdir();
+M = ViTReach.load(fullfile(here, 'ibp_3_3_8.mat'));
+img = squeeze(M.images(1,:,:,:));
+[lb, ub] = ViTReach.epsBox(M, img, 1/255);
+t0 = tic;
+L = ViTReach.reach(M, lb, ub, struct('mode','estimate','relu','fast'));
+fprintf('ibp reach (full eps) time = %.1fs, nVar=%d\n', toc(t0), L.nVar);
+[Llb, Lub] = L.estimateRanges();
+viol = 0;
+for t = 1:25
+  d = (2*rand(size(img))-1) * (1/255);
+  xp = min(max(img + d, 0), 1);
+  logit = ViTReach.evaluate(M, ViTReach.normImg(M, xp));
+  if any(logit < Llb - 1e-5) || any(logit > Lub + 1e-5), viol = viol + 1; end
+end
+fprintf('ibp soundness violations: %d/25\n', viol);
+assert(viol == 0, 'ibp reach UNSOUND: %d violations', viol);
+[robust, margins] = ViTReach.verify(M, lb, ub, M.labels(1), struct('marginMode','estimate'));
+fprintf('ibp full-eps verify: robust=%d, min margin=%.3f\n', robust, min(margins));
+
+% ---- local helpers ----
+function d = pdir()
+  d = fileparts(mfilename('fullpath'));
+end

--- a/code/nnv/tests/nn/attention/test_SoftmaxAttn_attention.m
+++ b/code/nnv/tests/nn/attention/test_SoftmaxAttn_attention.m
@@ -1,0 +1,111 @@
+%% test_SoftmaxAttn_attention - TDD for the single-head and multi-head attention reach
+% singleHeadAttn(Q,K,V,scale,[N D],mode): sound reach of softmax(scale*Q*K')*V with
+%   Q,K,V matrix-Stars (dim N*D). Q,K used only for bounds (scores); V kept symbolic.
+% selfAttentionReach(X,P,mode): full multi-head self-attention with Q/K/V/out
+%   projections, head split, concat -- the ViT encoder attention sublayer (no residual).
+% Soundness oracle: linprog containment; inputs sampled, true forward must be contained.
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260626);
+
+%% singleHeadAttn soundness: independent Q,K,V samples -> output contained
+for trial = 1:6
+  N = randi([2 6]); D = randi([2 16]); scale = 1/sqrt(D);
+  Q = rand_box_star(N*D, 0.4); K = rand_box_star(N*D, 0.4); V = rand_box_star(N*D, 0.4);
+  O = SoftmaxAttn.singleHeadAttn(Q, K, V, scale, [N D], 'estimate');
+  assert(O.dim == N*D);
+  for t = 1:120
+    q = realize(Q); k = realize(K); v = realize(V);
+    Qm = reshape(q,[N D]); Km = reshape(k,[N D]); Vm = reshape(v,[N D]);
+    scores = scale * (Qm * Km');
+    A = row_softmax(scores);
+    Om = reshape(A * Vm, [], 1);
+    assert(soundness_test_utils.verify_star_containment(O, Om, 1e-6), ...
+      'singleHeadAttn UNSOUND trial %d sample %d (N=%d D=%d)', trial, t, N, D);
+  end
+end
+fprintf('PASS singleHeadAttn soundness\n');
+
+%% selfAttentionReach soundness: small config -> rigorous LP containment
+% small N keeps the containment LP cheap; this is the rigorous soundness gate.
+cfg = struct('N',4,'E',12,'H',2);
+N=cfg.N; E=cfg.E; H=cfg.H; D=E/H; scale=1/sqrt(D);
+P = rand_attn_params(E, H, scale);
+X = rand_box_star(N*E, 0.05);
+AO = SoftmaxAttn.selfAttentionReach(X, N, P, 'estimate');
+assert(AO.dim == N*E && AO.nVar >= X.nVar, 'attn out shape/prefix');
+for t = 1:60
+  x = realize(X);  out = self_attn_eval(reshape(x,[N E]), N, P);
+  assert(soundness_test_utils.verify_star_containment(AO, reshape(out,[],1), 1e-5), ...
+    'selfAttentionReach UNSOUND (LP) sample %d', t);
+end
+Y = SoftmaxAttn.prefixAdd(X, AO);
+for t = 1:40
+  x = realize(X); out = self_attn_eval(reshape(x,[N E]), N, P);
+  assert(soundness_test_utils.verify_star_containment(Y, x + reshape(out,[],1), 1e-5), 'residual UNSOUND %d', t);
+end
+fprintf('PASS selfAttentionReach soundness + residual (LP, small)\n');
+
+%% selfAttentionReach soundness: ViT shapes -> fast estimate-box containment
+% For large stars the LP containment is too slow; instead check every true forward
+% lies inside the cheap estimate over-approx box. The estimate box OUTER-bounds the
+% reachable set, so a sample escaping it is a definite soundness violation.
+configs = { struct('N',5,'E',48,'H',3), struct('N',17,'E',48,'H',3) };
+for ci = 1:numel(configs)
+  cfg = configs{ci};
+  N = cfg.N; E = cfg.E; H = cfg.H; D = E/H; scale = 1/sqrt(D);
+  P = rand_attn_params(E, H, scale);
+  X = rand_box_star(N*E, 0.04);
+  AO = SoftmaxAttn.selfAttentionReach(X, N, P, 'estimate');
+  assert(AO.dim == N*E, 'attn out dim');
+  [albx, aubx] = AO.estimateRanges();
+  for t = 1:80
+    x = realize(X);  out = reshape(self_attn_eval(reshape(x,[N E]), N, P), [], 1);
+    assert(all(out >= albx - 1e-6) && all(out <= aubx + 1e-6), ...
+      'selfAttentionReach escapes estimate box (UNSOUND) cfg %d sample %d', ci, t);
+  end
+end
+fprintf('PASS selfAttentionReach soundness (estimate-box, ViT shapes)\n');
+
+% ================= local helpers =================
+function A = row_softmax(S)
+  m = max(S,[],2); E = exp(S-m); A = E./sum(E,2);
+end
+
+function S = rand_box_star(d, rad)
+  c = randn(d,1); S = Star(c-rad, c+rad);
+end
+
+function v = realize(S)
+  a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1);
+  tries=0;
+  while ~isempty(S.C) && any(S.C*a > S.d) && tries<200
+    a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1); tries=tries+1;
+  end
+  v = S.V(:,1) + S.V(:,2:end)*a;
+end
+
+function P = rand_attn_params(E, H, scale)
+  P.E=E; P.H=H; P.D=E/H; P.scale=scale;
+  P.Mq=randn(E,E)*0.1; P.bq=randn(E,1)*0.1;
+  P.Mk=randn(E,E)*0.1; P.bk=randn(E,1)*0.1;
+  P.Mv=randn(E,E)*0.1; P.bv=randn(E,1)*0.1;
+  P.Mo=randn(E,E)*0.1; P.bo=randn(E,1)*0.1;
+end
+
+function out = self_attn_eval(Xt, N, P)
+  % concrete forward of multi-head self-attention; Xt [N,E]
+  E=P.E; H=P.H; D=P.D;
+  Q = Xt*P.Mq + P.bq';  K = Xt*P.Mk + P.bk';  V = Xt*P.Mv + P.bv';
+  O = zeros(N,E);
+  for h=1:H
+    cols = (h-1)*D + (1:D);
+    Qh=Q(:,cols); Kh=K(:,cols); Vh=V(:,cols);
+    A = row_softmax(P.scale*(Qh*Kh'));
+    O(:,cols) = A*Vh;
+  end
+  out = O*P.Mo + P.bo';
+end

--- a/code/nnv/tests/nn/attention/test_SoftmaxAttn_avenvelope.m
+++ b/code/nnv/tests/nn/attention/test_SoftmaxAttn_avenvelope.m
@@ -1,0 +1,83 @@
+%% test_SoftmaxAttn_avenvelope - TDD for the sound symbolic A*V envelope
+% Mirrors n2v tests/soundness/test_soundness_av_envelope.py.
+% O = A @ V, with A in [a_lb,a_ub] (a_lb>=0, the softmax weights, concretized to a
+% box) and V a SYMBOLIC Star. The envelope is affine in V's predicates only, so O
+% stays correlated with the input. Sign-aware per-term McCormick (the V<=0 and mixed
+% branches are the historically-wrong ones -> hammered here across V regimes).
+% A and V are sampled INDEPENDENTLY; every true product must be contained (LP oracle).
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260625);
+
+%% soundness across V sign regimes (pos/neg/mixed) and shapes; A,V independent
+regimes = {'pos','neg','mixed'};
+shapes  = {[3 4 5],[5 5 16],[17 17 16],[2 3 2]};   % [M K D]
+for ri = 1:numel(regimes)
+  for si = 1:numel(shapes)
+    M = shapes{si}(1); K = shapes{si}(2); D = shapes{si}(3);
+    % attention weights box A in [a_lb,a_ub], a_lb>=0
+    a_lb = rand(M,K)*0.5;
+    a_ub = a_lb + rand(M,K)*0.5;
+    Vstar = rand_value_star(K, D, regimes{ri});
+    O = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, Vstar, [K D], 'estimate');
+    assert(O.dim == M*D, 'O dim');
+    % O predicates >= V's predicates (V is a prefix)
+    assert(O.nVar == Vstar.nVar + M*D, 'fresh predicate count');
+    for t = 1:250
+      av = sample_alpha(Vstar);
+      vvec = Vstar.V(:,1) + Vstar.V(:,2:end)*av;     % realized V
+      Vm = reshape(vvec, [K D]);
+      A = a_lb + (a_ub - a_lb).*rand(M,K);           % independent A in box
+      Om = A * Vm;                                    % true product [M D]
+      ovec = reshape(Om, [], 1);
+      assert(soundness_test_utils.verify_star_containment(O, ovec, 1e-6), ...
+        'avEnvelope UNSOUND regime %s shape %s sample %d', regimes{ri}, mat2str(shapes{si}), t);
+    end
+  end
+end
+fprintf('PASS avEnvelopeStar soundness (pos/neg/mixed, independent A,V)\n');
+
+%% degenerate V (point value) and tight A still sound
+M=4;K=3;D=2;
+c = randn(K*D,1);
+Vstar = Star(c, c);              % zero-width V (point)
+a_lb = rand(M,K); a_ub = a_lb;   % point A
+O = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, Vstar, [K D], 'estimate');
+Vm = reshape(c,[K D]); Om = reshape(a_lb*Vm,[],1);
+assert(soundness_test_utils.verify_star_containment(O, Om, 1e-5), 'degenerate UNSOUND');
+fprintf('PASS avEnvelopeStar degenerate\n');
+
+%% negative a_lb must raise (the floor>=0 contract)
+M=2;K=2;D=2;
+Vstar = rand_value_star(K,D,'mixed');
+threw = false;
+try
+  SoftmaxAttn.avEnvelopeStar(-0.1*ones(M,K), ones(M,K), Vstar, [K D], 'estimate');
+catch ME
+  threw = contains(ME.identifier,'SoftmaxAttn') || contains(ME.message,'a_lb');
+end
+assert(threw, 'negative a_lb should raise');
+fprintf('PASS avEnvelopeStar rejects negative a_lb\n');
+
+% ================= local helpers =================
+function S = rand_value_star(K, D, regime)
+  % random box Star for V (dim K*D), forced into a sign regime
+  d = K*D;
+  switch regime
+    case 'pos',   lo = 0.2 + rand(d,1);    hi = lo + 0.3 + rand(d,1);
+    case 'neg',   hi = -0.2 - rand(d,1);   lo = hi - 0.3 - rand(d,1);
+    case 'mixed', lo = -rand(d,1)-0.2;     hi = rand(d,1)+0.2;
+  end
+  S = Star(lo, hi);
+end
+
+function a = sample_alpha(S)
+  a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1);
+  tries = 0;
+  while ~isempty(S.C) && any(S.C*a > S.d) && tries < 100
+    a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1); tries = tries+1;
+  end
+end

--- a/code/nnv/tests/nn/attention/test_SoftmaxAttn_matmul.m
+++ b/code/nnv/tests/nn/attention/test_SoftmaxAttn_matmul.m
@@ -1,0 +1,113 @@
+%% test_SoftmaxAttn_matmul - TDD soundness tests for the sound set@set bilinear matmul
+% Mirrors n2v tests/soundness/test_soundness_bilinear_matmul.py:
+%   - Rump midpoint-radius interval matmul encloses every A@B with A in [al,au], B in [bl,bu]
+%   - operands sampled INDEPENDENTLY across sign regimes {pos,neg,mixed} (worst case for
+%     concretize, which drops cross-correlation)
+%   - bilinearMatMulStar: Star in -> box Star out, every sampled product contained (LP oracle)
+%   - negative scale handled sign-safe
+%
+% Soundness oracle: soundness_test_utils.verify_star_containment (linprog feasibility LP).
+% NOTE: tol band here is 0 (exact) for interval bounds, and the util's default band for stars.
+
+% ---- shared setup (runs before each %% section) ----
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');           % code/nnv
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260625);
+
+%% intervalMatMul encloses all sampled products (sign regimes, multiple shapes)
+shapes = {[3 4 5], [5 16 5], [5 5 16], [2 2 4], [1 8 1]};  % [m k n]
+regimes = {'pos','neg','mixed'};
+for si = 1:numel(shapes)
+  s = shapes{si}; m=s(1); k=s(2); n=s(3);
+  for ri = 1:numel(regimes)
+    [al,au] = rand_box(m,k,regimes{ri});
+    [bl,bu] = rand_box(k,n,regimes{ri});
+    [cl,cu] = SoftmaxAttn.intervalMatMul(al,au,bl,bu);
+    assert(isequal(size(cl),[m n]) && isequal(size(cu),[m n]), 'shape');
+    assert(all(cl(:) <= cu(:) + 1e-12), 'lb<=ub');
+    % brute-force: sample A,B independently, product must lie in [cl,cu]
+    for t = 1:300
+      A = al + (au-al).*rand(m,k);
+      B = bl + (bu-bl).*rand(k,n);
+      C = A*B;
+      assert(all(C(:) >= cl(:) - 1e-9) && all(C(:) <= cu(:) + 1e-9), ...
+        'interval matmul UNSOUND shape %s regime %s', mat2str(s), regimes{ri});
+    end
+    % corner check: all-low and all-high operands are inside
+    assert(all(vec(al*bl) >= cl(:)-1e-9 & vec(al*bl) <= cu(:)+1e-9));
+    assert(all(vec(au*bu) >= cl(:)-1e-9 & vec(au*bu) <= cu(:)+1e-9));
+  end
+end
+fprintf('PASS intervalMatMul soundness\n');
+
+%% bilinearMatMulStar: Star@Star -> box Star, sampled products contained (estimate mode)
+m=3; k=4; n=5;
+X = rand_star(m*k, 0.5);
+Y = rand_star(k*n, 0.5);
+S = SoftmaxAttn.bilinearMatMulStar(X, Y, [m k], [k n], 1.0, 'estimate');
+assert(S.dim == m*n, 'out dim');
+for t = 1:200
+  ax = sample_alpha(X); xvec = X.V(:,1) + X.V(:,2:end)*ax;
+  ay = sample_alpha(Y); yvec = Y.V(:,1) + Y.V(:,2:end)*ay;
+  Xm = reshape(xvec,[m k]); Ym = reshape(yvec,[k n]);
+  prod = reshape(Xm*Ym,[],1);
+  ok = soundness_test_utils.verify_star_containment(S, prod, 1e-6);
+  assert(ok, 'bilinearMatMulStar UNSOUND sample %d', t);
+end
+fprintf('PASS bilinearMatMulStar soundness (estimate)\n');
+
+%% bilinearMatMulStar with negative scale stays sound
+m=2;k=3;n=2; scale=-0.25;
+X = rand_star(m*k, 0.7); Y = rand_star(k*n, 0.7);
+S = SoftmaxAttn.bilinearMatMulStar(X, Y, [m k], [k n], scale, 'estimate');
+for t=1:200
+  ax=sample_alpha(X); xvec=X.V(:,1)+X.V(:,2:end)*ax;
+  ay=sample_alpha(Y); yvec=Y.V(:,1)+Y.V(:,2:end)*ay;
+  prod = reshape(scale*(reshape(xvec,[m k])*reshape(yvec,[k n])),[],1);
+  assert(soundness_test_utils.verify_star_containment(S, prod, 1e-6), 'neg-scale UNSOUND %d', t);
+end
+fprintf('PASS bilinearMatMulStar negative scale\n');
+
+%% lp mode is at least as tight as estimate and still sound
+m=3;k=3;n=3;
+X = rand_star(m*k, 0.4); Y = rand_star(k*n, 0.4);
+Se = SoftmaxAttn.bilinearMatMulStar(X, Y, [m k], [k n], 1.0, 'estimate');
+Sl = SoftmaxAttn.bilinearMatMulStar(X, Y, [m k], [k n], 1.0, 'lp');
+[le,ue]=Se.getRanges(); [ll,ul]=Sl.getRanges();
+assert(all(ll >= le - 1e-7) && all(ul <= ue + 1e-7), 'lp should be tighter-or-equal');
+for t=1:100
+  ax=sample_alpha(X); xvec=X.V(:,1)+X.V(:,2:end)*ax;
+  ay=sample_alpha(Y); yvec=Y.V(:,1)+Y.V(:,2:end)*ay;
+  prod = reshape(reshape(xvec,[m k])*reshape(yvec,[k n]),[],1);
+  assert(soundness_test_utils.verify_star_containment(Sl, prod, 1e-6), 'lp UNSOUND %d', t);
+end
+fprintf('PASS bilinearMatMulStar lp tighter+sound\n');
+
+% ================= local helpers =================
+function v = vec(M), v = M(:); end
+
+function [lo,hi] = rand_box(r,c,regime)
+  w = 0.5 + rand(r,c);          % positive width
+  switch regime
+    case 'pos',   lo = 0.1 + rand(r,c);        hi = lo + w;
+    case 'neg',   hi = -0.1 - rand(r,c);       lo = hi - w;
+    case 'mixed', lo = -rand(r,c)-0.1;         hi = rand(r,c)+0.1;
+  end
+end
+
+function S = rand_star(d, rad)
+  % box star [c-r, c+r] with random center, as a Star with explicit predicate box
+  c = randn(d,1);
+  lo = c - rad; hi = c + rad;
+  S = Star(lo, hi);
+end
+
+function a = sample_alpha(S)
+  a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1);
+  tries=0;
+  while ~isempty(S.C) && any(S.C*a > S.d) && tries<100
+    a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1); tries=tries+1;
+  end
+end

--- a/code/nnv/tests/nn/attention/test_SoftmaxAttn_prefix.m
+++ b/code/nnv/tests/nn/attention/test_SoftmaxAttn_prefix.m
@@ -1,0 +1,107 @@
+%% test_SoftmaxAttn_prefix - TDD for prefix-aligned residual add and head concat
+% prefixAdd(x, branch): x's predicates are a PREFIX of branch's (branch was built
+%   from x by appending relaxation predicates). Returns x+branch over branch's
+%   constraint system -- sound AND tight (keeps residual correlation a block-diagonal
+%   Minkowski join would drop), and provenance-safe (never the structural-equality
+%   fast path that under-approximates independent-but-identical operands).
+% prefixConcat({S_h}, n_old): stack states of stars sharing the first n_old preds
+%   into one star with block-diagonal fresh tails -> used to assemble attention heads.
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260625);
+
+%% prefixAdd: y = x + branch(x), sampled sums contained (residual stream)
+% Build x over input preds; branch = avEnvelope(...) which appends fresh preds.
+K=4; D=5; M=K;   % residual needs x.dim == branch.dim -> use M=K, D s.t. M*D == K*D? use square
+% make x.dim == branch.dim: branch dim = M*D, so set x to dim M*D
+Vstar = rand_box_star(K*D, 'mixed');
+a_lb = rand(M,K)*0.5; a_ub = a_lb + rand(M,K)*0.5;
+branch = SoftmaxAttn.avEnvelopeStar(a_lb, a_ub, Vstar, [K D], 'estimate');  % dim M*D, preds [alpha_old, fresh]
+% x: a star over the SAME alpha_old prefix only (dim M*D), built as an affine map of Vstar
+Wx = randn(M*D, K*D);
+x = Vstar.affineMap(Wx, zeros(M*D,1));     % x.nVar == Vstar.nVar == prefix of branch
+assert(x.nVar <= branch.nVar, 'x prefix');
+y = SoftmaxAttn.prefixAdd(x, branch);
+assert(y.dim == branch.dim && y.nVar == branch.nVar, 'y shape');
+for t=1:250
+  abeta = sample_alpha(branch);                 % full predicate vector of branch
+  aold  = abeta(1:Vstar.nVar);
+  vvec = Vstar.V(:,1) + Vstar.V(:,2:end)*aold;  % realized V
+  Vm = reshape(vvec,[K D]);
+  A = a_lb + (a_ub-a_lb).*rand(M,K);
+  br_true = reshape(A*Vm,[],1);                 % a valid branch output for this aold
+  x_true  = x.V(:,1) + x.V(:,2:end)*aold;
+  y_true  = x_true + br_true;
+  assert(soundness_test_utils.verify_star_containment(y, y_true, 1e-6), 'prefixAdd UNSOUND %d', t);
+end
+fprintf('PASS prefixAdd soundness\n');
+
+%% prefixAdd does NOT under-approximate independent-but-identical operands
+% (the structural-equality trap: x in [-1,1], plus an independent -x' in [-1,1];
+%  a structural "shared alpha" gate would collapse to {0}; true range is [-2,2]).
+% prefixAdd is only valid when one is a genuine prefix of the other; here we
+% verify the residual path keeps the full range when branch genuinely extends x.
+xb = Star(-1, 1);                       % dim 1, 1 pred
+br = Star([-1;-1+0], [1;1]);            % placeholder, rebuild properly below
+% branch over [alpha_x, fresh] with state = -fresh (independent of x):
+Vb = [0, 0, -1];                        % center 0, prefix gen 0, tail gen -1
+Cb = [1 0; -1 0; 0 1; 0 -1];           % box on [alpha_x, fresh]
+db = [1;1;1;1];
+br = Star(Vb, Cb, db, [-1;-1], [1;1]);
+y = SoftmaxAttn.prefixAdd(xb, br);
+lo = y.getMin(1,'linprog'); hi = y.getMax(1,'linprog');
+assert(lo <= -2+1e-6 && hi >= 2-1e-6, 'prefixAdd must keep [-2,2], got [%g,%g]', lo, hi);
+fprintf('PASS prefixAdd keeps independent-operand range\n');
+
+%% prefixConcat: assemble attention heads (slice shared V, av per head, concat)
+H=3; K=5; D=16; M=5; n_old_dim = K*D;
+Vfull = rand_box_star(H*K*D, 'mixed');   % full value projection
+Os = cell(1,H); A_lbs=cell(1,H); A_ubs=cell(1,H);
+for h=1:H
+  idx = (h-1)*K*D + (1:K*D);
+  Vh = slice_star(Vfull, idx);           % head h value sub-star (same preds)
+  A_lbs{h} = rand(M,K)*0.5; A_ubs{h} = A_lbs{h} + rand(M,K)*0.5;
+  Os{h} = SoftmaxAttn.avEnvelopeStar(A_lbs{h}, A_ubs{h}, Vh, [K D], 'estimate');
+end
+O = SoftmaxAttn.prefixConcat(Os, Vfull.nVar);
+assert(O.dim == H*M*D, 'concat dim');
+for t=1:150
+  aold = sample_alpha(Vfull);
+  vfull = Vfull.V(:,1) + Vfull.V(:,2:end)*aold;
+  o_true = [];
+  for h=1:H
+    idx = (h-1)*K*D + (1:K*D);
+    Vm = reshape(vfull(idx),[K D]);
+    A = A_lbs{h} + (A_ubs{h}-A_lbs{h}).*rand(M,K);
+    o_true = [o_true; reshape(A*Vm,[],1)];
+  end
+  assert(soundness_test_utils.verify_star_containment(O, o_true, 1e-6), 'prefixConcat UNSOUND %d', t);
+end
+fprintf('PASS prefixConcat soundness (multi-head assembly)\n');
+
+% ================= local helpers =================
+function S = rand_box_star(d, regime)
+  switch regime
+    case 'pos',   lo = 0.2+rand(d,1);  hi = lo+0.3+rand(d,1);
+    case 'neg',   hi = -0.2-rand(d,1); lo = hi-0.3-rand(d,1);
+    case 'mixed', lo = -rand(d,1)-0.2; hi = rand(d,1)+0.2;
+  end
+  S = Star(lo,hi);
+end
+
+function Sh = slice_star(S, idx)
+  % select state rows idx, keep all predicates/constraints
+  Vh = S.V(idx, :);
+  Sh = Star(Vh, S.C, S.d, S.predicate_lb, S.predicate_ub);
+end
+
+function a = sample_alpha(S)
+  a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1);
+  tries = 0;
+  while ~isempty(S.C) && any(S.C*a > S.d) && tries < 200
+    a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1); tries = tries+1;
+  end
+end

--- a/code/nnv/tests/nn/attention/test_SoftmaxAttn_softmax.m
+++ b/code/nnv/tests/nn/attention/test_SoftmaxAttn_softmax.m
@@ -1,0 +1,88 @@
+%% test_SoftmaxAttn_softmax - TDD for the exact correlated row-softmax bound
+% Mirrors n2v tests/soundness/test_soundness_softmax_attention.py.
+% softmax is taken over the KEY axis (dim 2 of an [R x n] logit box).
+% Monotonicity: dA_j/dS_j >= 0, dA_j/dS_k <= 0 (k~=j), so the per-coordinate
+% extremes are attained at the corners
+%   a_ub_j = softmax(s_lo everywhere, s_hi at j)_j
+%   a_lb_j = softmax(s_hi everywhere, s_lo at j)_j
+% giving the EXACT (tightest) axis-aligned enclosure of softmax over the box.
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260625);
+
+%% edge cases: equal logits -> uniform 1/n; single key -> exactly 1
+s = [2 2 2; -1 -1 -1];               % R=2, n=3, degenerate box (lo==hi)
+[al, au] = SoftmaxAttn.correlatedRowSoftmaxBounds(s, s);
+assert(max(abs(al(:) - 1/3)) < 1e-9, 'equal logits lower');
+assert(max(abs(au(:) - 1/3)) < 1e-9, 'equal logits upper');
+
+[al, au] = SoftmaxAttn.correlatedRowSoftmaxBounds([0.5; -2], [3; 1]);  % R=2, n=1
+assert(all(abs(al - 1) < 1e-12) && all(abs(au - 1) < 1e-12), 'single key = 1');
+
+%% soundness + tightness: sampled row-softmax lies in [a_lb,a_ub], bounds attained
+regimes = {'pos','neg','wide','mixed'};
+shapes  = {[5 5],[17 17],[3 1],[1 6],[4 3]};
+for ri = 1:numel(regimes)
+  for si = 1:numel(shapes)
+    R = shapes{si}(1); n = shapes{si}(2);
+    [s_lo, s_hi] = rand_logit_box(R, n, regimes{ri});
+    [al, au] = SoftmaxAttn.correlatedRowSoftmaxBounds(s_lo, s_hi);
+    assert(all(al(:) >= -1e-12) && all(au(:) <= 1+1e-12), 'within [0,1]');
+    assert(all(al(:) <= au(:) + 1e-12), 'lb<=ub');
+    for t = 1:400
+      S = s_lo + (s_hi - s_lo).*rand(R, n);
+      A = row_softmax(S);
+      assert(all(A(:) >= al(:) - 1e-9) && all(A(:) <= au(:) + 1e-9), ...
+        'softmax UNSOUND regime %s shape %s', regimes{ri}, mat2str(shapes{si}));
+    end
+    % each row must sum to 1; bound must be consistent with that
+    assert(all(sum(al,2) <= 1 + 1e-9) && all(sum(au,2) >= 1 - 1e-9), 'row-sum sandwich');
+  end
+end
+fprintf('PASS correlatedRowSoftmaxBounds soundness+tightness\n');
+
+%% softmaxAttnStar: Star logits -> box Star weights; sampled weights contained
+R = 5; n = 5;
+Slog = rand_star(R*n, 0.6);
+W = SoftmaxAttn.softmaxAttnStar(Slog, [R n], 'estimate');
+assert(W.dim == R*n);
+for t = 1:200
+  a = sample_alpha(Slog); v = Slog.V(:,1) + Slog.V(:,2:end)*a;
+  Smat = reshape(v, [R n]);
+  A = reshape(row_softmax(Smat), [], 1);
+  assert(soundness_test_utils.verify_star_containment(W, A, 1e-6), 'softmaxAttnStar UNSOUND %d', t);
+end
+fprintf('PASS softmaxAttnStar soundness\n');
+
+% ================= local helpers =================
+function A = row_softmax(S)
+  m = max(S, [], 2);
+  E = exp(S - m);
+  A = E ./ sum(E, 2);
+end
+
+function [lo, hi] = rand_logit_box(R, n, regime)
+  w = 0.3 + 0.8*rand(R, n);
+  switch regime
+    case 'pos',   lo = 0.2 + rand(R,n);   hi = lo + w;
+    case 'neg',   hi = -0.2 - rand(R,n);  lo = hi - w;
+    case 'wide',  lo = -3*rand(R,n)-1;    hi = 3*rand(R,n)+1;
+    case 'mixed', lo = -rand(R,n)-0.1;    hi = rand(R,n)+0.1;
+  end
+end
+
+function S = rand_star(d, rad)
+  c = randn(d,1);
+  S = Star(c - rad, c + rad);
+end
+
+function a = sample_alpha(S)
+  a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1);
+  tries = 0;
+  while ~isempty(S.C) && any(S.C*a > S.d) && tries < 100
+    a = S.predicate_lb + (S.predicate_ub - S.predicate_lb).*rand(S.nVar,1); tries = tries+1;
+  end
+end

--- a/code/nnv/tests/nn/attention/test_attention_layers.m
+++ b/code/nnv/tests/nn/attention/test_attention_layers.m
@@ -1,0 +1,77 @@
+%% test_attention_layers - TDD for sound reach in the NNV transformer layers
+% DynamicMatmulLayer.reach: sound set@set matmul (was an unconditional error).
+% ScaledDotProductAttentionLayer.reach: sound MULTI-TOKEN attention (was box-lift +
+%   single-token V-passthrough that ERRORED on multi-token). All star-family solving
+%   methods must return a sound set (never error, never an unsound bound).
+
+here = fileparts(mfilename('fullpath'));
+nnvroot = fullfile(here, '..', '..', '..');
+addpath(genpath(fullfile(nnvroot, 'engine')));
+addpath(genpath(fullfile(nnvroot, 'tests', 'soundness')));
+rng(20260626);
+
+%% DynamicMatmulLayer sound reach (set@set), every method, soundness contained
+m=3; k=4; n=5;
+L = DynamicMatmulLayer('dm');
+L.LeftShape = [m k]; L.RightShape = [k n];
+A = rand_star(m*k, 0.5); B = rand_star(k*n, 0.5);
+methods = {'approx-star','exact-star','abs-dom','relax-star-area','approx-zono'};
+for mi = 1:numel(methods)
+  S = L.reach({A,B}, methods{mi});
+  if isa(S,'Zono'), [slb,sub]=S.getBounds(); contain=@(p) all(p>=slb-1e-6 & p<=sub+1e-6);
+  else, contain=@(p) soundness_test_utils.verify_star_containment(S, p, 1e-6); end
+  for t=1:60
+    a=realize(A); b=realize(B);
+    prod = reshape(reshape(a,[m k])*reshape(b,[k n]),[],1);
+    assert(contain(prod), 'DynamicMatmul UNSOUND method %s sample %d', methods{mi}, t);
+  end
+end
+fprintf('PASS DynamicMatmulLayer sound reach (all methods)\n');
+
+%% DynamicMatmulLayer without shapes still refuses (sound-by-refusal)
+L2 = DynamicMatmulLayer('dm2');
+threw=false;
+try, L2.reach({A,B},'approx-star'); catch, threw=true; end
+assert(threw, 'must refuse without operand shapes');
+fprintf('PASS DynamicMatmulLayer refuses unknown shapes\n');
+
+%% ScaledDotProductAttentionLayer multi-token sound reach, all methods
+N=5; D=8; scale=1/sqrt(D);
+L = ScaledDotProductAttentionLayer('sdpa', D, D, N);   % QueryDim=KeyDim=D, ValueDim=D, SeqLength=N
+Q = rand_star(N*D, 0.4); K = rand_star(N*D, 0.4); V = rand_star(N*D, 0.4);
+methods = {'approx-star','exact-star','abs-dom','relax-star-area'};
+for mi=1:numel(methods)
+  S = L.reach(Q, K, V, methods{mi});
+  assert(isa(S,'Star') && S.dim==N*D, 'attn out shape (%s)', methods{mi});
+  for t=1:50
+    q=realize(Q); k_=realize(K); v=realize(V);
+    Qm=reshape(q,[N D]); Km=reshape(k_,[N D]); Vm=reshape(v,[N D]);
+    A = row_softmax(scale*(Qm*Km'));
+    Om = reshape(A*Vm,[],1);
+    assert(soundness_test_utils.verify_star_containment(S, Om, 1e-6), ...
+      'SDPA multi-token UNSOUND method %s sample %d', methods{mi}, t);
+  end
+end
+fprintf('PASS ScaledDotProductAttentionLayer multi-token sound (all methods)\n');
+
+%% SDPA single-token contract still exact (V-passthrough), no regression
+N1=1; D1=6;
+L = ScaledDotProductAttentionLayer('sdpa1', D1, D1, N1);
+Q=rand_star(D1,0.3); K=rand_star(D1,0.3); V=rand_star(D1,0.3);
+S = L.reach(Q,K,V,'approx-star');
+for t=1:50
+  v=realize(V);                         % single token: attn = V exactly
+  assert(soundness_test_utils.verify_star_containment(S, v, 1e-6), 'single-token regressed %d', t);
+end
+fprintf('PASS ScaledDotProductAttentionLayer single-token exact\n');
+
+% ---- helpers ----
+function A = row_softmax(S), m=max(S,[],2); e=exp(S-m); A=e./sum(e,2); end
+function S = rand_star(d, rad), c=randn(d,1); S=Star(c-rad,c+rad); end
+function v = realize(S)
+  a=S.predicate_lb+(S.predicate_ub-S.predicate_lb).*rand(S.nVar,1); tries=0;
+  while ~isempty(S.C) && any(S.C*a>S.d) && tries<200
+    a=S.predicate_lb+(S.predicate_ub-S.predicate_lb).*rand(S.nVar,1); tries=tries+1;
+  end
+  v=S.V(:,1)+S.V(:,2:end)*a;
+end

--- a/code/nnv/tests/soundness/test_transformer_soundness_regression.m
+++ b/code/nnv/tests/soundness/test_transformer_soundness_regression.m
@@ -39,16 +39,31 @@ try, L.reach(42); catch, errored = true; end
 assert(errored, 'intermediate softmax must error on unsupported set type, not silently passthrough');
 fprintf('Test 3 PASSED (softmax fails loud on unsupported type)\n');
 
-%% Test 4: SDPA multi-token reach errors (would be unsound); single-token still works
+%% Test 4: SDPA multi-token reach is now SOUND (correlated softmax + symbolic A*V);
+% single-token stays exact (V-passthrough). Multi-token used to fail loud because
+% no sound bound existed; it now propagates a sound set (MC-containment locked).
+rng(4); N = 3; D = 4; scale = 0.5;
 L = ScaledDotProductAttentionLayer('a');
-L.ValueDim = 4; L.QueryDim = 4; L.KeyDim = 4; L.Scale = 0.5;
-Q = Star(zeros(4,1), ones(4,1)); K = Q;
-errMulti = false;
-try, L.reach(Q, K, Star(zeros(8,1), ones(8,1)), 'approx-star'); catch, errMulti = true; end
-assert(errMulti, 'multi-token SDPA reach must error (single-token V-bounds would be unsound)');
-S = L.reach(Q, K, Star(zeros(4,1), ones(4,1)), 'approx-star');
-assert(S.dim == 4, 'single-token SDPA reach broken');
-fprintf('Test 4 PASSED (SDPA multi-token fail-loud, single-token ok)\n');
+L.ValueDim = D; L.QueryDim = D; L.KeyDim = D; L.Scale = scale;
+mk = @() Star(randn(N*D,1)-0.4, randn(N*D,1)+0.4);
+Q = mk(); K = mk(); V = mk();
+S = L.reach(Q, K, V, 'approx-star');
+assert(isa(S,'Star') && S.dim == N*D, 'multi-token SDPA reach shape');
+rsf = @(s) s.V(:,1) + s.V(:,2:end) * (s.predicate_lb + (s.predicate_ub - s.predicate_lb).*rand(s.nVar,1));
+viol = 0;
+for k = 1:300
+    qv = rsf(Q); kv = rsf(K); vv = rsf(V);
+    Qm = reshape(qv,[N D]); Km = reshape(kv,[N D]); Vm = reshape(vv,[N D]);
+    sc = scale*(Qm*Km'); m = max(sc,[],2); ex = exp(sc-m); A = ex./sum(ex,2);
+    Om = reshape(A*Vm,[],1);
+    if ~soundness_test_utils.verify_star_containment(S, Om, 1e-6), viol = viol + 1; end
+end
+assert(viol == 0, 'multi-token SDPA reach UNSOUND: %d/300 MC violations', viol);
+% single-token: attention == V exactly
+L1 = ScaledDotProductAttentionLayer('a1'); L1.ValueDim = 4; L1.QueryDim = 4; L1.KeyDim = 4; L1.Scale = 0.5;
+S1 = L1.reach(Star(zeros(4,1),ones(4,1)), Star(zeros(4,1),ones(4,1)), Star(zeros(4,1),ones(4,1)), 'approx-star');
+assert(S1.dim == 4, 'single-token SDPA reach broken');
+fprintf('Test 4 PASSED (SDPA multi-token SOUND, single-token exact)\n');
 
 %% Test 5: MHA multi-token reach errors (would be unsound)
 L = MultiHeadAttentionLayer();

--- a/code/nnv/tests/soundness/test_transformer_soundness_regression.m
+++ b/code/nnv/tests/soundness/test_transformer_soundness_regression.m
@@ -45,7 +45,8 @@ fprintf('Test 3 PASSED (softmax fails loud on unsupported type)\n');
 rng(4); N = 3; D = 4; scale = 0.5;
 L = ScaledDotProductAttentionLayer('a');
 L.ValueDim = D; L.QueryDim = D; L.KeyDim = D; L.Scale = scale;
-mk = @() Star(randn(N*D,1)-0.4, randn(N*D,1)+0.4);
+mkc = @(c) Star(c - 0.5, c + 0.5);   % box of radius 0.5 about a center
+mk  = @() mkc(randn(N*D,1));          % single random draw => lb<=ub guaranteed
 Q = mk(); K = mk(); V = mk();
 S = L.reach(Q, K, V, 'approx-star');
 assert(isa(S,'Star') && S.dim == N*D, 'multi-token SDPA reach shape');

--- a/code/nnv/tests/vnncomp25/test_vnncomp25_regression.m
+++ b/code/nnv/tests/vnncomp25/test_vnncomp25_regression.m
@@ -517,22 +517,37 @@ end
 assert(errored, 'Test 28 failed: straddle-zero divisor must raise divisorStraddlesZero');
 fprintf('Test 28 PASSED (ElementwiseDivisionLayer MC-sound + straddle-zero fail-loud)\n');
 
-%% Test 29: DynamicMatmulLayer reach ERRORS (no sound bound implemented); evaluate exact
-% The previous reach took ELEMENT-WISE interval products of the flattened
-% operands -- not a sound bound for a matrix product (out(i,j) sums k bilinear
-% terms and the output shape differs). It must refuse rather than mislead.
+%% Test 29: DynamicMatmulLayer reach -- sound with operand shapes, refuses without
+% Without shapes a sound interval matmul is impossible (out(i,j) sums k bilinear
+% terms), so reach refuses (reachNeedsShapes). With LeftShape/RightShape set it
+% returns a SOUND Rump interval-matmul enclosure (every sampled product contained).
 L29 = DynamicMatmulLayer('mm29', 2, 1, {'in1','in2'}, {'out'});
 errored = false;
 try
     L29.reach({Star(zeros(4,1), ones(4,1)), Star(zeros(4,1), ones(4,1))}, 'approx-star');
 catch ME29
-    errored = strcmp(ME29.identifier, 'DynamicMatmulLayer:reachNotImplemented');
+    errored = strcmp(ME29.identifier, 'DynamicMatmulLayer:reachNeedsShapes');
 end
-assert(errored, 'Test 29 failed: DynamicMatmul reach must raise reachNotImplemented');
+assert(errored, 'Test 29 failed: DynamicMatmul reach must refuse without operand shapes');
+% with shapes: sound 2x2 @ 2x2 (column-major reshape), MC-contained
+rng(29); L29.LeftShape = [2 2]; L29.RightShape = [2 2];
+Aset = Star(randn(4,1)-0.5, randn(4,1)+0.5);  % ensure lb<ub
+al = min(Aset.V(:,1)-0.5, Aset.V(:,1)+0.5); Aset = Star(al, al+1);
+Bset = Star(zeros(4,1), ones(4,1));
+S29 = L29.reach({Aset, Bset}, 'approx-star');
+assert(isa(S29,'Star') && S29.dim == 4, 'Test 29: sound reach shape');
+for t = 1:50
+    a = Aset.predicate_lb + (Aset.predicate_ub-Aset.predicate_lb).*rand(Aset.nVar,1);
+    b = Bset.predicate_lb + (Bset.predicate_ub-Bset.predicate_lb).*rand(Bset.nVar,1);
+    av = Aset.V(:,1)+Aset.V(:,2:end)*a; bv = Bset.V(:,1)+Bset.V(:,2:end)*b;
+    prod = reshape(reshape(av,[2 2])*reshape(bv,[2 2]),[],1);
+    assert(soundness_test_utils.verify_star_containment(S29, prod, 1e-6), ...
+        'Test 29 failed: DynamicMatmul reach UNSOUND sample %d', t);
+end
 A29 = rand(3,4,'single'); B29 = rand(4,2,'single');
 assert(max(abs(double(L29.evaluate({A29,B29}) - A29*B29)), [], 'all') < 1e-5, ...
     'Test 29 failed: evaluate must stay exact');
-fprintf('Test 29 PASSED (DynamicMatmulLayer reach fail-loud; evaluate exact)\n');
+fprintf('Test 29 PASSED (DynamicMatmulLayer sound-with-shapes / refuse-without; evaluate exact)\n');
 
 %% Test 30: PlaceholderLayer ACTIVE ops reach soundly or refuse (identity was unsound)
 % evaluate() computes Sign/Abs/Exp/... and Constant/Transpose, but reach() was

--- a/code/nnv/tests/vnncomp25/test_vnncomp25_regression.m
+++ b/code/nnv/tests/vnncomp25/test_vnncomp25_regression.m
@@ -531,8 +531,8 @@ end
 assert(errored, 'Test 29 failed: DynamicMatmul reach must refuse without operand shapes');
 % with shapes: sound 2x2 @ 2x2 (column-major reshape), MC-contained
 rng(29); L29.LeftShape = [2 2]; L29.RightShape = [2 2];
-Aset = Star(randn(4,1)-0.5, randn(4,1)+0.5);  % ensure lb<ub
-al = min(Aset.V(:,1)-0.5, Aset.V(:,1)+0.5); Aset = Star(al, al+1);
+ac = randn(4,1);                  % single random center => lb<=ub guaranteed
+Aset = Star(ac - 0.5, ac + 0.5);  % box of radius 0.5
 Bset = Star(zeros(4,1), ones(4,1));
 S29 = L29.reach({Aset, Bset}, 'approx-star');
 assert(isa(S29,'Star') && S29.dim == 4, 'Test 29: sound reach shape');


### PR DESCRIPTION
## Summary

Adds the sound set-propagation math for **softmax self-attention** to NNV, wires it
into the transformer layers, and assembles an end-to-end sound verifier for the
**VNN-COMP 2023 Vision Transformer** benchmark — all on NNV `Star` sets. Branches
off the current `master` (`4561ede22`); merges with no conflicts; all existing
regression suites stay green.

Attention `softmax(scale·Q·Kᵀ)·V` has uncertainty on Q, K *and* V (a bilinear →
softmax → bilinear composition). Before this PR NNV could not bound it soundly:
`DynamicMatmulLayer.reach` errored, and `ScaledDotProductAttentionLayer` box-lifted
the inputs and failed loud on multi-token sequences. This PR closes that gap.

## What's new

**`engine/nn/funcs/SoftmaxAttn.m`** — the attention analogue of the `PosLin`/`LogSig`
func classes; the reusable, unit-tested sound math:

| method | bounds | soundness basis |
|---|---|---|
| `intervalMatMul` / `bilinearMatMulStar` | set@set `Q·Kᵀ`, `A·V` | Rump midpoint–radius interval matmul |
| `correlatedRowSoftmaxBounds` | `softmax(S)` over a logit box | **exact** per-element range (monotonicity corners) |
| `avEnvelopeStar` | symbolic `A·V` (V kept as a Star) | sign-aware McCormick; output affine in V's predicates |
| `prefixAdd` / `prefixConcat` | residual add / multi-head assembly | provenance-safe prefix alignment |
| `singleHeadAttn` / `selfAttentionReach` | one attention sublayer | composition of the above |

**Layer wiring**
- `DynamicMatmulLayer.reach` — sound interval matmul when operand shapes
  (`LeftShape`/`RightShape`) are set; refuses without them (sound-by-refusal, as before).
- `ScaledDotProductAttentionLayer.reach` — sound **multi-token** attention across all
  star-family methods (`approx-star`, `exact-star`, `abs-dom`, `relax-star*`,
  `approx-zono`); single-token stays exact (V-passthrough). Was box-lift + fail-loud.

**Example** `examples/Transformer/ViT_VNNCOMP2023/` — `ViTReach.m` (forward pass with
**parity to onnxruntime ≈ 1.8e-6**, sound reach, two BaB methods), `extract_weights.py`
(ONNX → `.mat`), sweep/diagnostic scripts, README + STATUS.

## Soundness & tests

Every primitive is validated by Monte-Carlo containment against the `linprog` LP
oracle (`soundness_test_utils.verify_star_containment`) across all sign regimes,
multi-head shapes, and the historically-unsound branches (V≤0/mixed `A·V`, the
structural-equality residual trap). **0 sample escapes anywhere.**

- New: `tests/nn/attention/` (26 tests).
- Updated regression locks (now assert the *sound* behaviour rather than the old
  fail-loud): `tests/soundness/test_transformer_soundness_regression.m` (Test 4),
  `tests/vnncomp25/test_vnncomp25_regression.m` (Test 29).
- **Still green:** 47 vnncomp25 + 17 transformer-soundness + 19 SDPA + 3 ViT-parity
  (112 tests, 0 failures).

## Results (honest)

Single-shot sound reach is fast (≈0.8 s pgd / 3 s ibp) and sound. At the full
benchmark ε = 1/255 it certifies **≈0/200** — *by construction*: the benchmark's
`generate_properties.py` keeps only images where PGD fails **and** vanilla CROWN
cannot certify, i.e. exactly the instances every *incomplete* (non-BaB) method must
fail on. The published sound SOTA (α,β-CROWN 79/200) comes **entirely** from
branch-and-bound over the attention nonlinearity.

What the sound reach *does* deliver positively: `ibp_3_3_8` margins approach 0 at full
ε (≈ −0.06 with LP on the closest instance) and it **certifies a real radius
ε\* ≈ 0.5–0.8/255** (half to 80% of the benchmark ε). `pgd_2_3_16` is hostile to
interval bounds (ε\* ≈ 0, margins ≈ −1000), matching auto_LiRPA IBP.

Two **sound** BaB methods are included (input-split and FF-ReLU phase-split, both
driven by the sound reach). An empirical full-ε BaB sweep on the 5 closest ibp
instances is 0/5: the binding looseness is the box-lifted softmax *weights* (upstream
of the FF ReLUs), so closing the gap needs a symbolic softmax-weight relaxation **and**
BaB over the attention nonlinearity. NNV's existing `gpu_bab` engine refuses attention
(op whitelist), so that path is documented as future work in `STATUS.md`.

## Notes for review

- The benchmark `.mat` bundles are gitignored; `extract_weights.py` regenerates them
  from the ONNX (needs python `onnx`/`onnxruntime`/`scipy`).
- No changes to any existing layer's reach semantics beyond `DynamicMatmulLayer` and
  `ScaledDotProductAttentionLayer`; the two regression-test edits only update locks
  that asserted the now-superseded fail-loud behaviour.
