### PR TITLE
GPU-BaB: IBP-prefilter (default-on) — recovers the cifar100 conv timeouts, fully soundly

### DIFF
--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -103,7 +103,11 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
     if doErr
         derr = zeros(nSpec, B, precision);     % sound bound on the FP32 backward roundoff (accumulated)
         dmag = zeros(nSpec, B, precision);     % running sum of |d-terms| (the cross-op d=d+... chain)
+        derr_flr = zeros(nSpec, B, precision); % P2 leaf decomp (NNV_DEBUG_DERR): non-reducible FLOOR (relu-slope + d-add chains + final)
+        derr_mm  = zeros(nSpec, B, precision); % P2 leaf decomp: the affine/conv matmul (A-path) a-priori term
+        derr_int = zeros(nSpec, B, precision); % P2 leaf decomp: the relu-intercept reduction term actually emitted (a-priori or measured-delta)
     end
+    doDbg = doErr && ~isempty(getenv('NNV_DEBUG_DERR'));
 
     if isempty(rootBounds)
         % ---- forward IBP (batched, FULL DAG), pre-activation bounds at each ReLU, with node
@@ -323,9 +327,12 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 W = cast(op.W, precision); bb = cast(op.b(:), precision);
                 if doErr   % A*W contracts over out-width = size(A,2); output value-mag (no cancel) = |W|*vin+|b|
                     omg = double(abs(W)) * double(vin) + double(abs(bb));            % out-width x 1
-                    derr = derr + i_dterm_sd(A, reshape(omg, [], 1, 1), size(A,2), nSpec, B);
+                    t_amm = i_dterm_sd(A, reshape(omg, [], 1, 1), size(A,2), nSpec, B);
+                    derr = derr + t_amm;
+                    if doDbg, derr_mm = derr_mm + t_amm; end
                     dmag = dmag + i_dterm_raw_sd(A, reshape(double(abs(bb)), [], 1, 1), nSpec, B);  % d=d+A*b chain
                     derr = derr + us * dmag;
+                    if doDbg, derr_flr = derr_flr + us * dmag; end
                 end
                 d = d + reshape(pagemtimes(A, bb), nSpec, B);
                 A = pagemtimes(A, W);
@@ -343,9 +350,11 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                     % derr stays ~halved while remaining a rigorous bound).
                     Amag = Amag .* (1 + 2*i_gamma_raw_sd(mC, precision));
                     dmc  = dmc  .* (1 + 2*i_gamma_raw_sd(nO, precision));
-                    derr = derr + i_dterm_sd(Amag, reshape(double(vin), [], 1, 1), mC, nSpec, B) ...
-                                + i_gamma_sd(nO, precision) * dmc;                    % bias reduction length
+                    t_cmm = i_dterm_sd(Amag, reshape(double(vin), [], 1, 1), mC, nSpec, B);
+                    derr = derr + t_cmm + i_gamma_sd(nO, precision) * dmc;            % conv matmul + bias reduction length
+                    if doDbg, derr_mm = derr_mm + t_cmm + i_gamma_sd(nO, precision) * dmc; end
                     dmag = dmag + dmc; derr = derr + us * dmag;                       % d=d+bias add-chain
+                    if doDbg, derr_flr = derr_flr + us * dmag; end
                 end
                 [A, d] = i_conv_backward(A, d, op, precision);
             case 'normaffine'
@@ -397,11 +406,14 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                         cush  = double(2)*i_gamma_sd(dim,'double') * reshape(pagemtimes(double(abs(Aneg)), reshape(double(abs(bu)), dim,1,B)), nSpec, B);
                         t_red = min(single(i_gamma_sd(dim,'double')) * Abu, single(delta + cush));  % MIN(a-priori, measured)
                         derr  = derr + t_slp + t_red + single(double(4)*double(us)) * Abu;          % reduction (tightened) + derivation (kept)
+                        if doDbg, derr_int = derr_int + t_red; derr_flr = derr_flr + t_slp + single(double(4)*double(us)) * Abu; end
                     else
                         derr = derr + t_slp ...
-                                    + single(i_gamma_sd(dim,'double') + double(4)*double(us)) * Abu;
+                                    + single(i_gamma_sd(dim,'double') + double(4)*double(us)) * Abu;   % a-priori (byte-identical)
+                        if doDbg, derr_int = derr_int + single(i_gamma_sd(dim,'double')) * Abu; derr_flr = derr_flr + t_slp + single(double(4)*double(us)) * Abu; end
                     end
                     dmag = dmag + Abu; derr = derr + us * dmag;        % d=d+Aneg*bu add-chain
+                    if doDbg, derr_flr = derr_flr + us * dmag; end
                 end
                 d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);
                 if wantScore
@@ -416,7 +428,9 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
         s = op.src;                                       % route coefficient to op.src
         if doErr && (s == 0 || ~isempty(skipA{s}))        % a MERGE (accumulating +) -> coeff add-chain rounding
             if s == 0, vm = double(vmag{1}); else, vm = double(vmag{s + 1}); end
-            derr = derr + i_dterm_sd(A, reshape(vm, [], 1, 1), nOps, nSpec, B);
+            t_merge = i_dterm_sd(A, reshape(vm, [], 1, 1), nOps, nSpec, B);
+            derr = derr + t_merge;
+            if doDbg, derr_mm = derr_mm + t_merge; end
         end
         if s == 0
             if isempty(inputSkipA), inputSkipA = A; else, inputSkipA = inputSkipA + A; end
@@ -440,15 +454,18 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
     if doErr   % widen the LOWER bound OUTWARD (down) by the final-contraction rad + the accumulated
                % per-op derr, so margins_single <= margins_double <= true (monotone-sound, can EMIT)
         rad  = i_outward_rad_sd(A, x_lb, x_ub, precision);
-        derr = derr + us * abs(d) + cast(3,precision)*us * (abs(aposx) + abs(anegx));  % '+d' u*|d| + the two final adds fl(fl(aposx+anegx)+d) ~2u*P (3*us*P w/ margin; reduced rad k no longer covers them) -- re-review CHECK 3, 2026-06-18
+        t_fin = us * abs(d) + cast(3,precision)*us * (abs(aposx) + abs(anegx));
+        derr = derr + t_fin;  % '+d' u*|d| + the two final adds fl(fl(aposx+anegx)+d) ~2u*P (3*us*P w/ margin; reduced rad k no longer covers them) -- re-review CHECK 3, 2026-06-18
         margins = margins - rad - derr;
-        if ~isempty(getenv('NNV_DEBUG_DERR'))             % M3b tightening diagnosis (no behaviour change)
+        if doDbg                                          % M3b tightening diagnosis (no behaviour change)
+            derr_flr = derr_flr + t_fin;
             mraw = margins + rad + derr;                  % the un-widened margin
             [mw, iw] = min(margins(:));                   % binding spec (widened)
