### PR TITLE
VNN-COMP 2026 submission prep: license, R2026a AMI, deps, driver

### DIFF
--- a/code/nnv/examples/Submission/VNN_COMP2026/config.yaml
+++ b/code/nnv/examples/Submission/VNN_COMP2026/config.yaml
@@ -1,5 +1,7 @@
 name: nnv
-ami: ami-094040f6770aae1e3
+# MATLAB R2026a (matlab_linux) AMI from the submission dropdown -- install_tool.sh provisions
+# R2026a support packages, so the AMI MUST ship R2026a (the old ami-094040f6770aae1e3 was R2024b).
+ami: ami-0d88088c4d5b7e5e0
 scripts_dir: code/nnv/examples/Submission/VNN_COMP2026/
 manual_installation_step: False
 run_installation_script_as_root: False

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -30,11 +30,8 @@ python3 -m pip install .
 matlab -nodisplay -r "cd /home/ubuntu/toolkit/code/nnv/examples/Submission/VNN_COMP2026/; prepare_run; quit"
 
 sudo apt install -y python3-pip
-# NOTE: python `torch` is NOT needed for the VNN-COMP path -- it is only used by
-# engine/nn/Prob_reach (probabilistic-reach research code), which the competition does not
-# run. The MATLAB PyTorch *converter* is an mpm support package (install_tool.sh), unrelated
-# to python torch. Removed the unpinned ~2GB `pip install torch` to save AWS setup time +
-# drop a failure point. (Re-add `python3 -m pip install torch` here if Prob_reach is ever run.)
+# torch backs engine/nn/Prob_reach (cp-star / probabilistic-reach paths) -- keep it.
+python3 -m pip install torch
 python3 -m pip install numpy
 python3 -m pip install scipy
 # onnxruntime backs BOTH the SAT-witness replay gate (validate_witness_onnx.m ->

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -10,9 +10,12 @@ curl --retry 100 --retry-connrefused -L -o license.lic "https://www.dropbox.com/
 sleep 5
 ls -al
 
-cp -f license.lic /usr/local/matlab/licenses/
+# sudo: /usr/local/matlab/licenses is root-owned and post_install runs non-root
+# (run_post_installation_script_as_root=False). Without sudo the copy fails -> MATLAB never
+# licenses -> every benchmark unknown. Passwordless sudo is available (install_tool.sh uses it).
+sudo cp -f license.lic /usr/local/matlab/licenses/
 
-rm -f /usr/local/matlab/licenses/license_info.xml
+sudo rm -f /usr/local/matlab/licenses/license_info.xml
 
 cd /usr/local/matlab/extern/engines/python
 python3 -m pip install .

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -10,10 +10,18 @@ curl --retry 100 --retry-connrefused -L -o license.lic "https://www.dropbox.com/
 sleep 5
 ls -al
 
+# FAIL LOUDLY on a bad/empty download (else MATLAB never licenses and EVERY benchmark silently
+# returns unknown). A valid MathWorks passcode file contains INCREMENT lines / the header.
+if [ ! -s license.lic ] || ! grep -qE 'INCREMENT|MathWorks license' license.lic; then
+    echo "ERROR: MATLAB license download failed or invalid (license.lic missing/empty/not a passcode file)" >&2
+    exit 1
+fi
+
 # sudo: /usr/local/matlab/licenses is root-owned and post_install runs non-root
 # (run_post_installation_script_as_root=False). Without sudo the copy fails -> MATLAB never
 # licenses -> every benchmark unknown. Passwordless sudo is available (install_tool.sh uses it).
-sudo cp -f license.lic /usr/local/matlab/licenses/
+sudo cp -f license.lic /usr/local/matlab/licenses/ || { echo "ERROR: failed to install license to /usr/local/matlab/licenses" >&2; exit 1; }
+[ -s /usr/local/matlab/licenses/license.lic ] || { echo "ERROR: license not present in /usr/local/matlab/licenses after copy" >&2; exit 1; }
 
 sudo rm -f /usr/local/matlab/licenses/license_info.xml
 

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -1,18 +1,18 @@
-cd ~/.matlab/R2024b_licenses
+mkdir -p ~/.matlab/R2026a_licenses
+cd ~/.matlab/R2026a_licenses
 
-curl --retry 100 --retry-connrefused -L -O https://www.dropbox.com/scl/fi/94gyrz1sdpiuvd7e8nc0r/LicenseTL.zip?rlkey=cbbrrkley11nnxd5r9mgrnkg1&st=4bx85clk&dl=0
-sleep 60
-ls -al
-
-unzip  *.zip*
-
+# MAC-locked MATLAB R2026a license (HOSTID 02e1e896fadb == ENI eni-0b11771dfe21b94ee).
+# Verified 2026-06-28: FLEXlm passcode file, 116 products incl. Deep Learning (Neural_Network_Toolbox),
+# Parallel Computing (Distrib_Computing_Toolbox, for GPU/parfor), Optimization (linprog), GPU_Coder;
+# expires 30-may-2027. Fetched at runtime; the .lic is MAC-locked so the URL is unusable off this ENI.
+# NOTE: URL is QUOTED (the prior year's unquoted &-URL backgrounded curl + dropped query params).
+curl --retry 100 --retry-connrefused -L -o license.lic "https://www.dropbox.com/scl/fi/w5jgddmf3qm5znjw67ajm/matlab-license-vnncomp2026-nnv.lic?rlkey=z3wnimbad4ykjyde95yhq7ik3&st=2oc64st3&dl=1"
+sleep 5
 ls -al
 
 cp -f license.lic /usr/local/matlab/licenses/
 
