### PR TITLE
nn4sys lindex: parser handles both X_0 and X[0,0] (recover +12, regression fix)

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
+++ b/code/nnv/examples/Submission/VNN_COMP2026/nn4sys_lindex_decide.py
@@ -106,8 +106,13 @@ def parse_boxes(vnn_path):
     """Return boxes [(lo,hi)], a[N], b[N] (unsafe = Y<=a or Y>=b; defaults open)."""
     with open(vnn_path, encoding="utf-8") as f:
         txt = f.read()
-    pat = (r"\(and\s*\(>=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*\(<=\s*X\[0,0\]\s*([-\d.eE]+)\)\s*"
-           r"\((<=|>=)\s*Y\[0,0\]\s*([-\d.eE]+)\)")
+    # Accept BOTH vnnlib index conventions: the 2.0 `X[0,0]`/`Y[0,0]` form AND the 1.0 `X_0`/`Y_0`
+    # form. nn4sys is a CARRY-OVER cat whose competition vnnlib is served from the 1.0/ dir (X_0),
+    # but this parser was written only for X[0,0] -> it silently parsed 0 sub-queries -> CANT ->
+    # every lindex instance fell to unknown (the +24 lindex recovery, PR #426, was lost). Widening
+    # the index pattern is purely a PARSE change; the sound IBP+witness decision logic is unchanged.
+    pat = (r"\(and\s*\(>=\s*X(?:\[0,\s*0\]|_0)\s*([-\d.eE]+)\)\s*\(<=\s*X(?:\[0,\s*0\]|_0)\s*([-\d.eE]+)\)\s*"
+           r"\((<=|>=)\s*Y(?:\[0,\s*0\]|_0)\s*([-\d.eE]+)\)")
     from collections import OrderedDict
     g = OrderedDict()
     for lo, hi, sense, bnd in re.findall(pat, txt):


### PR DESCRIPTION
## nn4sys lindex regression — silently lost +12 (up to +24)

The full faithful re-sweep showed nn4sys at 5% (10/194) vs S11's 18%. Root cause: `parse_boxes` in `nn4sys_lindex_decide.py` matched **only** the 2.0 `X[0,0]` index form, but nn4sys is a **carry-over** cat whose competition vnnlib is served from `1.0/` using `X_0` → 0 sub-queries parsed → `CANT` → every lindex instance fell to **unknown** (the +24 lindex route, PR #426, silently lost).

**Fix:** widen the index pattern to `(?:\[0,\s*0\]|_0)` — accepts both forms. Purely a parse change; the sound IBP + witness + self-check decision logic is untouched.

**Gold-gate:** 12/12 lindex now decide (all unsat) on 1.0; still works on 2.0; **0 violations across 60,201 boxes** via independent ORT sampling (200/box) + the decider's own 'IBP contains true ORT output' self-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)