### PR TITLE
relusplitter: raise FC GPU-BaB node budget 5000→50000 (node-limited argmax certs, +3 sound)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/run_vnncomp_instance.m
@@ -1222,6 +1222,15 @@ function [status, reachOptionsList] = i_gpu_bab_precheck(category, nnvnet, lb, u
             end
         else
             mn = 5000; if isConv, mn = 64; end                 % conv-without-GPU: bounded (slow but sound)
+            % Tier-1A node-budget raise (relusplitter): the FC ReLU-split BaB on these argmax nets is
+            % NODE-LIMITED, not bound-limited -- the default mn=5000 cap stops the search just before it
+            % certifies. Probe (2026-06-26): 2/15 relusplitter unknowns recover at 9.7k/47.7k nodes, in
+            % 8.7s/13.9s (~0.3-0.9ms/node, so 50k nodes ~= 15-45s, well within the 180s budget; the
+            % non-recoverable self-cap fast at the node limit). SOUND: CPU-double sound emit (no FP32
+            % trust); a 'robust' is an FP64-certified unsat, so this only ADDS sound certs (0 false-sat
+            % in the probe). Scoped to relusplitter -- short-budget FC cats (safenlp 20s) keep mn=5000.
+            if contains(category, "relusplitter"), mn = 50000; end
+            ev = str2double(getenv('NNV_FC_MAXNODES')); if isfinite(ev) && ev >= 1, mn = ev; end
             [gv, ginfo] = gpu_bab_try_verify(nnvnet, lb, ub, prop, struct('engine','batched','maxNodes',mn));
             if strcmp(gv, 'robust')
                 status = 1; reachOptionsList = {};


### PR DESCRIPTION
## What
The FC ReLU-split BaB (`gpu_bab_try_verify`) on relusplitter's **argmax** nets is **node-limited, not bound-limited** — the hardcoded `mn=5000` cap (run_vnncomp_instance.m l.1224) stopped the search just before it could certify. Raise it to **50000** for relusplitter (env-tunable via `NNV_FC_MAXNODES`), scoped so short-budget FC cats (safenlp 20s) keep `mn=5000`.

## Validation (all 61 relusplitter sweep-unknowns @ official 180s)
- **+3 recovered** (unknown→unsat), certs in **5.5–13.6s** (~0.3–0.9 ms/node → 50k nodes ≈ 15–45s, well within the 180s budget; the non-recoverable self-cap fast at the node limit).
- **10/10 regression-unsat preserved, 0 regressed, 0 false-sat.**
- **Sound:** CPU-double sound emit (no FP32 trust) — a `robust` verdict is an FP64-certified unsat, so this only *adds* sound certs. relusplitter **49% → 52%**.

## Context
This is the cheap, validated half ("Tier-1A") of the Phase-C α/β-CROWN work: ~13% of these argmax-FC unknowns were just node-budget-capped. The majority (the other ~87%) are *bound-limited* and need the deeper α/β-CROWN tightening rewrite. The bigger Tier-1A target — cifar100/tinyimagenet conv (same node-limited pattern, already env-tunable via `NNV_CONV_MAXNODES`) — is a separate probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)