-rm *.zip*
-
-rm /usr/local/matlab/licenses/license_info.xml
+rm -f /usr/local/matlab/licenses/license_info.xml
 
 cd /usr/local/matlab/extern/engines/python
 python3 -m pip install .

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -30,7 +30,11 @@ python3 -m pip install .
 matlab -nodisplay -r "cd /home/ubuntu/toolkit/code/nnv/examples/Submission/VNN_COMP2026/; prepare_run; quit"
 
 sudo apt install -y python3-pip
-python3 -m pip install torch
+# NOTE: python `torch` is NOT needed for the VNN-COMP path -- it is only used by
+# engine/nn/Prob_reach (probabilistic-reach research code), which the competition does not
+# run. The MATLAB PyTorch *converter* is an mpm support package (install_tool.sh), unrelated
+# to python torch. Removed the unpinned ~2GB `pip install torch` to save AWS setup time +
+# drop a failure point. (Re-add `python3 -m pip install torch` here if Prob_reach is ever run.)
 python3 -m pip install numpy
 python3 -m pip install scipy
 # onnxruntime backs BOTH the SAT-witness replay gate (validate_witness_onnx.m ->

--- a/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
+++ b/code/nnv/examples/Submission/VNN_COMP2026/post_install.sh
@@ -44,6 +44,7 @@ python3 -m pip install onnx==1.20.0 onnxruntime==1.23.1
 # Enable GPU persistence mode (prevents driver unloading)
 sudo nvidia-smi -pm 1
 
-# Lock the kernenl verison and GPU drivers.
-sudo apt-mark hold linux-image-generic linux-headers-generic nvidia-driver-535
+# Lock the kernel version and GPU drivers (driver 570 -- the version on our tested g5 AMI; NNV GPU
+# reach needs >=570). Pair with the form's "restart after post-install" so the driver is reloaded.
+sudo apt-mark hold linux-image-generic linux-headers-generic nvidia-driver-570
 sudo systemctl disable unattended-upgrades

--- a/code/nnv/tools/onnx2nnv_python/requirements.txt
+++ b/code/nnv/tools/onnx2nnv_python/requirements.txt
@@ -23,5 +23,5 @@ vnnlib
 # hdf5storage: v7.3 (HDF5) .mat writer for manifests whose weights exceed scipy savemat's
 # 2 GB limit (large models, e.g. yolo 640x640 / vit). onnx2nnv.py imports it on that path
 # (~line 2195); WITHOUT it a >2GB manifest falls back to savemat which ERRORS on the oversized
-# tensor -> the manifest never generates. Pure-python (pulls h5py). Required for completeness.
+# tensor -> the manifest never generates. Pulls h5py (ships manylinux wheels -> no compiler needed).
 hdf5storage

--- a/code/nnv/tools/onnx2nnv_python/requirements.txt
+++ b/code/nnv/tools/onnx2nnv_python/requirements.txt
@@ -20,3 +20,8 @@ onnxruntime==1.23.1
 onnxsim
 onnxoptimizer
 vnnlib
+# hdf5storage: v7.3 (HDF5) .mat writer for manifests whose weights exceed scipy savemat's
+# 2 GB limit (large models, e.g. yolo 640x640 / vit). onnx2nnv.py imports it on that path
+# (~line 2195); WITHOUT it a >2GB manifest falls back to savemat which ERRORS on the oversized
+# tensor -> the manifest never generates. Pure-python (pulls h5py). Required for completeness.
+hdf5storage


### PR DESCRIPTION
Submission-side config for the VNN-COMP 2026 AWS run (no verifier-logic changes; cannot affect verdicts/−150).

## Changes
- **License**: wire the MAC-locked R2026a MATLAB license into `post_install.sh` (HOSTID `02e1e896fadb` == ENI `eni-0b11771dfe21b94ee`; verified 116 products incl. Deep Learning + Parallel Computing + Optimization + GPU_Coder; exp 2027). Raw `.lic` never committed (MAC-locked, runtime fetch). R2024b→R2026a license dir.
- **AMI (C1)**: `config.yaml` → `ami-0d88088c4d5b7e5e0` (MATLAB R2026a, from the submission dropdown). The old `ami-094040f6770aae1e3` is R2024b and would mismatch the R2026a install → all 30 cats fail.
- **License write perms (C2)**: `sudo` the root-owned `/usr/local/matlab/licenses` copy (post_install runs non-root).
- **GPU driver**: lock `nvidia-driver-570` (tested g5 AMI; NNV GPU needs ≥570).
- **Deps**: add missing `hdf5storage` to `requirements.txt` (onnx2nnv.py needs it for >2GB manifests); keep `torch` (Prob_reach / cp-star).

Rebased onto current master (#442/#443/#444 included). From the pre-submission hardening audit (`status-repo/research/PRESUBMISSION_HARDENING_PLAN_2026-06-28.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)