-            fprintf('[derr] raw_min=%.6g widened_min=%.6g | binding: raw=%.6g rad=%.6g derr=%.6g\n', ...
-                gather(min(mraw(:))), gather(mw), gather(mraw(iw)), gather(rad(iw)), gather(derr(iw)));
-            vm = cellfun(@(v) max(abs(double(v(:)))), vmag);
-            fprintf('[derr] vmag(IBP) max-per-op: %s\n', mat2str(gather(vm(:))', 4));
+            db = double(derr(iw));
+            fprintf('[derr] raw_min=%.6g widened_min=%.6g | binding: raw=%.6g rad=%.6g derr=%.6g floor=%.6g matmul=%.6g intercept=%.6g (frac flr=%.3g mm=%.3g int=%.3g)\n', ...
+                gather(min(mraw(:))), gather(mw), gather(mraw(iw)), gather(rad(iw)), db, ...
+                gather(double(derr_flr(iw))), gather(double(derr_mm(iw))), gather(double(derr_int(iw))), ...
+                gather(double(derr_flr(iw))/max(1e-30,db)), gather(double(derr_mm(iw))/max(1e-30,db)), gather(double(derr_int(iw))/max(1e-30,db)));
         end
     end
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_spec_dag.m
@@ -98,6 +98,7 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
     % rootBounds for doErr; the emit path (cifar/tiny) always supplies them (rootTight).
     doErr = strcmp(precision, 'single') && ~isempty(vmag) && ~isempty(rootBounds);
     soundFP32 = doErr;
+    doRun = doErr && ~isempty(getenv('NNV_DERR_RUNNING'));   % P2: measured-delta (running-error) on the relu-intercept reduction -- MUST match gpu_bab_crown_tight
     us = single(eps('single') / 2);            % single unit roundoff (the d=d+... add-chain rounds here)
     if doErr
         derr = zeros(nSpec, B, precision);     % sound bound on the FP32 backward roundoff (accumulated)
@@ -384,8 +385,22 @@ function [margins, preL, preU, scoreCell, soundFP32] = gpu_bab_crown_spec_dag(op
                 if doErr   % slope mult (|A_in|<=|A|, no cancel) + the bu intercept (PER-NODE dim x B, R1a)
                            % |A| covers the d-pass; +4u for the au=u/(u-l)/bu=-au*l derivation rounding
                     Abu  = i_dterm_raw_sd(A, reshape(double(abs(bu)), dim, 1, B), nSpec, B);   % |A|*|bu| (nSpec x B)
-                    derr = derr + i_dterm_sd(A, reshape(double(vin), dim, 1, 1), 8, nSpec, B) ...    % m=8: slope multiply (~u) + the relu RELAXATION-DERIVATION rounding (~3u*vin at z=u; scales with vin, NOT bu) -- review 2026-06-18
-                                + single(i_gamma_sd(dim,'double') + double(4)*double(us)) * Abu;
+                    t_slp = i_dterm_sd(A, reshape(double(vin), dim, 1, 1), 8, nSpec, B);       % m=8 slope+derivation (floor, kept)
+                    if doRun   % P2 RUNNING-ERROR: replace gamma_dim WORST-CASE reduction roundoff with the MEASURED roundoff
+                        % of the actual d-add d=d+pagemtimes(Aneg,bu) (line below) + a sound fl64-residual cushion.
+                        % min(a-priori,measured) is sound (both over-bound |fl32(Aneg*bu)-exact|); the +4u DERIVATION
+                        % term (kept) covers the au/bu single-construction error. MUST match gpu_bab_crown_tight.
+                        bur   = reshape(bu, dim, 1, B);
+                        p32   = reshape(pagemtimes(Aneg, bur), nSpec, B);                          % FP32 reduction (== the d-add)
+                        p64   = reshape(pagemtimes(double(Aneg), double(bur)), nSpec, B);          % FP64 reference
+                        delta = abs(double(p32) - p64);                                            % measured roundoff (nSpec x B)
+                        cush  = double(2)*i_gamma_sd(dim,'double') * reshape(pagemtimes(double(abs(Aneg)), reshape(double(abs(bu)), dim,1,B)), nSpec, B);
+                        t_red = min(single(i_gamma_sd(dim,'double')) * Abu, single(delta + cush));  % MIN(a-priori, measured)
+                        derr  = derr + t_slp + t_red + single(double(4)*double(us)) * Abu;          % reduction (tightened) + derivation (kept)
+                    else
+                        derr = derr + t_slp ...
+                                    + single(i_gamma_sd(dim,'double') + double(4)*double(us)) * Abu;
+                    end
                     dmag = dmag + Abu; derr = derr + us * dmag;        % d=d+Aneg*bu add-chain
                 end
                 d = d + reshape(pagemtimes(Aneg, reshape(bu, dim, 1, B)), nSpec, B);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -156,6 +156,29 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
         end
     end
 
+    % M1 (P2.0 measurement, read-only, env-gated default-off): decompose the derr looseness -- log per op the
+    % IBP value-magnitude majorant `vmag` (what derr contracts against) vs the tighter crown_tight bound
+    % magnitude (what Approach A would use). The ratio is Approach A's ceiling. NO behavior change when unset.
+    if ~isempty(getenv('NNV_LOG_VMAG'))
+        try
+            fid = fopen(getenv('NNV_LOG_VMAG'), 'a');
+            if fid > 0
+                for kk = 1:nOps
+                    vm = NaN; cb = NaN;
+                    if ~isempty(vmag) && numel(vmag) >= kk && ~isempty(vmag{kk})
+                        vm = max(abs(double(gather(vmag{kk}(:)))));
+                    end
+                    if numel(preL) >= kk && ~isempty(preL{kk})
+                        cb = max([max(abs(double(gather(preL{kk}(:))))); max(abs(double(gather(preU{kk}(:)))))]);
+                    end
+                    fprintf(fid, 'VMAG op=%d type=%s vmag=%.6g crown=%.6g ratio=%.6g\n', kk, ops{kk}.type, vm, cb, vm/cb);
+                end
+                fprintf(fid, 'VMAG --- end-of-call (nOps=%d) ---\n', nOps);
+                fclose(fid);
+            end
+        catch, end
+    end
+
     % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
     [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true, vmag);
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -411,7 +411,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     derr_mm = zeros(nS, 1, precision);              % P2 step-0 decomp (env NNV_DERR_DECOMP, read-only): the matmul-reduction subset of derr
     derr_flr = zeros(nS, 1, precision);             % P2 step-0 decomp: the NON-reducible FLOOR (measured-delta can't shrink it): relu-slope i_dt(A,vin,8) + d-add chains us*dmag + relu-4u + final adds
     derr_slp = zeros(nS, 1, precision);             % P2 step-0 decomp: the relu-slope i_dt(A,vin,8) term alone (advisor-flagged: gamma_8 small but x a full |A|*vin reduction)
+    derr_runi = zeros(nS, 1, precision);            % P2 RUNNING-ERROR: the measured-delta relu-intercept term actually used (min(a-priori,measured)) -> the build's emitted widening
     doDecomp = ~isempty(getenv('NNV_DERR_DECOMP'));
+    doRun = strcmp(precision, 'single') && ~isempty(getenv('NNV_DERR_RUNNING'));   % P2: measured-delta (running-error) on the d-path intercept reductions
     dmag = zeros(nS, 1, precision);                 % running sum of |d-terms|: the cross-op d add-chain
     us   = single(eps('single') / 2);               % rounding (each d=d+t injects u*|partial sum| <= u*dmag)
     if upto == 0                              % A0 is already on the engine input (op 0)
@@ -552,11 +554,30 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % slope mults (|A_in|<=|A|, no cancel) + the bu intercept; |A| (not |Aneg|) so it
                        % covers BOTH passes (lower: d+=Aneg*bu, upper: d+=Apos*bu) -- review #2; +4u for
                        % the au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
+                if doRun   % P2 RUNNING-ERROR: replace the gamma_width WORST-CASE reduction roundoff with the MEASURED roundoff
+                    % of the actual d-add d=d+Ab*bu (line 531/534) + a sound fl64-residual cushion. min(a-priori,measured)
+                    % is sound (both are valid over-bounds on |fl32(Ab*bu)-exact|). The +4u DERIVATION term (au/bu single
+                    % construction error, scales with vin not the reduction) is KEPT -- measured-delta only covers the reduction.
+                    t_red_ap = single(i_gamma(numel(bu), 'double') * (double(abs(A)) * double(abs(bu))));   % a-priori reduction roundoff
+                    t_drv    = single(double(4)*double(us) * (double(abs(A)) * double(abs(bu))));            % derivation roundoff (kept)
+                    if lower, Ab = Aneg; else, Ab = Apos; end                                               % the ACTUAL d-add coefficient
+                    p64   = double(Ab) * double(bu);                                                        % FP64 reference of the reduction
+                    delta = abs(double(Ab * bu) - p64);                                                     % |fl32 - fl64| = measured roundoff (nS x 1)
+                    cush  = double(2) * i_gamma(numel(bu), 'double') * (double(abs(Ab)) * double(abs(bu))); % bounds |fl64-exact| + the single() cast
+                    t_red = min(t_red_ap, single(delta + cush));                                            % MIN(a-priori, measured): sound + never worse
+                    derr  = derr + i_dt(A, vin, 8) + t_red + t_drv;
+                    derr_runi = derr_runi + t_red;
+                    if doDecomp
+                        t_slp = i_dt(A, vin, 8); derr_slp = derr_slp + t_slp;
+                        derr_flr = derr_flr + t_slp + t_drv;
+                    end
+                else
                 derr = derr + i_dt(A, vin, 8) ...    % m=8: slope multiply (~u) + the relu RELAXATION-DERIVATION rounding (au=u/(u-l),bu=-au*l in single dips the relaxed line below relu by ~3u*vin at z=u; this scales with vin, NOT bu, so the +4u*|bu| term below does NOT cover it when u>>|l| -> bu->0). adversarial review 2026-06-18.
                             + single((i_gamma(numel(bu), 'double') + double(4)*double(us)) * (double(abs(A)) * double(abs(bu))));
                 if doDecomp   % read-only floor decomp: relu-slope (floor) + the 4u relaxation-derivation slack (floor); the gamma_width*|A|*|bu| part is REDUCIBLE so excluded from floor
                     t_slp = i_dt(A, vin, 8); derr_slp = derr_slp + t_slp;
                     derr_flr = derr_flr + t_slp + single(double(4)*double(us) * (double(abs(A)) * double(abs(bu))));
+                end
                 end
                 dmag = dmag + i_draw(A, abs(bu)); derr = derr + us * dmag;        % d=d+(Aneg|Apos)*bu add-chain
                 if doDecomp, derr_flr = derr_flr + us * dmag; end                 % d-add chain (floor)
@@ -618,13 +639,15 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 if lower, bnd_b = double(bound); else, bnd_b = -double(bound); end   % violation side: smaller = closer
                 [wmarg_b, ib] = min(bnd_b);
                 flr_b = double(derr_flr(ib)); derr_b = double(derr(ib)); rad_b = double(radv(ib));
+                mat_b = double(derr_mm(ib)); runi_b = double(derr_runi(ib));         % bind_matmul (sets 2/5 vs 4/5) + the running-error intercept actually emitted
                 rawmarg_b = wmarg_b + rad_b + derr_b;                                % raw (pre-widening) margin at the binding spec
                 fprintf(fid_d, ['DECOMP nS=%d widening=%.6g rad=%.6g derr=%.6g floor=%.6g relu_slope=%.6g matmul=%.6g ' ...
                     'floor_frac=%.4g reducible_frac=%.4g matmul_frac=%.4g rad_frac_of_widening=%.4g ' ...
-                    'bind_rawmargin=%.6g bind_widened=%.6g bind_floor=%.6g bind_derr=%.6g bind_floor_frac=%.4g\n'], ...
+                    'bind_rawmargin=%.6g bind_widened=%.6g bind_floor=%.6g bind_derr=%.6g bind_floor_frac=%.4g ' ...
+                    'bind_matmul=%.6g bind_runintercept=%.6g\n'], ...
                     nS, drad+dtot, drad, dtot, dflr, dslp, dmm, dflr/max(1e-30,dtot), (dtot-dflr)/max(1e-30,dtot), ...
                     dmm/max(1e-30,dtot), drad/max(1e-30,drad+dtot), ...
-                    rawmarg_b, wmarg_b, flr_b, derr_b, flr_b/max(1e-30,derr_b));
+                    rawmarg_b, wmarg_b, flr_b, derr_b, flr_b/max(1e-30,derr_b), mat_b, runi_b);
                 fclose(fid_d);
             end
         end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -57,7 +57,7 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             vmag = {}; ibpLd = {}; ibpUd = {};
         end
     end
-    if isempty(ibpLd) && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER'))
+    if isempty(ibpLd) && ~strcmp(getenv('NNV_CROWN_IBP_PREFILTER'), '0')   % DEFAULT-ON (opt out with =0)
         % The PREFILTER also wants the sound DOUBLE IBP on the NON-sound paths -- the unsound single GPU SCREEN
         % and the FP64 confirm -- which are the actual cifar100 bottleneck (the screen times out in the wide-conv
         % chunked CROWN before the confirm even runs). The double IBP forward is value-vectors only (cheap, cannot
@@ -129,11 +129,13 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 % NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
                 % src==0 here is the sound-FP32 input-fed case routed off the fast cast above (widened).
                 if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
-                % IBP-PREFILTER (verdict-identical, sound-path only): a relu neuron the SOUND DOUBLE IBP proves
-                % stable (ibpLo>=0 or ibpHi<=0) has an EXACT relaxation (slope 1/0), so the downstream backward
-                % uses that exact slope regardless of [pl,pu] tightness -> skip its CROWN backward, fill from IBP.
+                % IBP-PREFILTER (DEFAULT-ON, opt out NNV_CROWN_IBP_PREFILTER=0): a relu neuron the SOUND DOUBLE IBP
+                % proves stable (ibpLo>=0 or ibpHi<=0) has an EXACT relaxation (slope 1/0), so the downstream backward
+                % uses that exact slope regardless of [pl,pu] tightness -> skip its CROWN backward, fill from IBP. On
+                % the DOUBLE FP64-confirm path this is bit-identical (faster, not different); 75/75 soundness suite +
+                % 5/5 thin-margin recoveries certified (idx_496/4385/5308/4757/8589 UNSAT in 120-194s) vs timeout off.
                 ibpLo = []; ibpHi = [];
-                if strcmp(tk,'relu') && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER'))
+                if strcmp(tk,'relu') && ~strcmp(getenv('NNV_CROWN_IBP_PREFILTER'), '0')
                     if ~isempty(ibpLd) && numel(ibpLd) >= src+1 && ~isempty(ibpLd{src+1})
                         ibpLo = ibpLd{src+1}; ibpHi = ibpUd{src+1};            % SOUND single-emit path (sound DOUBLE IBP from line 54)
                     elseif strcmp(precision,'double') && ~isempty(ibpL) && numel(ibpL) >= src+1 && ~isempty(ibpL{src+1})

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -229,6 +229,18 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
             Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
             pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
             pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+            if strcmp(precision,'single') && ~isempty(getenv('NNV_DERR_ACTUAL'))
+                % P2 (advisor): the NET |fl32-fl64| roundoff of THIS interm-bound chunk (same call the DECOMP logs as
+                % nS=nb). Compare to the per-op measured-delta derr at matched depth -> is the ~500x cancellation gap real?
+                pld = i_backward(ops, src, double(Ck), x_lb, x_ub, preL, preU, 'double', true, {});
+                act = abs(double(gather(pl(rows))) - double(gather(pld(:))));
+                as = sort(act); medi = as(max(1, round(0.5*numel(as))));
+                fid_a = fopen(getenv('NNV_DERR_ACTUAL'), 'a');
+                if fid_a > 0
+                    fprintf(fid_a, 'INTERM src=%d nk=%d nb=%d max_net=%.6g median_net=%.6g\n', src, nk, nb, max(act), medi);
+                    fclose(fid_a);
+                end
+            end
             s0 = s0 + B;
         catch ME
             % AUTO-CHUNK: a memory budget B chosen too large for the live device/host still OOMs. B

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -388,6 +388,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     d = zeros(nS, 1, precision);
     doErr = strcmp(precision, 'single') && ~isempty(vmag);
     derr = zeros(nS, 1, precision);
+    derr_mm = zeros(nS, 1, precision);              % P2 step-0 decomp (env NNV_DERR_DECOMP, read-only): the matmul-reduction subset of derr
+    doDecomp = ~isempty(getenv('NNV_DERR_DECOMP'));
     dmag = zeros(nS, 1, precision);                 % running sum of |d-terms|: the cross-op d add-chain
     us   = single(eps('single') / 2);               % rounding (each d=d+t injects u*|partial sum| <= u*dmag)
     if upto == 0                              % A0 is already on the engine input (op 0)
@@ -475,7 +477,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             W = cast(op.W, precision); b = cast(op.b(:), precision);
             if doErr   % A*W contracts over out-width; output value-mag majorant (no cancel) = |W|*vin+|b|
                 omg = double(abs(W)) * double(vin) + double(abs(b));              % DOUBLE-computed magnitude majorant
-                derr = derr + i_dt(A, omg, size(A,2));
+                t_mm = i_dt(A, omg, size(A,2)); derr = derr + t_mm; if doDecomp, derr_mm = derr_mm + t_mm; end
                 dmag = dmag + i_draw(A, abs(b)); derr = derr + us * dmag;          % d=d+A*b add-chain
             end
             d = d + A * b;
@@ -490,8 +492,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 % true single rounding even for large outShape (mirrors gpu_bab_crown_spec_dag conv fix).
                 Amag = Amag .* (1 + 2*i_gamma_raw_ct(mC, precision));
                 dmc  = dmc  .* (1 + 2*i_gamma_raw_ct(nO, precision));
-                derr = derr + i_dt(Amag, vin, mC) ...
+                t_mm = i_dt(Amag, vin, mC); derr = derr + t_mm ...
                             + single(i_gamma(nO, 'double') * double(dmc));          % bias reduction length (review #5)
+                if doDecomp, derr_mm = derr_mm + t_mm; end
                 dmag = dmag + dmc; derr = derr + us * dmag;                         % d=d+bias add-chain
             end
             [A, d] = i_conv_backward(A, d, op, precision);
@@ -563,6 +566,15 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
         else
             derr = derr + cast(3,precision)*us * (abs(Apos * cast(x_ub, precision)) + abs(Aneg * cast(x_lb, precision)));
             bound = bound + rad + derr;
+        end
+        if doDecomp                                          % P2 step-0: log the matmul-reduction fraction of the final derr
+            fid_d = fopen(getenv('NNV_DERR_DECOMP'), 'a');
+            if fid_d > 0
+                dtot = max(double(derr)); dmm = max(double(derr_mm)); drad = max(double(rad));
+                fprintf(fid_d, 'DECOMP nS=%d widening=%.6g rad=%.6g derr=%.6g derr_matmul=%.6g matmul_frac_of_derr=%.4g rad_frac_of_widening=%.4g\n', ...
+                    nS, drad+dtot, drad, dtot, dmm, dmm/max(1e-30,dtot), drad/max(1e-30,drad+dtot));
+                fclose(fid_d);
+            end
         end
     end
 end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -121,9 +121,12 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 % stable (ibpLo>=0 or ibpHi<=0) has an EXACT relaxation (slope 1/0), so the downstream backward
                 % uses that exact slope regardless of [pl,pu] tightness -> skip its CROWN backward, fill from IBP.
                 ibpLo = []; ibpHi = [];
-                if strcmp(tk,'relu') && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER')) ...
-                        && ~isempty(ibpLd) && numel(ibpLd) >= src+1 && ~isempty(ibpLd{src+1})
-                    ibpLo = ibpLd{src+1}; ibpHi = ibpUd{src+1};
+                if strcmp(tk,'relu') && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER'))
+                    if ~isempty(ibpLd) && numel(ibpLd) >= src+1 && ~isempty(ibpLd{src+1})
+                        ibpLo = ibpLd{src+1}; ibpHi = ibpUd{src+1};            % SOUND single-emit path (sound DOUBLE IBP from line 54)
+                    elseif strcmp(precision,'double') && ~isempty(ibpL) && numel(ibpL) >= src+1 && ~isempty(ibpL{src+1})
+                        ibpLo = ibpL{src+1}; ibpHi = ibpU{src+1};             % FP64-CONFIRM path (line 75 IBP is double here = sound; no widening -> VERDICT-IDENTICAL) -- the broad cifar100 win
+                    end
                 end
                 if doProf, tL_ = tic; end
                 [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag, ibpLo, ibpHi);

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -84,7 +84,7 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
     doProf = ~isempty(getenv('NNV_CROWN_PROF'));     % perf profile (read-only): where the sound root spends time
     if doProf
         global G_CROWN_PROF; %#ok<TLEV>
-        G_CROWN_PROF = struct('up', 0, 'lo', 0, 'oom', 0);
+        G_CROWN_PROF = struct('oom', 0, 'nb', 0);
         gpL = zeros(nOps, 1); gpW = zeros(nOps, 1); gpT0 = tic;
     end
     for k = 1:nOps
@@ -165,9 +165,9 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
     end
     if doProf
         tot = toc(gpT0); [~, ord] = sort(gpL, 'descend');
-        fprintf('[crown-prof] interm-pass=%.1fs upper-bwd=%.1fs lower-bwd=%.1fs oom-halvings=%d | top layers: ', ...
-            tot, G_CROWN_PROF.up, G_CROWN_PROF.lo, G_CROWN_PROF.oom);
-        for ii = 1:min(8, nOps), j = ord(ii); if gpL(j) > 0.05, fprintf('op%d(%s,w%d)=%.1fs ', j, ops{j}.type, gpW(j), gpL(j)); end; end
+        fprintf('[crown-prof] interm-pass=%.1fs chunked-passes=%d oom-halvings=%d | top layers: ', ...
+            tot, G_CROWN_PROF.nb, G_CROWN_PROF.oom);
+        for ii = 1:min(10, nOps), j = ord(ii); if gpL(j) > 0.05, fprintf('op%d(%s,w%d)=%.1fs ', j, ops{j}.type, gpW(j), gpL(j)); end; end
         fprintf('\n');
     end
 
@@ -244,11 +244,9 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
             i_maybe_inject_oom(B, oomTest);
             Ck = zeros(nb, nk, precision);
             Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
-            if doP, tu_ = tic; end
+            if doP, G_CROWN_PROF.nb = G_CROWN_PROF.nb + 1; end   % count chunked backward passes (per-chunk sync was too heavy)
             pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
-            if doP, if isa(pu,'gpuArray'), wait(gpuDevice); end; G_CROWN_PROF.up = G_CROWN_PROF.up + toc(tu_); tl_ = tic; end
             pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
-            if doP, if isa(pl,'gpuArray'), wait(gpuDevice); end; G_CROWN_PROF.lo = G_CROWN_PROF.lo + toc(tl_); end
             if strcmp(precision,'single') && ~isempty(getenv('NNV_DERR_ACTUAL'))
                 % P2 (advisor): the NET |fl32-fl64| roundoff of THIS interm-bound chunk (same call the DECOMP logs as
                 % nS=nb). Compare to the per-op measured-delta derr at matched depth -> is the ~500x cancellation gap real?

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -181,6 +181,26 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
 
     % ---- final spec margin (lower bound on C*output) + the input-space lower plane ----
     [margins, Ain, din] = i_backward(ops, nOps, cast(C, precision), x_lb, x_ub, preL, preU, precision, true, vmag);
+    if strcmp(precision, 'single') && ~isempty(getenv('NNV_DERR_ACTUAL'))
+        % P2 gate (read-only): the ACTUAL accumulated FP32 roundoff of this spec backward = |single - double|.
+        % Recompute the IDENTICAL backward in double (vmag={} -> pure FP64, derr=0), sharing preL/preU so it
+        % isolates the backward arithmetic roundoff. This is the achievable measured-delta widening WITH
+        % cancellation = the lower bound on what the running-error build emits. floor + actual_residual < margin
+        % is the real go/no-go (advisor); the a-priori reducible_frac only said the slack EXISTS, not that it vanishes.
+        try
+            m_d = i_backward(ops, nOps, cast(C, 'double'), x_lb, x_ub, preL, preU, 'double', true, {});
+            act = abs(double(gather(margins(:))) - double(gather(m_d(:))));
+            ms  = double(gather(margins(:)));
+            [wm, ib] = min(ms);                                 % binding spec = smallest single margin
+            acts = sort(act); medi = acts(max(1, round(0.5*numel(acts))));
+            fid_a = fopen(getenv('NNV_DERR_ACTUAL'), 'a');
+            if fid_a > 0
+                fprintf(fid_a, 'ACTUAL nS=%d max_actual=%.6g median_actual=%.6g bind_single=%.6g bind_double=%.6g bind_actual=%.6g\n', ...
+                    numel(ms), max(act), medi, wm, double(gather(m_d(ib))), act(ib));
+                fclose(fid_a);
+            end
+        catch, end
+    end
 end
 
 function tf = i_box_exact(boxExact, idx)

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -389,6 +389,8 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     doErr = strcmp(precision, 'single') && ~isempty(vmag);
     derr = zeros(nS, 1, precision);
     derr_mm = zeros(nS, 1, precision);              % P2 step-0 decomp (env NNV_DERR_DECOMP, read-only): the matmul-reduction subset of derr
+    derr_flr = zeros(nS, 1, precision);             % P2 step-0 decomp: the NON-reducible FLOOR (measured-delta can't shrink it): relu-slope i_dt(A,vin,8) + d-add chains us*dmag + relu-4u + final adds
+    derr_slp = zeros(nS, 1, precision);             % P2 step-0 decomp: the relu-slope i_dt(A,vin,8) term alone (advisor-flagged: gamma_8 small but x a full |A|*vin reduction)
     doDecomp = ~isempty(getenv('NNV_DERR_DECOMP'));
     dmag = zeros(nS, 1, precision);                 % running sum of |d-terms|: the cross-op d add-chain
     us   = single(eps('single') / 2);               % rounding (each d=d+t injects u*|partial sum| <= u*dmag)
@@ -448,7 +450,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 ccl = double(abs(cL)) + double(abs(cU));
                 derr = derr + i_dt(A, vab + vab, 2) ...
                             + i_dt(A, ccl, wa);
+                if doDecomp, derr_flr = derr_flr + i_dt(A, vab + vab, 2); end       % product McCormick slope (floor, m=2); i_dt(A,ccl,wa) intercept is REDUCIBLE
                 dmag = dmag + i_draw(A, ccl); derr = derr + us * dmag;
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                   % d-add chain (floor)
             end
             if lower
                 Ax = Apos .* aL.' + Aneg .* aU.';
@@ -479,6 +483,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 omg = double(abs(W)) * double(vin) + double(abs(b));              % DOUBLE-computed magnitude majorant
                 t_mm = i_dt(A, omg, size(A,2)); derr = derr + t_mm; if doDecomp, derr_mm = derr_mm + t_mm; end
                 dmag = dmag + i_draw(A, abs(b)); derr = derr + us * dmag;          % d=d+A*b add-chain
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                  % d-add chain (floor)
             end
             d = d + A * b;
             A = A * W;
@@ -496,6 +501,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                             + single(i_gamma(nO, 'double') * double(dmc));          % bias reduction length (review #5)
                 if doDecomp, derr_mm = derr_mm + t_mm; end
                 dmag = dmag + dmc; derr = derr + us * dmag;                         % d=d+bias add-chain
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                   % d-add chain (floor)
             end
             [A, d] = i_conv_backward(A, d, op, precision);
         elseif strcmp(op.type, 'normaffine')
@@ -504,7 +510,9 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                 tfm = i_bcast_flat(abs(op.shift), op.shape, precision);            % |shift| flat
                 derr = derr + i_dt(A, double(sfm) .* double(vin), 2) ...           % (|A|.*sf')*vin == |A|*(sf.*vin)
                             + i_dt(A, tfm, numel(tfm));                            % the missing intercept term
+                if doDecomp, derr_flr = derr_flr + i_dt(A, double(sfm) .* double(vin), 2); end  % slope-scale (floor, m=2); intercept i_dt(A,tfm,.) is REDUCIBLE
                 dmag = dmag + i_draw(A, tfm); derr = derr + us * dmag;             % d=d+A*tf add-chain
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                  % d-add chain (floor)
             end
             [A, d] = i_normaffine_backward(A, d, op, precision);
         elseif strcmp(op.type, 'avgpool')
@@ -515,6 +523,7 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
             if doErr   % selection exact (0/1); conservative term for the umax relaxation intercept + its d-add
                 derr = derr + i_dt(A, vin + vmag{k + 1}, 2*prod(op.pool));
                 dmag = dmag + i_draw(A, vmag{k + 1}); derr = derr + us * dmag;
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                   % d-add chain (floor); i_dt intercept term is REDUCIBLE
             end
         else                                  % relu relaxation (sign-aware), preL/preU{k}
             l = preL{k}; u = preU{k};
@@ -525,7 +534,12 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
                        % the au=u/(u-l)/bu=-au*l derivation rounding (review #11), independent of width
                 derr = derr + i_dt(A, vin, 8) ...    % m=8: slope multiply (~u) + the relu RELAXATION-DERIVATION rounding (au=u/(u-l),bu=-au*l in single dips the relaxed line below relu by ~3u*vin at z=u; this scales with vin, NOT bu, so the +4u*|bu| term below does NOT cover it when u>>|l| -> bu->0). adversarial review 2026-06-18.
                             + single((i_gamma(numel(bu), 'double') + double(4)*double(us)) * (double(abs(A)) * double(abs(bu))));
+                if doDecomp   % read-only floor decomp: relu-slope (floor) + the 4u relaxation-derivation slack (floor); the gamma_width*|A|*|bu| part is REDUCIBLE so excluded from floor
+                    t_slp = i_dt(A, vin, 8); derr_slp = derr_slp + t_slp;
+                    derr_flr = derr_flr + t_slp + single(double(4)*double(us) * (double(abs(A)) * double(abs(bu))));
+                end
                 dmag = dmag + i_draw(A, abs(bu)); derr = derr + us * dmag;        % d=d+(Aneg|Apos)*bu add-chain
+                if doDecomp, derr_flr = derr_flr + us * dmag; end                 % d-add chain (floor)
             end
             if lower
                 d = d + Aneg * bu;
@@ -556,23 +570,41 @@ function [bound, Ain, din] = i_backward(ops, upto, A0, x_lb, x_ub, preL, preU, p
     if doErr                                                 % sound-FP32 opt-in (else no widening -> screen unchanged)
         rad  = i_outward_rad(A, x_lb, x_ub, precision);      % final-contraction roundoff (M2)
         derr = derr + us * abs(d);                           % the '+ d' add's u*|d| roundoff (review #6)
+        if doDecomp, derr_flr = derr_flr + us * abs(d); end  % final d-add roundoff (floor)
         % + the two final non-contraction adds margins=fl(fl(aposx+anegx)+d): each rounds by <= u*P
         % (P=|aposx|+|anegx|), so ~2u*P total; the reduced (1+2^-7) rad k no longer leaves slack for them
         % (esp. small input dim n<~1024: MNIST/ACAS/control). 3*us*P covers both adds w/ margin (>= the
         % true |a| <= P, no cancellation). adversarial review 2026-06-18 (re-review CHECK 3).
         if lower
-            derr = derr + cast(3,precision)*us * (abs(Apos * cast(x_lb, precision)) + abs(Aneg * cast(x_ub, precision)));
+            t_ia = cast(3,precision)*us * (abs(Apos * cast(x_lb, precision)) + abs(Aneg * cast(x_ub, precision)));
+            derr = derr + t_ia;
             bound = bound - rad - derr;
         else
-            derr = derr + cast(3,precision)*us * (abs(Apos * cast(x_ub, precision)) + abs(Aneg * cast(x_lb, precision)));
+            t_ia = cast(3,precision)*us * (abs(Apos * cast(x_ub, precision)) + abs(Aneg * cast(x_lb, precision)));
+            derr = derr + t_ia;
             bound = bound + rad + derr;
         end
-        if doDecomp                                          % P2 step-0: log the matmul-reduction fraction of the final derr
+        if doDecomp
+            derr_flr = derr_flr + t_ia;                      % final input-add roundoff (floor)
+        end
+        if doDecomp   % P2 step-0 (reducible-vs-floor): the FLOOR (measured-delta CANNOT shrink) is the go/no-go vs the intrinsic margins {1.4e-4,.0082,.0108,.0412,.0423}
             fid_d = fopen(getenv('NNV_DERR_DECOMP'), 'a');
             if fid_d > 0
                 dtot = max(double(derr)); dmm = max(double(derr_mm)); drad = max(double(rad));
-                fprintf(fid_d, 'DECOMP nS=%d widening=%.6g rad=%.6g derr=%.6g derr_matmul=%.6g matmul_frac_of_derr=%.4g rad_frac_of_widening=%.4g\n', ...
-                    nS, drad+dtot, drad, dtot, dmm, dmm/max(1e-30,dtot), drad/max(1e-30,drad+dtot));
+                dflr = max(double(derr_flr)); dslp = max(double(derr_slp));
+                % BINDING spec = argmin of the widened bound (the spec closest to violation = sets the verdict).
+                % Its floor vs its raw margin is the exact go/no-go; the max over all specs over-states the floor.
+                radv = rad; if isscalar(radv), radv = radv*ones(nS,1,precision); end
+                if lower, bnd_b = double(bound); else, bnd_b = -double(bound); end   % violation side: smaller = closer
+                [wmarg_b, ib] = min(bnd_b);
+                flr_b = double(derr_flr(ib)); derr_b = double(derr(ib)); rad_b = double(radv(ib));
+                rawmarg_b = wmarg_b + rad_b + derr_b;                                % raw (pre-widening) margin at the binding spec
+                fprintf(fid_d, ['DECOMP nS=%d widening=%.6g rad=%.6g derr=%.6g floor=%.6g relu_slope=%.6g matmul=%.6g ' ...
+                    'floor_frac=%.4g reducible_frac=%.4g matmul_frac=%.4g rad_frac_of_widening=%.4g ' ...
+                    'bind_rawmargin=%.6g bind_widened=%.6g bind_floor=%.6g bind_derr=%.6g bind_floor_frac=%.4g\n'], ...
+                    nS, drad+dtot, drad, dtot, dflr, dslp, dmm, dflr/max(1e-30,dtot), (dtot-dflr)/max(1e-30,dtot), ...
+                    dmm/max(1e-30,dtot), drad/max(1e-30,drad+dtot), ...
+                    rawmarg_b, wmarg_b, flr_b, derr_b, flr_b/max(1e-30,derr_b));
                 fclose(fid_d);
             end
         end

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -42,6 +42,7 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
     % bound is outward-widened to be a PROVABLE sound lower/upper bound, so the verdict can be EMITTED
     % from FP32 (M3). FP64 ('double') is always exact-enough -> never widened (the oracle).
     vmag = {};
+    ibpLd = {}; ibpUd = {};                  % sound DOUBLE per-op IBP bounds (for the stable-neuron prefilter below)
     if strcmp(precision, 'single') && ~isempty(getenv('NNV_SOUND_FP32_TIGHT'))
         try
             % vmag in DOUBLE -> a rigorous value-magnitude majorant regardless of net depth (the
@@ -51,9 +52,9 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             % is cheap + cannot OOM. derr then mixes single |A| with double vmag -> the widening is
             % computed in double (rigorous over-estimate); the fast single CROWN coefficient pass is
             % unchanged. (Review findings #3/#9.)
-            [~, ~, vmag] = gpu_bab_ibp(ops, x_lb, x_ub, 'double');
+            [~, ~, vmag, ibpLd, ibpUd] = gpu_bab_ibp(ops, x_lb, x_ub, 'double');
         catch
-            vmag = {};
+            vmag = {}; ibpLd = {}; ibpUd = {};
         end
     end
     % SOUNDNESS FLAG: the sound-FP32 OUTWARD widening is actually applied only when precision is
@@ -116,8 +117,16 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 % NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
                 % src==0 here is the sound-FP32 input-fed case routed off the fast cast above (widened).
                 if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
+                % IBP-PREFILTER (verdict-identical, sound-path only): a relu neuron the SOUND DOUBLE IBP proves
+                % stable (ibpLo>=0 or ibpHi<=0) has an EXACT relaxation (slope 1/0), so the downstream backward
+                % uses that exact slope regardless of [pl,pu] tightness -> skip its CROWN backward, fill from IBP.
+                ibpLo = []; ibpHi = [];
+                if strcmp(tk,'relu') && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER')) ...
+                        && ~isempty(ibpLd) && numel(ibpLd) >= src+1 && ~isempty(ibpLd{src+1})
+                    ibpLo = ibpLd{src+1}; ibpHi = ibpUd{src+1};
+                end
                 if doProf, tL_ = tic; end
-                [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
+                [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag, ibpLo, ibpHi);
                 if doProf, if isa(pl,'gpuArray'), wait(gpuDevice); end; gpL(k) = toc(tL_); gpW(k) = nk; end
             end
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
@@ -228,30 +237,43 @@ function tf = i_box_exact(boxExact, idx)
     tf = ~isempty(v) && all(logical(v(:)));
 end
 
-function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag)
+function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag, ibpLo, ibpHi)
 % Tight per-neuron intermediate bounds (lower pl / upper pu, nk x 1) via a CHUNKED identity seed.
 % Replaces a dense Ck = eye(nk) (the O(nk^2) memory blow-up) with row-blocks; EXACT -- each seed row
 % is bounded independently of the others, so union(blocks) == full. B>=nk => the original single pass.
+% IBP-PREFILTER (ibpLo/ibpHi non-empty): only rows the SOUND IBP cannot prove stable need a CROWN
+% backward; stable rows get the (sound) IBP bound. Verdict-identical for relu (a stable relu's relaxation
+% is exact slope 1/0, so downstream uses that slope regardless of [pl,pu] tightness).
+    if nargin < 10, ibpLo = []; end
+    if nargin < 11, ibpHi = []; end
     B = i_chunk_rows(nk, precision);
     oomTest = getenv('NNV_CROWN_TEST_OOM');                  % test seam (empty in production)
     doP = ~isempty(getenv('NNV_CROWN_PROF'));                % read-only perf profile (default-off)
     if doP, global G_CROWN_PROF; end %#ok<TLEV>
-    pl = zeros(nk, 1, precision); pu = zeros(nk, 1, precision);
+    if ~isempty(ibpLo)
+        ibpLo = double(gather(ibpLo(:))); ibpHi = double(gather(ibpHi(:)));
+        idxAll = find((ibpLo < 0) & (ibpHi > 0));            % the only rows that need a CROWN backward
+        pl = cast(ibpLo, precision); pu = cast(ibpHi, precision);  % stable rows: the sound IBP bound (exact relaxation)
+    else
+        idxAll = (1:nk).';
+        pl = zeros(nk, 1, precision); pu = zeros(nk, 1, precision);
+    end
+    nu = numel(idxAll);
     s0 = 1;
-    while s0 <= nk
-        rows = s0:min(s0 + B - 1, nk); nb = numel(rows);
+    while s0 <= nu
+        sel = idxAll(s0:min(s0 + B - 1, nu)); nb = numel(sel);
         try
             i_maybe_inject_oom(B, oomTest);
             Ck = zeros(nb, nk, precision);
-            Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
+            Ck(sub2ind([nb nk], (1:nb).', sel(:))) = 1;        % a row-block of eye(nk) over the unstable subset
             if doP, G_CROWN_PROF.nb = G_CROWN_PROF.nb + 1; end   % count chunked backward passes (per-chunk sync was too heavy)
-            pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
-            pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+            pu(sel) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
+            pl(sel) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
             if strcmp(precision,'single') && ~isempty(getenv('NNV_DERR_ACTUAL'))
                 % P2 (advisor): the NET |fl32-fl64| roundoff of THIS interm-bound chunk (same call the DECOMP logs as
                 % nS=nb). Compare to the per-op measured-delta derr at matched depth -> is the ~500x cancellation gap real?
                 pld = i_backward(ops, src, double(Ck), x_lb, x_ub, preL, preU, 'double', true, {});
-                act = abs(double(gather(pl(rows))) - double(gather(pld(:))));
+                act = abs(double(gather(pl(sel))) - double(gather(pld(:))));
                 as = sort(act); medi = as(max(1, round(0.5*numel(as))));
                 fid_a = fopen(getenv('NNV_DERR_ACTUAL'), 'a');
                 if fid_a > 0

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -81,6 +81,12 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
     % ---- tight intermediate bounds, layer by layer ----
     % Compute input bounds for every op whose backward relaxation needs them: ReLU (the
     % pre-activation) AND maxpool (the window inputs that decide the sound max relaxation).
+    doProf = ~isempty(getenv('NNV_CROWN_PROF'));     % perf profile (read-only): where the sound root spends time
+    if doProf
+        global G_CROWN_PROF; %#ok<TLEV>
+        G_CROWN_PROF = struct('up', 0, 'lo', 0, 'oom', 0);
+        gpL = zeros(nOps, 1); gpW = zeros(nOps, 1); gpT0 = tic;
+    end
     for k = 1:nOps
         tk = ops{k}.type;
         if strcmp(tk, 'relu') || strcmp(tk, 'maxpool')
@@ -110,7 +116,9 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 % NNV_CROWN_MEM_GB; B>=nk reproduces the original single eye(nk) pass.
                 % src==0 here is the sound-FP32 input-fed case routed off the fast cast above (widened).
                 if src == 0, nk = numel(x_lb); else, nk = i_layer_width(ops, src); end
+                if doProf, tL_ = tic; end
                 [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU, precision, vmag);
+                if doProf, if isa(pl,'gpuArray'), wait(gpuDevice); end; gpL(k) = toc(tL_); gpW(k) = nk; end
             end
             if strcmp(tk, 'relu') && ~isempty(fixings) && numel(fixings) >= k && ~isempty(fixings{k})
                 fx = fixings{k};                    % BaB node: clamp fixed neurons + propagate
@@ -154,6 +162,13 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
                 preU{k} = min(preU{k}, cast(mulFix{k}.hi(:), precision));
             end
         end
+    end
+    if doProf
+        tot = toc(gpT0); [~, ord] = sort(gpL, 'descend');
+        fprintf('[crown-prof] interm-pass=%.1fs upper-bwd=%.1fs lower-bwd=%.1fs oom-halvings=%d | top layers: ', ...
+            tot, G_CROWN_PROF.up, G_CROWN_PROF.lo, G_CROWN_PROF.oom);
+        for ii = 1:min(8, nOps), j = ord(ii); if gpL(j) > 0.05, fprintf('op%d(%s,w%d)=%.1fs ', j, ops{j}.type, gpW(j), gpL(j)); end; end
+        fprintf('\n');
     end
 
     % M1 (P2.0 measurement, read-only, env-gated default-off): decompose the derr looseness -- log per op the
@@ -219,6 +234,8 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
 % is bounded independently of the others, so union(blocks) == full. B>=nk => the original single pass.
     B = i_chunk_rows(nk, precision);
     oomTest = getenv('NNV_CROWN_TEST_OOM');                  % test seam (empty in production)
+    doP = ~isempty(getenv('NNV_CROWN_PROF'));                % read-only perf profile (default-off)
+    if doP, global G_CROWN_PROF; end %#ok<TLEV>
     pl = zeros(nk, 1, precision); pu = zeros(nk, 1, precision);
     s0 = 1;
     while s0 <= nk
@@ -227,8 +244,11 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
             i_maybe_inject_oom(B, oomTest);
             Ck = zeros(nb, nk, precision);
             Ck(sub2ind([nb nk], (1:nb).', rows(:))) = 1;        % a row-block of eye(nk)
+            if doP, tu_ = tic; end
             pu(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, false, vmag);
+            if doP, if isa(pu,'gpuArray'), wait(gpuDevice); end; G_CROWN_PROF.up = G_CROWN_PROF.up + toc(tu_); tl_ = tic; end
             pl(rows) = i_backward(ops, src, Ck, x_lb, x_ub, preL, preU, precision, true,  vmag);
+            if doP, if isa(pl,'gpuArray'), wait(gpuDevice); end; G_CROWN_PROF.lo = G_CROWN_PROF.lo + toc(tl_); end
             if strcmp(precision,'single') && ~isempty(getenv('NNV_DERR_ACTUAL'))
                 % P2 (advisor): the NET |fl32-fl64| roundoff of THIS interm-bound chunk (same call the DECOMP logs as
                 % nS=nb). Compare to the per-op measured-delta derr at matched depth -> is the ~500x cancellation gap real?
@@ -248,6 +268,7 @@ function [pl, pu] = i_interm_bounds_chunked(ops, src, nk, x_lb, x_ub, preL, preU
             % so halve B and RETRY the SAME block. SOUND: cannot change a verdict, only memory/speed.
             % Non-memory errors (a genuine bug) rethrow immediately; at B==1 there is no smaller retry.
             if B <= 1 || ~i_is_oom(ME), rethrow(ME); end
+            if doP && isstruct(G_CROWN_PROF), G_CROWN_PROF.oom = G_CROWN_PROF.oom + 1; end
             clear Ck;                    % release the (nb x nk) seed so the smaller-B retry has headroom
             Bn = max(1, floor(B / 2));
             fprintf('[crown-chunk] OOM at B=%d (nk=%d, op %d): %s -> halving to B=%d\n', ...

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_crown_tight.m
@@ -57,6 +57,18 @@ function [margins, preL, preU, unstable, Ain, din, mulPlanes, soundFP32] = gpu_b
             vmag = {}; ibpLd = {}; ibpUd = {};
         end
     end
+    if isempty(ibpLd) && ~isempty(getenv('NNV_CROWN_IBP_PREFILTER'))
+        % The PREFILTER also wants the sound DOUBLE IBP on the NON-sound paths -- the unsound single GPU SCREEN
+        % and the FP64 confirm -- which are the actual cifar100 bottleneck (the screen times out in the wide-conv
+        % chunked CROWN before the confirm even runs). The double IBP forward is value-vectors only (cheap, cannot
+        % OOM). Sound classification on any path; on the unsound screen it only FILTERS (the verdict comes from the
+        % sound confirm) and it is TIGHTER, so it can only help -- never a false-negative (slope 1 is the tightest).
+        try
+            [~, ~, ~, ibpLd, ibpUd] = gpu_bab_ibp(ops, x_lb, x_ub, 'double');
+        catch
+            ibpLd = {}; ibpUd = {};
+        end
+    end
     % SOUNDNESS FLAG: the sound-FP32 OUTWARD widening is actually applied only when precision is
     % 'single' AND vmag was successfully computed (non-empty). If vmag failed (caught above -> {}),
     % derr stays 0 -> the single-precision margins are the UNSOUND fast screen, NOT a sound bound.

--- a/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
+++ b/code/nnv/engine/nn/gpu_bab/gpu_bab_relu_split_batched.m
@@ -146,6 +146,29 @@ function [status, info] = gpu_bab_relu_split_batched(ops, x_lb, x_ub, trueLabel,
         end
         preL = cell(nOps,1); preU = cell(nOps,1);
         for r = 1:numel(reluIdx), k = reluIdx(r); preL{k} = gather(rtL{k}); preU{k} = gather(rtU{k}); end
+        % NEURAL-METRIC log (read-only, env-gated NNV_LOG_METRICS, default-off): the activation pattern
+        % (per-relu stable+/stable-/unstable counts + bound MAGNITUDE -> why derr is ~2.0) and the root spec
+        % margin DISTRIBUTION (distance from the spec boundary). For the parameter-sweep feasibility diagnosis.
+        if ~isempty(getenv('NNV_LOG_METRICS'))
+            try
+                mf = fopen(getenv('NNV_LOG_METRICS'), 'a');
+                if mf > 0
+                    totU = 0; maxMag = 0;
+                    for r = 1:numel(reluIdx)
+                        k = reluIdx(r); pl = double(preL{k}(:)); pu = double(preU{k}(:));
+                        nU = sum(pl < 0 & pu > 0); nP = sum(pl >= 0); nM = sum(pu <= 0);
+                        mg = max([0; abs(pl); abs(pu)]); totU = totU + nU; maxMag = max(maxMag, mg);
+                        fprintf(mf, 'METRIC relu=%d width=%d stableActive=%d stableInactive=%d unstable=%d maxBoundMag=%.4g\n', ...
+                            k, numel(pl), nP, nM, nU, mg);
+                    end
+                    mr = double(mRoot(:)); mrs = sort(mr);
+                    p25 = mrs(min(numel(mrs), max(1, round(0.25*numel(mrs)))));
+                    fprintf(mf, 'METRIC root totUnstable=%d maxBoundMag=%.4g specMargin: min=%.6g p25=%.6g med=%.6g max=%.6g nNeg=%d/%d\n', ...
+                        totU, maxMag, min(mr), p25, median(mr), max(mr), sum(mr<0), numel(mr));
+                    fclose(mf);
+                end
+            catch, end
+        end
         % AMORTIZED alpha-CROWN: optimize alpha ONCE at the root (B=1, no per-node gradient memory)
         % and reuse the FIXED slopes for every BaB node via spec_dag -> LARGE frontier (the per-node
         % alpha autodiff OOMs past frontier ~8 on cifar). env NNV_AMORT_ALPHA = #root iters.

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_ibp_prefilter.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_ibp_prefilter.m
@@ -41,9 +41,9 @@ function test_prefilter_sound_on_deep_nets(tc)
         end
         ops{end+1} = struct('type','affine','W',randn(nout,w)/sqrt(w),'b',randn(nout,1),'src',2*depth,'nOut',nout); %#ok<AGROW>
         lb = -0.1*ones(nin,1); ub = 0.1*ones(nin,1);
-        setenv('NNV_CROWN_IBP_PREFILTER', '');  off = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); off = off(:);
+        setenv('NNV_CROWN_IBP_PREFILTER', '0'); off = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); off = off(:);  % '0' = prefilter OFF (default is now ON)
         setenv('NNV_CROWN_IBP_PREFILTER', '1'); on  = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); on  = on(:);
-        setenv('NNV_CROWN_IBP_PREFILTER', '');
+        setenv('NNV_CROWN_IBP_PREFILTER', '0');   % pure no-prefilter FP64 oracle
         H = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); H = H(:);
         verifyTrue(tc, all(isfinite(on)), sprintf('seed %d: finite', seed));
         % P1: prefilter single margin <= FP64 oracle (sound). tol 1e-5 >> double roundoff, << a real unsound gap.

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_ibp_prefilter.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_ibp_prefilter.m
@@ -1,0 +1,64 @@
+function tests = test_gpu_bab_ibp_prefilter
+% TEST_GPU_BAB_IBP_PREFILTER  Soundness of the IBP-prefilter for the sound-path interm bounds (perf lever).
+%   NNV_CROWN_IBP_PREFILTER skips the chunked CROWN backward for relu neurons the SOUND DOUBLE IBP proves
+%   stable (ibpLo>=0 or ibpHi<=0) and fills them from the (sound) IBP bound. A stable relu's relaxation is
+%   EXACT (slope 1/0), so this is sound; it is also TIGHTER than the no-prefilter path (which widens every
+%   bound by derr, so a marginally-stable neuron whose WIDENED CROWN bound straddles 0 gets needlessly
+%   relaxed -- the prefilter keeps it exact via the un-widened IBP). NOT bit-identical: a wrong relaxation
+%   here = a spuriously-high margin = a wrong unsat = -150, so this asserts the prefilter margin stays a
+%   SOUND lower bound on DEEP nets where it genuinely differs from the no-prefilter path.
+%     P1 SOUND-vs-ORACLE: prefilter (single) margin <= FP64 oracle margin (the existing sound guarantee).
+%     P2 SOUND-vs-MC:     prefilter margin <= the true min of C*f over the box (Monte-Carlo).
+%     P3 DIFFERS:         on these deep nets the prefilter genuinely differs from no-prefilter (>=1 of the
+%                         set), so P1/P2 are exercising the tightening path, not the trivial identical case.
+%   Run: runtests('test_gpu_bab_ibp_prefilter').
+    tests = functiontests(localfunctions);
+end
+
+function setup(tc)
+    tc.TestData.oldSound = getenv('NNV_SOUND_FP32_TIGHT');
+    tc.TestData.oldPre   = getenv('NNV_CROWN_IBP_PREFILTER');
+    setenv('NNV_SOUND_FP32_TIGHT', '1');
+end
+
+function teardown(tc)
+    setenv('NNV_SOUND_FP32_TIGHT', tc.TestData.oldSound);
+    setenv('NNV_CROWN_IBP_PREFILTER', tc.TestData.oldPre);
+end
+
+function test_prefilter_sound_on_deep_nets(tc)
+    nin = 12; nout = 6; w = 400;
+    C = [1 -1 0 0 0 0; 0 0 1 -1 0 0; 0 0 0 0 1 -1];
+    nDiffer = 0; worstOracle = -inf; worstMC = -inf;
+    for seed = [1 3 5 9 14 22 31 47]
+        rng(seed, 'twister');
+        depth = 3 + mod(seed, 4);                          % 3..6 relu layers -> non-trivial derr widening
+        ops = {}; pin = nin;
+        for L = 1:depth
+            ops{end+1} = struct('type','affine','W',randn(w,pin)/sqrt(pin),'b',0.12+0.3*randn(w,1),'src',2*(L-1),'nOut',w); %#ok<AGROW>
+            ops{end+1} = struct('type','relu','src',2*L-1); %#ok<AGROW>
+            pin = w;
+        end
+        ops{end+1} = struct('type','affine','W',randn(nout,w)/sqrt(w),'b',randn(nout,1),'src',2*depth,'nOut',nout); %#ok<AGROW>
+        lb = -0.1*ones(nin,1); ub = 0.1*ones(nin,1);
+        setenv('NNV_CROWN_IBP_PREFILTER', '');  off = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); off = off(:);
+        setenv('NNV_CROWN_IBP_PREFILTER', '1'); on  = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); on  = on(:);
+        setenv('NNV_CROWN_IBP_PREFILTER', '');
+        H = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); H = H(:);
+        verifyTrue(tc, all(isfinite(on)), sprintf('seed %d: finite', seed));
+        % P1: prefilter single margin <= FP64 oracle (sound). tol 1e-5 >> double roundoff, << a real unsound gap.
+        verifyLessThanOrEqual(tc, on, H + 1e-5, sprintf('P1 seed %d: prefilter margin must be <= FP64 oracle', seed));
+        worstOracle = max(worstOracle, max(on - H));
+        if max(abs(on - off)) > 1e-6
+            nDiffer = nDiffer + 1;
+            N = 40000; X = lb + (ub - lb).*rand(nin, N); cur = X;
+            for L = 1:depth, cur = max(ops{2*L-1}.W*cur + ops{2*L-1}.b, 0); end
+            mcmin = min(C*(ops{end}.W*cur + ops{end}.b), [], 2);
+            verifyLessThanOrEqual(tc, on, mcmin + 1e-4, sprintf('P2 seed %d: prefilter margin must be <= MC true min', seed));
+            worstMC = max(worstMC, max(on - mcmin));
+        end
+    end
+    % P3: the tightening path must actually be exercised (else P1/P2 only tested the trivial identical case).
+    verifyGreaterThanOrEqual(tc, nDiffer, 1, 'P3: at least one deep net must differ prefilter-vs-baseline (else not exercising the flip)');
+    fprintf('  [ibp-prefilter] differing nets=%d  worst(pre-oracle)=%.2e  worst(pre-MC)=%.2e\n', nDiffer, worstOracle, worstMC);
+end

--- a/code/nnv/engine/nn/gpu_bab/test_gpu_bab_running_derr.m
+++ b/code/nnv/engine/nn/gpu_bab/test_gpu_bab_running_derr.m
@@ -1,0 +1,136 @@
+function tests = test_gpu_bab_running_derr
+% TEST_GPU_BAB_RUNNING_DERR  Soundness + tightness of the running-error (measured-delta) derr (P2).
+%   NNV_DERR_RUNNING replaces the relu-intercept's a-priori gamma_width WORST-CASE reduction roundoff
+%   with the MEASURED roundoff |fl32(Ab*bu)-fl64(Ab*bu)| + a sound fl64-residual cushion, via
+%   min(a-priori, measured). A wrong (under-)widening = a spuriously-high margin = a wrong unsat = -150,
+%   so this is the GOLD-GATE on WIDE hidden layers (large numel(bu) -> the a-priori gamma_width is large
+%   and the measured-delta meaningfully smaller, exercising the new path -- unlike the width<=16 cases in
+%   test_gpu_bab_sound_fp32). Asserts, with NNV_DERR_RUNNING=1, on randomized wide ReLU nets:
+%     S1 SOUND:  the measured-delta single margin <= the FP64 oracle margin (STRICT tol -- an under-
+%                widening cushion bug surfaces as single > double). running_derr >= |fp32-fp64| (advisor).
+%     S2 MC:     the measured-delta single margin <= the true min of C*f over the box (Monte-Carlo).
+%     S3 TIGHT:  the measured-delta margin is >= the a-priori margin (the min() can only LOOSEN the
+%                widening, never tighten it past sound) -- and on a WIDE layer it is strictly tighter,
+%                confirming the new term actually fires (else the build is a no-op).
+%   Run: runtests('test_gpu_bab_running_derr').
+    tests = functiontests(localfunctions);
+end
+
+function setup(tc)
+    % the widening is opt-in via NNV_SOUND_FP32_TIGHT; the measured-delta via NNV_DERR_RUNNING.
+    tc.TestData.oldSound = getenv('NNV_SOUND_FP32_TIGHT');
+    tc.TestData.oldRun   = getenv('NNV_DERR_RUNNING');
+    setenv('NNV_SOUND_FP32_TIGHT', '1');
+end
+
+function teardown(tc)
+    setenv('NNV_SOUND_FP32_TIGHT', tc.TestData.oldSound);
+    setenv('NNV_DERR_RUNNING', tc.TestData.oldRun);
+end
+
+function test_running_derr_wide(tc)
+    % WIDE hidden layer (W=3000) S1 SOUNDNESS over several seeds. NOTE: a 2-relu net couples the measured-delta
+    % into the INTERMEDIATE bounds (preL/preU), and CROWN relaxations are NOT monotonic in those bounds, so the
+    % raw margin can shift either way vs a-priori -- the ONLY invariant is sound: measured-delta single <= FP64
+    % oracle. (The clean monotone "tighter than a-priori" check is test_running_derr_onerelu, where the relu's
+    % own interm bound comes from the input affine and is unaffected by the relu measured-delta.)
+    for seed = [1 7 21 42]
+        rng(seed, 'twister');
+        ops = i_widenet(18, 3000, 6);
+        lb = -0.2 * ones(18, 1); ub = 0.2 * ones(18, 1);
+        C  = [1 -1 0 0 0 0; 0 1 -1 0 0 0; 0 0 0 1 -1 0];
+        mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);   % FP64 oracle
+        setenv('NNV_DERR_RUNNING', '1'); mRun = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mRun = mRun(:);
+        verifyTrue(tc, all(isfinite(mRun)), sprintf('seed %d: finite', seed));
+        % S1 SOUND (strict): measured-delta single <= FP64 oracle. tol 1e-6 >> double roundoff (~1e-12),
+        % << a real under-widening (a-priori widening here is ~1e-4..1e-2, an under-widen bug would be that scale).
+        verifyLessThanOrEqual(tc, mRun, mH + 1e-6, sprintf('S1 seed %d: measured-delta margin must be <= FP64 oracle', seed));
+    end
+end
+
+function test_running_derr_onerelu(tc)
+    % S3 TIGHT (clean, no interm coupling): ONE hidden relu (input -> affine(W=4000) -> relu -> affine(out)).
+    % The relu's interm bound is the input affine (no relu before it) so the relu measured-delta does NOT change
+    % preL/preU -> the final relaxation is identical -> mRun differs from mAp ONLY by the relu-intercept derr,
+    % which min(a-priori,measured) can only SHRINK. So mRun >= mAp strictly (the new term fired + is tighter).
+    for seed = [2 19]
+        rng(seed, 'twister');
+        w = 4000;
+        W1 = randn(w, 14)/sqrt(14); b1 = randn(w, 1)*0.1;
+        W2 = randn(5, w)/sqrt(w);   b2 = randn(5, 1)*0.1;
+        ops = { struct('type','affine','W',W1,'b',b1,'src',0,'nOut',w), ...
+                struct('type','relu','src',1), ...
+                struct('type','affine','W',W2,'b',b2,'src',2,'nOut',5) };
+        lb = -0.2 * ones(14, 1); ub = 0.2 * ones(14, 1);
+        C  = [1 -1 0 0 0; 0 0 1 -1 0];
+        mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);
+        setenv('NNV_DERR_RUNNING', '');  mAp  = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mAp  = mAp(:);
+        setenv('NNV_DERR_RUNNING', '1'); mRun = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mRun = mRun(:);
+        verifyLessThanOrEqual(tc, mRun, mH + 1e-6, sprintf('S1 (1-relu) seed %d: measured-delta <= FP64 oracle', seed));
+        verifyGreaterThanOrEqual(tc, mRun, mAp - 1e-7, sprintf('S3 (1-relu) seed %d: measured-delta >= a-priori (min can only shrink the widening)', seed));
+        verifyGreaterThan(tc, max(mRun - mAp), 1e-6, sprintf('S3 (1-relu) seed %d: measured-delta STRICTLY tighter (the new term fired)', seed));
+    end
+end
+
+function test_running_derr_mc(tc)
+    % S2: measured-delta single margin is a genuine sound lower bound vs Monte-Carlo ground truth.
+    rng(13, 'twister');
+    ops = i_widenet(12, 2000, 5);
+    lb = -0.25 * ones(12, 1); ub = 0.25 * ones(12, 1);
+    C  = [1 -1 0 0 0; 0 0 1 -1 0];
+    setenv('NNV_DERR_RUNNING', '1');
+    mRun = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mRun = mRun(:);
+    N = 60000; X = lb + (ub - lb) .* rand(12, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, mRun, minCY + 1e-5, 'S2: measured-delta margin must be <= the MC true min');
+end
+
+function test_running_derr_residual(tc)
+    % S1/S3 on a residual (add) DAG with a wide branch -- exercises the 'add' merge + the wide-relu intercept.
+    rng(8, 'twister');
+    W1 = randn(2000, 10)/8; b1 = randn(2000, 1);
+    W2 = randn(2000, 2000)/45; b2 = randn(2000, 1);
+    W3 = randn(4, 2000)/45; b3 = randn(4, 1);
+    ops = { struct('type','affine','W',W1,'b',b1,'src',0,'nOut',2000), ...
+            struct('type','relu','src',1), ...
+            struct('type','affine','W',W2,'b',b2,'src',2,'nOut',2000), ...
+            struct('type','relu','src',3), ...
+            struct('type','add','inputs',[2 4],'shape',[],'nOut',2000), ...
+            struct('type','affine','W',W3,'b',b3,'src',5,'nOut',4) };
+    lb = -0.15 * ones(10, 1); ub = 0.15 * ones(10, 1);
+    C  = [1 -1 0 0; 0 1 -1 0];
+    mH = double(gpu_bab_crown_tight(ops, lb, ub, C, 'double', {})); mH = mH(:);
+    setenv('NNV_DERR_RUNNING', '1'); mRun = double(gpu_bab_crown_tight(ops, lb, ub, C, 'single', {})); mRun = mRun(:);
+    verifyTrue(tc, all(isfinite(mRun)));
+    verifyLessThanOrEqual(tc, mRun, mH + 1e-6, 'S1 (residual): measured-delta <= FP64 oracle');
+    N = 60000; X = lb + (ub - lb) .* rand(10, N);
+    minCY = min(C * i_eval(ops, X), [], 2);
+    verifyLessThanOrEqual(tc, mRun, minCY + 1e-5, 'S2 (residual): measured-delta <= MC true min');
+end
+
+function ops = i_widenet(nin, w, nout)
+    % input(nin) -> affine(w) -> relu -> affine(w) -> relu -> affine(nout); weights scaled so the
+    % pre-activations straddle 0 (many unstable relus -> nonzero bu intercepts -> the term fires).
+    W1 = randn(w, nin)/sqrt(nin);   b1 = randn(w, 1)*0.1;
+    W2 = randn(w, w)/sqrt(w);       b2 = randn(w, 1)*0.1;
+    W3 = randn(nout, w)/sqrt(w);    b3 = randn(nout, 1)*0.1;
+    ops = { struct('type','affine','W',W1,'b',b1,'src',0,'nOut',w), ...
+            struct('type','relu','src',1), ...
+            struct('type','affine','W',W2,'b',b2,'src',2,'nOut',w), ...
+            struct('type','relu','src',3), ...
+            struct('type','affine','W',W3,'b',b3,'src',4,'nOut',nout) };
+end
+
+function Y = i_eval(ops, X)
+    cache = cell(numel(ops) + 1, 1); cache{1} = X;
+    for k = 1:numel(ops)
+        op = ops{k};
+        switch op.type
+            case 'affine', cache{k+1} = op.W * cache{op.src+1} + op.b(:);
+            case 'relu',   cache{k+1} = max(cache{op.src+1}, 0);
+            case 'add',    cache{k+1} = cache{op.inputs(1)+1} + cache{op.inputs(2)+1};
+            otherwise, error('i_eval:op', 'unsupported op "%s"', op.type);
+        end
+    end
+    Y = cache{end};
+end


### PR DESCRIPTION
## Summary
**IBP-prefilter for the GPU-BaB CROWN interm bounds (`gpu_bab_crown_tight`), DEFAULT-ON (opt out `NNV_CROWN_IBP_PREFILTER=0`).** The sound DOUBLE IBP proves ~97% of wide-layer relu neurons stable; a stable relu's relaxation is exact (slope 1/0), so the downstream backward uses that exact slope regardless of `[pl,pu]` tightness → skip its chunked CROWN backward and fill from the (sound) IBP bound.

### Impact (validated)
- **Sound-root interm pass 419s → 6.5s (~64×)**, OOM-halvings 13 → 0 (the wide-conv `[crown-chunk]` OOM-retry storm is gone).
- On the competition default conv config (GPU-screen → **FP64-confirm**) it is **VERDICT-IDENTICAL** — the double confirm is *bit-identical*, just faster (skips ~97% of its wide-conv interm bounds) → changes **no** verdict, only **recovers** genuinely-robust-but-slow-root instances that timed out: **the 5 cifar100 resnet_large thin-margin instances (idx 496/4385/5308/4757/8589) now certify UNSAT in 120–194s** (timeout without it; A/B confirmed). Negligible overhead (one cheap value-only double-IBP forward) and no regression.

### Soundness (gold-gated — 0-WRONG)
- Full `gpu_bab` soundness suite: **75/75** with prefilter on; default-on path **33/33**.
- New `test_gpu_bab_ibp_prefilter`: on deep nets where it genuinely differs, prefilter margin ≤ FP64 oracle **and** ≤ Monte-Carlo true-min.
- Sound+tighter on the single sound-emit path (the no-prefilter widening needlessly relaxes truly-stable neurons); **bit-identical** on the double FP64-confirm path; verdict-safe on the unsound screen (filter; verdict from the sound confirm).

## Scope note (reviewer)
This is the `ttj/gpu-bab-diagnostics` branch — besides the prefilter (the only behavior change), it carries **default-off, inert** additions used in the investigation: read-only diagnostics (`NNV_DERR_DECOMP`/`NNV_DERR_ACTUAL`/`NNV_DEBUG_DERR`/`NNV_CROWN_PROF`) and a gold-gated running-error measured-δ (`NNV_DERR_RUNNING`, `test_gpu_bab_running_derr`). **Happy to split out a prefilter-only PR if preferred.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015S5FFjy7MeJdSSovzjC6yw