### PR TITLE
netcache: reject substituted-double net on cache HIT (cifar100 Dot-indexing → sound re-import)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -2076,10 +2076,20 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             if contains(wmsg,'Default objects will be substituted') || contains(wmsg,'Unable to load instances of class')
                 error('netcache:degraded','custom-layer +package missing -> re-import (%s)', wmsg);
             end
+            % TYPE-VALIDITY guard (soundness): a silent dlnetwork.loadobj failure can substitute a plain
+            % `double` for C.net while the metadata (bytes/datenum/ver) still matches -> the HIT is accepted
+            % and a later dot-index throws "Dot indexing is not supported for variables of type double"
+            % (cifar100, 5 instances) -> unknown; worse, a partially-substituted net could reach and emit a
+            % CONFIDENT WRONG verdict. Reject any cache whose net is not a real network object (or whose NNV
+            % net is invalid) and fall through to a fresh re-import. Can only help: a valid cache has a
+            % non-numeric C.net + a valid C.nnvnet, so genuine HITs are unaffected.
+            cacheNetOK = isfield(C,'net') && ~isnumeric(C.net) ...
+                      && isfield(C,'nnvnet') && ~isnumeric(C.nnvnet) && is_nnvnet_valid(C.nnvnet);
             if isfield(C,'onnx_bytes') && isequal(C.onnx_bytes, d.bytes) ...
                     && abs(C.onnx_datenum - d.datenum) < 1e-9 ...
                     && isfield(C,'nnv_ver') && strcmp(C.nnv_ver, i_nnv_ver()) ...
-                    && isfield(C,'cfg_ver') && strcmp(C.cfg_ver, i_cfg_ver())   % invalidate on config change
+                    && isfield(C,'cfg_ver') && strcmp(C.cfg_ver, i_cfg_ver()) ...   % invalidate on config change
+                    && cacheNetOK                                                    % reject substituted-double / invalid net
                 net=C.net; nnvnet=C.nnvnet; needReshape=C.needReshape; reachOptionsList=C.reachOptionsList;
                 inputSize=C.inputSize; inputFormat=C.inputFormat; nRand=C.nRand; falsifyOpts=C.falsifyOpts;
                 fprintf('net cache HIT (%s)\n', p);

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -2080,11 +2080,15 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
             % `double` for C.net while the metadata (bytes/datenum/ver) still matches -> the HIT is accepted
             % and a later dot-index throws "Dot indexing is not supported for variables of type double"
             % (cifar100, 5 instances) -> unknown; worse, a partially-substituted net could reach and emit a
-            % CONFIDENT WRONG verdict. Reject any cache whose net is not a real network object (or whose NNV
-            % net is invalid) and fall through to a fresh re-import. Can only help: a valid cache has a
-            % non-numeric C.net + a valid C.nnvnet, so genuine HITs are unaffected.
-            cacheNetOK = isfield(C,'net') && ~isnumeric(C.net) ...
-                      && isfield(C,'nnvnet') && ~isnumeric(C.nnvnet) && is_nnvnet_valid(C.nnvnet);
+            % CONFIDENT WRONG verdict. Require both C.net and C.nnvnet to be REAL network OBJECTS (not a
+            % numeric/char/string/struct substitution) and fall through to a fresh re-import otherwise. We use
+            % `isobject(x) && ~isstring(x)` because a `double`/`char`/`struct`/`cell` substitution is not an
+            % object, and a `string` IS reported as an object by isobject so it needs the extra ~isstring
+            % (verified 2026-06-26). Can only help: a valid cache's net/nnvnet are class objects, so genuine
+            % HITs are unaffected.
+            isNetObj   = @(x) isobject(x) && ~isstring(x);
+            cacheNetOK = isfield(C,'net') && isNetObj(C.net) ...
+                      && isfield(C,'nnvnet') && isNetObj(C.nnvnet) && is_nnvnet_valid(C.nnvnet);
             if isfield(C,'onnx_bytes') && isequal(C.onnx_bytes, d.bytes) ...
                     && abs(C.onnx_datenum - d.datenum) < 1e-9 ...
                     && isfield(C,'nnv_ver') && strcmp(C.nnv_ver, i_nnv_ver()) ...


### PR DESCRIPTION
## What
A silent `dlnetwork.loadobj` failure can substitute a plain `double` for `C.net` while the cache metadata (bytes/datenum/ver) still matches → the cache HIT is accepted and a later dot-index throws **"Dot indexing is not supported for variables of type double"** (cifar100, 5 instances) → `unknown`. Worse, a *partially*-substituted net could reach and emit a **confident wrong verdict** — a latent −150 hole.

## Fix (soundness-positive)
Add a type-validity guard to the cache-HIT condition in `i_load_vnncomp_network_cached`:
```matlab
cacheNetOK = isfield(C,'net') && ~isnumeric(C.net) ...
          && isfield(C,'nnvnet') && ~isnumeric(C.nnvnet) && is_nnvnet_valid(C.nnvnet);
```
On failure → fall through to a fresh re-import (the existing miss path). The existing self-heal only caught the *warning*-based +package substitution; this also catches a silent `loadobj`→`double`.

## Why it can't regress
A valid cache has a real network `C.net` (non-numeric) and a valid `C.nnvnet` → `cacheNetOK = true`, HIT unchanged. Only a corrupt/substituted cache is rejected. **Unit-tested:** valid→1, `net=double`→0, `nnvnet=double`→0. Parses clean; guard sits inside the loader's existing try/catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)