### PR TITLE
Class A error-fix: drop dead approx-zono/abs-dom rungs for slow_cats (#441)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/i_finalize_reach_options.m
+++ b/code/nnv/examples/Submission/VNN_COMP2026/i_finalize_reach_options.m
@@ -39,13 +39,17 @@ function reachOptionsList = i_finalize_reach_options(reachOptionsList, category,
         reachOptionsList = [{o1, o2}, reachOptionsList];
     end
 
-    % (2) slow_cats: drop exact-star, lead with zonotope + abstract-domain
+    % (2) slow_cats: drop exact-star (it never certifies these resnets/FC nets and just burns the
+    % per-instance budget). The earlier {approx-zono, abs-dom} PREPEND was DEAD CODE: create_input_set
+    % only ever builds Star/ImageStar (never Zono/ImageZono), so approx-zono throws "Input is not an
+    % ImageZono" and abs-dom throws "only star based methods are supported" -- BOTH always error ->
+    % caught at the reach try/catch -> fall through to the native approx-star ladder. Removing them
+    % clears the spurious per-instance error lines (the no-error mandate, GitHub #441 Class A) and is
+    % strictly VERDICT-PRESERVING: the native ladder -- which produced every actual verdict -- is
+    % unchanged, and dropping two always-erroring rungs only SAVES their wasted reach attempts.
     slow_cats = ["cifar100","cora","safenlp","sat_relu","tinyimagenet","vggnet"];
     if any(contains(category, slow_cats)) && nnvnetValid
-        kept = reachOptionsList(~cellfun(@(o) strcmp(o.reachMethod, 'exact-star'), reachOptionsList));
-        zo = struct(); zo.reachMethod = 'approx-zono';
-        ad = struct(); ad.reachMethod = 'abs-dom';
-        reachOptionsList = [{zo, ad}, kept];
+        reachOptionsList = reachOptionsList(~cellfun(@(o) strcmp(o.reachMethod, 'exact-star'), reachOptionsList));
     end
 
     % (3) cp-star quarantine (env-gated, DEFAULT OFF -> identity / behavior unchanged)


### PR DESCRIPTION
## Class A error-fix (GitHub #441) — verdict-preserving hygiene

`i_finalize_reach_options.m` prepended `{approx-zono, abs-dom}` for slow_cats, but `create_input_set` only ever builds Star/ImageStar (never Zono/ImageZono) → both rungs **always error** (`Input is not an ImageZono` / `only star based methods are supported`), get caught, and fall through to the native approx-star ladder.

**Removing them is strictly verdict-preserving** (the native ladder that produced every verdict is unchanged) and clears the spurious per-instance error lines for cifar100/cora/safenlp/sat_relu/tinyimagenet/vggnet — the no-error-run mandate. Keeps the exact-star drop intact.

**Gate:** CI soundness suite + a verdict-parity check (slow_cat verdicts identical with/without this change) before merge. Part of the overnight error-fix mandate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)