### PR TITLE
acasxu import: normalize two-network tuple field (iso/mono) → import f net (sound/hygiene)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1406,8 +1406,9 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         ftok = regexp(char(onnx), '''f''\s*,\s*''([^'']+)''', 'tokens', 'once');
         if ~isempty(ftok)
             benchroot = fileparts(fileparts(char(vnnlib)));   % .../<ver>/vnnlib/x.vnnlib -> .../<ver>
-            onnx_f = fullfile(benchroot, ftok{1});
-            if ~isfile(onnx_f) && isfile(onnx_f + ".gz"), gunzip(onnx_f + ".gz"); end
+            onnx_f = char(fullfile(benchroot, ftok{1}));       % keep char; build .gz path by char concat
+            gzf = [onnx_f '.gz'];                              % (char concat -- avoids the char+string '+' pitfall)
+            if ~isfile(onnx_f) && isfile(gzf), gunzip(gzf); end
         end
         net = importNetworkFromONNX(onnx_f, "InputDataFormats","BCSS");
         nnvnet = matlab2nnv(net);

--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1394,7 +1394,22 @@ function [net,nnvnet,needReshape,reachOptionsList,inputSize,inputFormat,nRand,fa
         % times out on the hard props even multi-core, and approx-star (DeepZ-level) is too loose to
         % decide them. The approx-first + multi-core ladder below is SOUND and helps any approx-
         % decidable prop, but the CROWN-needing props need a tighter method (separate, deeper work).
-        net = importNetworkFromONNX(onnx, "InputDataFormats","BCSS");
+        %
+        % TWO-NETWORK NORMALIZATION (isomorphic/monotonic_acasxu 2026): their instances.csv onnx field is a
+        % python tuple-list string "[('f','onnx/..'),('g','onnx/..')]", which importNetworkFromONNX cannot
+        % open -> LOAD FAILED -> unknown (and, in the dev harness, a re-loop). We import the f net here
+        % (resolved against the benchmark root from the vnnlib path); the relational verification + the g net
+        % are handled by the property.multinet / verify_multinet branch in run_vnncomp_instance, behind the
+        % authoritative validate_witness_multinet ORT gate. monotonic (g equal-to f) reaches verify_multinet;
+        % isomorphic (g != f) is flagged property.unsupported -> unknown upstream. Sound either way.
+        onnx_f = onnx;
+        ftok = regexp(char(onnx), '''f''\s*,\s*''([^'']+)''', 'tokens', 'once');
+        if ~isempty(ftok)
+            benchroot = fileparts(fileparts(char(vnnlib)));   % .../<ver>/vnnlib/x.vnnlib -> .../<ver>
+            onnx_f = fullfile(benchroot, ftok{1});
+            if ~isfile(onnx_f) && isfile(onnx_f + ".gz"), gunzip(onnx_f + ".gz"); end
+        end
+        net = importNetworkFromONNX(onnx_f, "InputDataFormats","BCSS");
         nnvnet = matlab2nnv(net);
         % SOUND-FIRST ladder for ALL props: fast approx-star (tightest non-exact; ~1-2s on these
         % tiny 5->5 nets, settles the robust/UNSAT props) then MULTI-CORE exact-star as the complete


### PR DESCRIPTION
## What
`isomorphic_acasxu_2026` / `monotonic_acasxu_2026` encode their onnx as a python tuple string `[('f','onnx/..'),('g','onnx/..')]`. `importNetworkFromONNX` can't open that → **LOAD FAILED → unknown** (and a done.csv re-loop in the dev harness — the root of the 2026-06-26 ~3.2h stall). 

## Fix
In the acasxu import branch: detect the tuple, regexp-extract the `f`-net path, resolve it against the benchmark root (from the vnnlib path), gunzip if needed, import that. The relational verification + the `g` net are handled by the existing `property.multinet` / `verify_multinet` branch behind the **`validate_witness_multinet` ORT gate**. Monotonic (g equal-to f) reaches it; isomorphic (g≠f) stays `property.unsupported → unknown` upstream.

## Soundness / scope (honest)
This is a **soundness/hygiene** fix: it removes a crash + the dev-sweep re-loop and enables the *gated* multinet path. **No-op for normal `acasxu_2023`** (the regexp doesn't match a plain path). **Validated:** 8 monotonic instances → **0 LOAD FAILED** (was 8/8 crash), all run the multinet path. Verdicts stay witness-gated and came back `unknown` in the sample — so this PR does **not** itself add decided instances; the mono/iso decided-recovery remains a separate gated effort (careful keyed re-run + ground-truth, per the standing iso/mono note). Verdict soundness is unchanged (the existing witness gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)